### PR TITLE
feat(logger) add option to setup logger with initial params

### DIFF
--- a/client/src/logger/logger.ts
+++ b/client/src/logger/logger.ts
@@ -1,13 +1,13 @@
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 
-import { MethodsLogMessage, LogMessage, LogType, Environment } from 'models/Logger';
+import { MethodsLogMessage, LogMessage, LogType, Environment, InitialLogData, Service, Severity } from 'models/Logger';
 
 class Logger {
-    
+
     _applicationInsights: ApplicationInsights;
 
-    constructor () {
-        if(process.env.REACT_APP_INSTRUMENTATION_KEY) {
+    constructor() {
+        if (process.env.REACT_APP_INSTRUMENTATION_KEY) {
             this._applicationInsights = new ApplicationInsights({
                 config: {
                     instrumentationKey: process.env.REACT_APP_INSTRUMENTATION_KEY
@@ -35,13 +35,14 @@ class Logger {
             ...partialLogMessage,
             environment: process.env.REACT_APP_ENVIRONMENT as Environment,
             timestamp: new Date().toLocaleString('he-IL'),
-            type: logType
+            type: logType,
+            service: Service.CLIENT
         }
         if (JSON.parse(process.env.REACT_APP_SHOULD_POST_TO_AZURE as string)) {
             this._postToAzure(logMessage);
         }
     }
-    
+
     info(logMessage: MethodsLogMessage) {
         this._buildLogMessage(logMessage, LogType.INFO)
     }
@@ -52,6 +53,14 @@ class Logger {
 
     error(logMessage: MethodsLogMessage) {
         this._buildLogMessage(logMessage, LogType.ERROR)
+    }
+
+    setup(logData: InitialLogData) {
+        return {
+            info: (step: string, severity: Severity) => this.info({ ...logData, step, severity }),
+            warn: (step: string, severity: Severity) => this.warn({ ...logData, step, severity }),
+            error: (step: string, severity: Severity) => this.error({ ...logData, step, severity })
+        }
     }
 }
 

--- a/client/src/logger/logger.ts
+++ b/client/src/logger/logger.ts
@@ -32,11 +32,11 @@ class Logger {
 
     _buildLogMessage(partialLogMessage: MethodsLogMessage, logType: LogType) {
         const logMessage: LogMessage = {
+            service: Service.CLIENT,
             ...partialLogMessage,
             environment: process.env.REACT_APP_ENVIRONMENT as Environment,
             timestamp: new Date().toLocaleString('he-IL'),
             type: logType,
-            service: Service.CLIENT
         }
         if (JSON.parse(process.env.REACT_APP_SHOULD_POST_TO_AZURE as string)) {
             this._postToAzure(logMessage);

--- a/client/src/models/Logger.ts
+++ b/client/src/models/Logger.ts
@@ -25,13 +25,16 @@ export enum Environment {
     PROD = 'prod'
 }
 
-export interface MethodsLogMessage {
+export interface MethodsLogMessage extends InitialLogData {
+    step: string;
+    severity: Severity;
+}
+
+export interface InitialLogData {
     user?: string;
     investigation?: number;
+    service?: Service;
     workflow: string;
-    step: string;
-    service: Service;
-    severity: Severity;
 }
 
 export interface InitialLogMessage {

--- a/server/src/Logger/Logger.ts
+++ b/server/src/Logger/Logger.ts
@@ -2,7 +2,7 @@ import dotenv from 'dotenv';
 const appinsights = require('applicationinsights');
 import { createLogger, transports, format, Logger as winstonLogger } from 'winston';
 
-import { MethodsLogMessage, LogMessage, InitialLogMessage, LogType, Environment } from '../Models/Logger/types';
+import { MethodsLogMessage, LogMessage, InitialLogMessage, LogType, Environment, Severity, InitialLogData, Service } from '../Models/Logger/types';
 
 dotenv.config();
 
@@ -27,8 +27,9 @@ class Logger {
                     };
                     const messageFromMethod: MethodsLogMessage = JSON.parse(JSON.stringify(info.message));
                     const outputLog: LogMessage = {
+                        service: Service.SERVER,
                         ...initialLog,
-                        ...messageFromMethod
+                        ...messageFromMethod,
                     }
                     if (JSON.parse(process.env.SHOULD_POST_TO_AZURE)) {
                         this._postToAzure(outputLog);
@@ -56,6 +57,14 @@ class Logger {
 
     info(logMessage: MethodsLogMessage) {
         this.logger.info(logMessage);
+    }
+
+    setup(logData: InitialLogData) {
+        return {
+            info: (step: string, severity: Severity) => this.info({ ...logData, step, severity }),
+            warn: (step: string, severity: Severity) => this.warning({ ...logData, step, severity }),
+            error: (step: string, severity: Severity) => this.error({ ...logData, step, severity })
+        }
     }
 
 }

--- a/server/src/Models/Logger/types.ts
+++ b/server/src/Models/Logger/types.ts
@@ -25,13 +25,16 @@ export enum Environment {
     PROD = 'prod'
 }
 
-export interface MethodsLogMessage {
+export interface MethodsLogMessage extends InitialLogData {
+    step: string;
+    severity: Severity;
+}
+
+export interface InitialLogData {
     user?: string;
     investigation?: number;
+    service?: Service;
     workflow: string;
-    step: string;
-    service: Service;
-    severity: Severity;
 }
 
 export interface InitialLogMessage {


### PR DESCRIPTION
This PR adds a new way to write logs with less boilerplate by defining initial log data and then writing logs with only step and severity.

The new syntax will be:
```javascript
const occupationLogger = logger.setup({
            workflow: 'Fetching Occupations',
            user: userId,
            investigation: epidemiologyNumber
        });
occupationLogger.info('launching occupations request', Severity.LOW)
occupationLogger.warn('maybe something wrong', Severity.MEDIUM)
occupationLogger.error('Something failed', Severity.CRITICAL)
```