### PR TITLE
Fix(trigger validation) - When entering a non-valid tab the problematic fields will be marked

### DIFF
--- a/client/src/commons/TypingPreventionTextField/TypingPreventionTextField.tsx
+++ b/client/src/commons/TypingPreventionTextField/TypingPreventionTextField.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TextField, Tooltip } from '@material-ui/core';
+import { TextField } from '@material-ui/core';
 
 import get from 'Utils/auxiliaryFunctions/auxiliaryFunctions'
 
@@ -40,7 +40,6 @@ const TypePreventiveTextField: TypePreventiveTextFieldType = (props) => {
   const errorObject = get(errors, name);
 
   return (
-    <Tooltip open={errorObject? true : false} title={errorObject ? errorMessage : ""}>
       <TextField
         test-id={testId}
         required={required}
@@ -53,7 +52,6 @@ const TypePreventiveTextField: TypePreventiveTextFieldType = (props) => {
         placeholder={placeholder}
         className={className}
       />
-    </Tooltip>
   );
 };
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/ClinicalDetails.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/ClinicalDetails.tsx
@@ -89,7 +89,7 @@ const ClinicalDetails: React.FC<Props> = ({ id, onSubmit }: Props): JSX.Element 
     }, [initialDBClinicalDetails])
 
     React.useEffect(() => {
-        if(formsValidations && formsValidations[id] !== null){
+        if (formsValidations && formsValidations[id] !== null) {
             trigger();
         }
     }, [touched])

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/ClinicalDetails.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/ClinicalDetails.tsx
@@ -28,7 +28,7 @@ import BackgroundDiseasesFields from './BackgroundDiseasesFields';
 const ClinicalDetails: React.FC<Props> = ({ id, onSubmit }: Props): JSX.Element => {
     const classes = useStyles();
     const [initialDBClinicalDetails, setInitialDBClinicalDetails] = React.useState<ClinicalDetailsData>(initialClinicalDetails);
-    const { control, setValue, getValues, handleSubmit, reset, watch, errors, setError, clearErrors, trigger } = useForm({
+    const { control, setValue, getValues, formState, reset, watch, errors, setError, clearErrors, trigger } = useForm({
         mode: 'all',
         defaultValues: initialDBClinicalDetails,
         resolver: yupResolver(ClinicalDetailsSchema)
@@ -46,7 +46,10 @@ const ClinicalDetails: React.FC<Props> = ({ id, onSubmit }: Props): JSX.Element 
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
     const investigatedPatientId = useSelector<StoreStateType, number>(state => state.investigation.investigatedPatientId);
     const investigationId = useSelector<StoreStateType, number>((state) => state.investigation.epidemiologyNumber);
-    
+    const formsValidations = useSelector<StoreStateType, (boolean | null)[]>((state) => state.formsValidations[investigationId]);
+
+    const { touched } = formState;
+
     const { getStreetByCity, saveClinicalDetails } = useClinicalDetails({
         setSymptoms,
         setBackgroundDiseases, 
@@ -84,6 +87,12 @@ const ClinicalDetails: React.FC<Props> = ({ id, onSubmit }: Props): JSX.Element 
     React.useEffect(() => {
         reset(initialDBClinicalDetails);
     }, [initialDBClinicalDetails])
+
+    React.useEffect(() => {
+        if(formsValidations && formsValidations[id] !== null){
+            trigger();
+        }
+    }, [touched])
 
     const saveForm = (e: any) => {
         e.preventDefault();

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/ExposuresAndFlights.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/ExposuresAndFlights.tsx
@@ -51,7 +51,7 @@ const ExposuresAndFlights : React.FC<Props> = ({ id, onSubmit }: Props): JSX.Ele
   const doesHaveFlights = (checkedExposures: Exposure[]) => checkedExposures.some(exposure => exposure.wasAbroad)
 
   React.useEffect(() => {
-    if(formsValidations && formsValidations[id] !== null){
+    if (formsValidations && formsValidations[id] !== null) {
         trigger();
     }
   }, [touched])

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/ExposuresAndFlights.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/ExposuresAndFlights.tsx
@@ -17,6 +17,7 @@ import { exposureAndFlightsContext, fieldsNames, Exposure, initialExposureOrFlig
 import FlightsForm from './FlightsForm/FlightsForm';
 import useStyles from './ExposuresAndFlightsStyles';
 import ExposureForm from './ExposureForm/ExposureForm';
+import { useForm } from 'react-hook-form';
 
 
 const addConfirmedExposureButton: string = 'הוסף חשיפה';
@@ -29,7 +30,12 @@ const ExposuresAndFlights : React.FC<Props> = ({ id, onSubmit }: Props): JSX.Ele
   const {saveExposureAndFlightData} = useExposuresSaving({ exposureAndFlightsData, setExposureDataAndFlights });
 
   const investigationId = useSelector<StoreStateType, number>((state) => state.investigation.epidemiologyNumber);
+  const formsValidations = useSelector<StoreStateType, (boolean | null)[]>((state) => state.formsValidations[investigationId]);
 
+  const { control, setValue, getValues, reset, errors, setError, clearErrors, trigger, formState } = useForm({
+  });
+
+  const { touched } = formState;
   const { fieldName } = useFormStyles();
   const classes = useStyles();
 
@@ -43,6 +49,12 @@ const ExposuresAndFlights : React.FC<Props> = ({ id, onSubmit }: Props): JSX.Ele
 
   const doesHaveConfirmedExposures = (checkedExposures: Exposure[]) => checkedExposures.some(exposure => exposure.wasConfirmedExposure)
   const doesHaveFlights = (checkedExposures: Exposure[]) => checkedExposures.some(exposure => exposure.wasAbroad)
+
+  React.useEffect(() => {
+    if(formsValidations && formsValidations[id] !== null){
+        trigger();
+    }
+  }, [touched])
 
   React.useEffect(() => {
     (wereConfirmedExposures && !doesHaveConfirmedExposures(exposures)) && onExposureAdded(true, false);

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/PersonalInfoTab.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/PersonalInfoTab.tsx
@@ -134,7 +134,7 @@ const PersonalInfoTab: React.FC<Props> = ( { id, onSubmit } : Props ): JSX.Eleme
     }, [occupation]);
 
     React.useEffect(() => {
-        if(formsValidations && formsValidations[id] !== null){
+        if (formsValidations && formsValidations[id] !== null) {
             trigger();
         }
     }, [touched])

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/PersonalInfoTab.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/PersonalInfoTab.tsx
@@ -62,16 +62,19 @@ const PersonalInfoTab: React.FC<Props> = ( { id, onSubmit } : Props ): JSX.Eleme
     const cities = useSelector<StoreStateType, Map<string, City>>(state => state.cities);
     const investigatedPatientId = useSelector<StoreStateType, number>(state => state.investigation.investigatedPatientId);
     const investigationId = useSelector<StoreStateType, number>((state) => state.investigation.epidemiologyNumber);
+    const formsValidations = useSelector<StoreStateType, (boolean | null)[]>((state) => state.formsValidations[investigationId]);
 
     const { fetchPersonalInfo, getSubOccupations, getEducationSubOccupations, getStreetsByCity } = usePersonalInfoTab({setInsuranceCompanies,
         setPersonalInfoData, setSubOccupations, setSubOccupationName, setCityName, setStreetName, setStreets, occupationsStateContext
     });
 
-    const { control, setValue, getValues, reset, errors, setError, clearErrors } = useForm({
+    const { control, setValue, getValues, reset, errors, setError, clearErrors, trigger, formState } = useForm({
         mode: 'all',
         defaultValues: personalInfoState,
         resolver: yupResolver(personalInfoValidationSchema),
     });
+
+    const { touched } = formState;
 
     const handleChangeOccupation = (event: React.ChangeEvent<HTMLInputElement>) => {
         const newOccupation = event.target.value
@@ -120,7 +123,7 @@ const PersonalInfoTab: React.FC<Props> = ( { id, onSubmit } : Props ): JSX.Eleme
         }
         reset(personalInfoState)
     },[personalInfoState])
-    
+
     React.useEffect(() => {
         if (occupation === Occupations.DEFENSE_FORCES ||
             occupation === Occupations.HEALTH_SYSTEM) {
@@ -129,6 +132,12 @@ const PersonalInfoTab: React.FC<Props> = ( { id, onSubmit } : Props ): JSX.Eleme
             setSubOccupations([]);
         }
     }, [occupation]);
+
+    React.useEffect(() => {
+        if(formsValidations && formsValidations[id] !== null){
+            trigger();
+        }
+    }, [touched])
 
     React.useEffect(() => {
         cityId && getStreetsByCity(cityId);


### PR DESCRIPTION
Solves bug [410](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/410/)

*Triggers validation when entering a non-valid form
*Removes Tooltip popup on error in Alphanumeric/Alphabetic text fields
(for the moment both Interactions Tab and Contact Questioning Tab can't be non-valid will be changed in the future)