### PR TITLE
fix(city-autoComplete) - Typing new value in city autocomplete will change current value to null

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/PersonalInfoTab.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/PersonalInfoTab.tsx
@@ -421,9 +421,7 @@ const PersonalInfoTab: React.FC<Props> = ({ id, onSubmit }: Props): JSX.Element 
                                             setValue(PersonalInfoDataContextFields.STREET, '')
                                             setStreetName('')
                                             setCityName(newInputValue);
-                                            if (!newInputValue) {
-                                                setValue(PersonalInfoDataContextFields.CITY, '')
-                                            }
+                                            setValue(PersonalInfoDataContextFields.CITY, '')
                                         }
                                     }}
                                     onChange={(event, newValue) => {


### PR DESCRIPTION
fixes bug [635](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/635/)
you may change the value only by using the autocomplete feature and select your new value from the options 
(as an autocomplete should work)