### PR TITLE
feat(forms) Create alphanumeric text field

### DIFF
--- a/client/src/commons/AlphanumericTextField/AlphanumericTextField.tsx
+++ b/client/src/commons/AlphanumericTextField/AlphanumericTextField.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { TextField } from '@material-ui/core';
+import AlphanumericTextFieldType from './AlphanumericTextFieldTypes';
+import * as yup from "yup";
+
+const stringAlphanum = yup
+  .string()
+  .required()
+  .matches(/^[a-zA-Z\u0590-\u05fe0-9\s]*$/);
+
+const AutocompletedField: AlphanumericTextFieldType = (props) => {
+    const { onBlur, onChange, value, name, setError, clearErrors } = props;
+    return (
+        <TextField
+            onBlur={onBlur}
+            onChange={async (e) => {
+                const newValue = e.target.value;
+                const isValid = await stringAlphanum.isValid(newValue);
+                if (isValid || newValue === "") {
+                    clearErrors(name);
+                    onChange(newValue);
+                } else {
+                    setError(name, {
+                        type: "manual",
+                        message: "השדה יכול להכיל רק אותיות ומספרים"
+                    });
+                }
+            }}
+            value={value}
+            name={name}
+        />
+    );
+};
+
+export default AutocompletedField;

--- a/client/src/commons/AlphanumericTextField/AlphanumericTextFieldTypes.ts
+++ b/client/src/commons/AlphanumericTextField/AlphanumericTextFieldTypes.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export interface AlphanumericTextFieldProps<T> {
+    onChange: (value: string) => void,
+    onBlur: (event: React.ChangeEvent<{}>) => void,
+    value: T | null,
+    name: string,
+    setError: (name: string, error: { type?: string, types?: object, message?: string, shouldFocus?: boolean }) => void,
+    clearErrors: (name?: string | string[]) => void
+}
+
+type AlphanumericTextFieldType = <T>(props: AlphanumericTextFieldProps<T>) => JSX.Element;
+export default AlphanumericTextFieldType;


### PR DESCRIPTION
This pull request contains an alphanumeric text field (can only accept letters, numbers and spaces). There is no usage to this component yet; it will be used with `react-hook-form` so these changes have no immediate effect.