### PR TITLE
Feat/personal info axios

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3495,7 +3495,8 @@
         "big-integer": {
             "version": "1.6.48",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-            "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+            "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+            "dev": true
         },
         "big.js": {
             "version": "5.2.2",
@@ -8509,7 +8510,8 @@
         "js-sha3": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-            "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+            "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+            "dev": true
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -9420,6 +9422,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
             "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
+            "dev": true,
             "requires": {
                 "big-integer": "^1.6.16"
             }
@@ -11905,42 +11908,10 @@
                 "lodash.isplainobject": "^4.0.6"
             }
         },
-        "redux-state-sync": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/redux-state-sync/-/redux-state-sync-3.1.2.tgz",
-            "integrity": "sha512-HJtyqckwb56iE2OvNOLwjW+Qnn7xA/R+jqP4mdYnSREk0bKVs4gVbE4bsiUZGOw5DzXlz5jHozg1x38gggWArQ==",
-            "requires": {
-                "broadcast-channel": "^3.1.0"
-            },
-            "dependencies": {
-                "broadcast-channel": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.2.0.tgz",
-                    "integrity": "sha512-LaFTMPcULFJ84ROED6TNaKmp4pnJohPbuQ8RmQ2plB7U4YgVkHdl58cgP6bK+zUYo5EIydACMH6JalA2nac/3g==",
-                    "requires": {
-                        "@babel/runtime": "^7.7.2",
-                        "detect-node": "^2.0.4",
-                        "js-sha3": "0.8.0",
-                        "microseconds": "0.2.0",
-                        "nano-time": "1.0.0",
-                        "rimraf": "3.0.2",
-                        "unload": "2.2.0"
-                    }
-                },
-                "microseconds": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-                    "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
-                },
-                "rimraf": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                }
-            }
+        "redux-persist": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+            "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ=="
         },
         "redux-thunk": {
             "version": "2.3.0",
@@ -13951,6 +13922,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
             "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+            "dev": true,
             "requires": {
                 "@babel/runtime": "^7.6.2",
                 "detect-node": "^2.0.4"

--- a/client/package.json
+++ b/client/package.json
@@ -55,7 +55,7 @@
         "react-router-dom": "^5.2.0",
         "react-scripts": "3.4.3",
         "redux": "^4.0.5",
-        "redux-state-sync": "^3.1.2",
+        "redux-persist": "^6.0.0",
         "redux-thunk": "^2.3.0",
         "sweetalert2": "^9.17.1",
         "xlsx": "^0.16.8",

--- a/client/src/Utils/ControllerHooks/useExposuresSaving.ts
+++ b/client/src/Utils/ControllerHooks/useExposuresSaving.ts
@@ -22,7 +22,7 @@ interface DBExposure extends Omit<Exposure, 'exposureAddress'> {
 const useExposuresSaving = (exposuresAndFlightsVariables: ExposureAndFlightsDetailsAndSet) => {
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
     const investigatedPatientId = useSelector<StoreStateType, number>(state => state.investigation.investigatedPatient.investigatedPatientId);
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
 
     const saveResortsData = () : Promise<void> => {
         let { wasInEilat, wasInDeadSea } = exposuresAndFlightsVariables.exposureAndFlightsData;

--- a/client/src/Utils/StatusUtils/useStatusUtils.ts
+++ b/client/src/Utils/StatusUtils/useStatusUtils.ts
@@ -14,7 +14,7 @@ const useStatusUtils = () => {
 
     const investigatedPatient = useSelector<StoreStateType, InvestigatedPatient>(state => state.investigation.investigatedPatient);
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
     const investigationEndTime = useSelector<StoreStateType, Date | null>(state => state.investigation.endTime);
     const wasInvestigationReopend = investigationEndTime !== null;
 

--- a/client/src/Utils/vendor/useDuplicateContactId.ts
+++ b/client/src/Utils/vendor/useDuplicateContactId.ts
@@ -21,7 +21,7 @@ const useDuplicateContactId = () => {
     
     const { alertWarning } = useCustomSwal();
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
 
     const findDuplicateIds = (idsToCheck: ContactId[]) => {
         const trimmedIds: ContactId[] = idsToCheck.filter(id => id);

--- a/client/src/commons/Forms/PlacesTypesAndSubTypes/usePlacesTypesAndSubTypes.ts
+++ b/client/src/commons/Forms/PlacesTypesAndSubTypes/usePlacesTypesAndSubTypes.ts
@@ -11,7 +11,7 @@ import { usePlacesTypesAndSubTypesIncome } from './usePlacesTypesAndSubTypesInte
 
 const usePlacesTypesAndSubTypes = (parameters: usePlacesTypesAndSubTypesIncome) => {
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
 
     const { setPlacesSubTypesByTypes } = parameters;
 

--- a/client/src/components/App/App.tsx
+++ b/client/src/components/App/App.tsx
@@ -52,12 +52,15 @@ const getStubAuthUserData = () => ({
 
 const App: React.FC = (): JSX.Element => {
 
-    const user = useSelector<StoreStateType, User>(state => state.user);
+    const user = useSelector<StoreStateType, User>(state => state.user.data);
+    const isUserLoggedIn = useSelector<StoreStateType, boolean>(state => state.user.isLoggedIn);
 
     const [isSignUpOpen, setIsSignUpOpen] = useState<boolean>(false);
 
     useEffect(() => {
-        initUser();
+        if(!isUserLoggedIn) {
+            initUser();
+        }
     }, []);
 
     const initUser = async () => {

--- a/client/src/components/App/AppToolbar/useAppToolbar.tsx
+++ b/client/src/components/App/AppToolbar/useAppToolbar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Swal from 'sweetalert2';
 import { useSelector } from 'react-redux';
 import axios from 'axios';
+import { persistor } from 'redux/store';
 
 import User from 'models/User';
 import logger from 'logger/logger';
@@ -22,7 +23,7 @@ export interface useTopToolbarOutcome  {
 }
 
 const useAppToolbar = () :  useTopToolbarOutcome => {
-    const user = useSelector<StoreStateType, User>(state => state.user);
+    const user = useSelector<StoreStateType, User>(state => state.user.data);
     const classes = useStyles();
     
     const [countyDisplayName, setCountyDisplayName] = React.useState<string>('');
@@ -78,6 +79,7 @@ const useAppToolbar = () :  useTopToolbarOutcome => {
 
     const logout = async () => {
         await setUserActivityStatus(false);
+        await persistor.purge();
         window.location.href = `${window.location.protocol}//${window.location.hostname}/.auth/logout`;
     }
 

--- a/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigatedPersonInfo/InvestigatedPersonInfo.tsx
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigatedPersonInfo/InvestigatedPersonInfo.tsx
@@ -53,7 +53,7 @@ const InvestigatedPersonInfo = (props: Props) => {
     const statuses = useSelector<StoreStateType, string[]>(state => state.statuses);
     const subStatuses = useSelector<StoreStateType, string[]>(state => state.subStatuses);
     const isLoading = useSelector<StoreStateType, boolean>(state => state.isLoading);
-    const userType = useSelector<StoreStateType, number>(state => state.user.userType);
+    const userType = useSelector<StoreStateType, number>(state => state.user.data.userType);
 
     const validationSchema = investigationStatus.subStatus === transferredSubStatus ?
         yup.string().required(requiredMessage).matches(excludeSpecialCharsRegex, errorMessage).max(50, maxLengthErrorMessage).nullable() :

--- a/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigatedPersonInfo/useInvestigatedPersonInfo.ts
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigatedPersonInfo/useInvestigatedPersonInfo.ts
@@ -27,8 +27,8 @@ const useInvestigatedPersonInfo = (): InvestigatedPersonInfoOutcome => {
     const {updateIsDeceased, updateIsCurrentlyHospitialized} = useStatusUtils();
     const { alertWarning } = useCustomSwal();
 
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
-    const userRole = useSelector<StoreStateType, number>(state => state.user.userType);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
+    const userRole = useSelector<StoreStateType, number>(state => state.user.data.userType);
     const currInvestigatorId = useSelector<StoreStateType, string>(state => state.investigation.creator);
     const investigationStatus = useSelector<StoreStateType, InvestigationStatus>(state => state.investigation.investigationStatus);
 

--- a/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigationInfoBar.tsx
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigationInfoBar.tsx
@@ -66,7 +66,7 @@ const InvestigationInfoBar: React.FC<Props> = ({ currentTab }: Props) => {
 
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
     const lastOpenedEpidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.lastOpenedEpidemiologyNumber);
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
 
     React.useEffect(() => {
         if (lastOpenedEpidemiologyNumber !== defaultEpidemiologyNumber) {

--- a/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigationInfoBar.tsx
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigationInfoBar.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import Swal from 'sweetalert2';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import axios from 'axios';
 
-import axios from 'Utils/axios';
 import logger from 'logger/logger';
 import { timeout } from 'Utils/Timeout/Timeout';
 import { Service, Severity } from 'models/Logger';

--- a/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigationInfoBar.tsx
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigationInfoBar.tsx
@@ -5,7 +5,6 @@ import { useHistory } from 'react-router-dom';
 
 import axios from 'Utils/axios';
 import logger from 'logger/logger';
-import { store } from 'redux/store';
 import { timeout } from 'Utils/Timeout/Timeout';
 import { Service, Severity } from 'models/Logger';
 import StoreStateType from 'redux/storeStateType';
@@ -66,18 +65,16 @@ const InvestigationInfoBar: React.FC<Props> = ({ currentTab }: Props) => {
     const [investigationStaticInfo, setInvestigationStaticInfo] = React.useState<InvestigationInfo>(defaultInvestigationStaticInfo);
 
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
+    const lastOpenedEpidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.lastOpenedEpidemiologyNumber);
     const userId = useSelector<StoreStateType, string>(state => state.user.id);
 
     React.useEffect(() => {
-        timeout(2000).then(() => {
-            let openedEpidemiologyNumber = store.getState().investigation.lastOpenedEpidemiologyNumber;
-            if (openedEpidemiologyNumber !== defaultEpidemiologyNumber) {
-                setEpidemiologyNum(openedEpidemiologyNumber);
-                setLastOpenedEpidemiologyNum(defaultEpidemiologyNumber);
-            } else {
-                handleInvalidEntrance();
-            }
-        });
+        if (lastOpenedEpidemiologyNumber !== defaultEpidemiologyNumber) {
+            setEpidemiologyNum(lastOpenedEpidemiologyNumber);
+            setLastOpenedEpidemiologyNum(defaultEpidemiologyNumber);
+        } else {
+            handleInvalidEntrance();
+        }
     }, []);
 
     React.useEffect(() => {

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/ClinicalDetails.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/ClinicalDetails.tsx
@@ -49,7 +49,7 @@ const ClinicalDetails: React.FC<Props> = ({ id }: Props): JSX.Element => {
     const cities = useSelector<StoreStateType, Map<string, City>>(state => state.cities);
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
     const investigatedPatientId = useSelector<StoreStateType, number>(state => state.investigation.investigatedPatient.investigatedPatientId);
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
 
     const { fetchClinicalDetails, getStreetByCity, saveClinicalDetails, isolationSources } = useClinicalDetails({
             setSymptoms, setBackgroundDiseases, setIsolationCityName, setIsolationStreetName, setStreetsInCity });

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/useClinicalDetails.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/useClinicalDetails.ts
@@ -42,7 +42,7 @@ const useClinicalDetails = (parameters: useClinicalDetailsIncome): useClinicalDe
     const { setSymptoms, setBackgroundDiseases, setIsolationCityName, setIsolationStreetName, setStreetsInCity } = parameters;
 
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
     const address = useSelector<StoreStateType, DBAddress>(state => state.address);
     const [isolationSources, setIsolationSources] = React.useState<IsolationSource[]>([]);
     

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/useContactQuestioning.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/useContactQuestioning.ts
@@ -23,7 +23,7 @@ import {
 const useContactQuestioning = (parameters: useContactQuestioningParameters): useContactQuestioningOutcome => {
     const {id, setAllContactedInteractions, allContactedInteractions, setFamilyRelationships, setContactStatuses} = parameters;
     
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
 
     const { checkDuplicateIds } = useDuplicateContactId();

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/ExposureForm/ExposureForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/ExposureForm/ExposureForm.tsx
@@ -52,7 +52,7 @@ const ExposureForm = (props: any) => {
   const [optionalCovidPatients, setOptionalCovidPatients] = useState<CovidPatient[]>([]);
 
   const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
-  const userId = useSelector<StoreStateType, string>(state => state.user.id);
+  const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
 
   const selectedExposureSourceDisplay = (exposureSource: CovidPatient): string => {
     const fields: string[] = [];

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/ExposuresAndFlights.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/ExposuresAndFlights.tsx
@@ -37,7 +37,7 @@ const ExposuresAndFlights: React.FC<Props> = ({ id }: Props): JSX.Element => {
 
   const investigationId = useSelector<StoreStateType, number>((state) => state.investigation.epidemiologyNumber);
   const investigatedPatientId = useSelector<StoreStateType, number>((state) => state.investigation.investigatedPatient.investigatedPatientId);
-  const userId = useSelector<StoreStateType, string>(state => state.user.id);
+  const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
 
   const methods = useForm();
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/ContactDateCard/InteractionCard/ExcelUploader/ContactUploader.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/ContactDateCard/InteractionCard/ExcelUploader/ContactUploader.tsx
@@ -32,7 +32,7 @@ const ContactUploader = ({ contactEvent, onSave, allInteractions }: ExcelUploade
     const buttonRef = React.useRef<HTMLInputElement>(null);
     
     const epidemiologyNumber = useSelector<StoreStateType, number>((state) => state.investigation.epidemiologyNumber);
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
     
     const existingContacts : Contact[] = allInteractions
     .flatMap(interaction => interaction.contacts

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionEventForm/useInteractionsForm.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionEventForm/useInteractionsForm.ts
@@ -14,7 +14,7 @@ const useInteractionsForm = (props: useInteractionFormIncome): useInteractionFor
         const {loadInteractions, closeNewDialog, closeEditDialog} = props;
         const {parseLocation} = useDBParser();
         const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
-        const userId = useSelector<StoreStateType, string>(state => state.user.id);
+        const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
 
         const saveInteractions = async (interactionsDataToSave: InteractionEventDialogData) => {
             const locationAddress = interactionsDataToSave[InteractionEventDialogFields.LOCATION_ADDRESS] ?

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/useInteractionsTab.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/useInteractionsTab.ts
@@ -35,7 +35,7 @@ const useInteractionsTab = (parameters: useInteractionsTabParameters): useIntera
     const [symptomsStartDate, setSymptomsStartDate] = useState<Date | null>(null);
 
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
 
     const classes = useStyles({});
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/PersonalInfoTabInterfaces.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/PersonalInfoTabInterfaces.ts
@@ -2,7 +2,7 @@ import Street from 'models/Street';
 import SubOccupationAndStreet from 'models/SubOccupationAndStreet';
 import investigatedPatientRole from 'models/investigatedPatientRole';
 import { OccupationsContext } from 'commons/Contexts/OccupationsContext';
-import { PersonalInfoFormData } from 'models/Contexts/PersonalInfoContextData';
+import { PersonalInfoDbData, PersonalInfoFormData } from 'models/Contexts/PersonalInfoContextData';
 
 export interface usePersonalInfoTabParameters {
     occupationsStateContext: OccupationsContext;
@@ -24,4 +24,5 @@ export interface usePersonalInfoTabOutcome {
     getSubOccupations: (parentOccupation: string) => void;
     getEducationSubOccupations: (city: string) => void;
     getStreetsByCity: (cityId: string) => void;
+    savePersonalData: (personalInfoData: PersonalInfoDbData, data: { [x: string]: any }, id: number) => void;
 };

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/usePersonalInfoTab.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/usePersonalInfoTab.ts
@@ -22,7 +22,7 @@ const usePersonalInfoTab = (parameters: usePersonalInfoTabParameters): usePerson
 
     const classes = useStyles({});
 
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
     const investigatedPatientId = useSelector<StoreStateType, number>(state => state.investigation.investigatedPatient.investigatedPatientId);
     const investigationStatus = useSelector<StoreStateType, InvestigationStatus>((state) => state.investigation.investigationStatus);

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/usePersonalInfoTab.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/usePersonalInfoTab.ts
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import axios from 'Utils/axios';
 import logger from 'logger/logger';
 import { initDBAddress } from 'models/DBAddress';
-import { Service, Severity } from 'models/Logger';
+import { Severity } from 'models/Logger';
 import StoreStateType from 'redux/storeStateType';
 import Occupations from 'models/enums/Occupations';
 import { setInvestigatedPatientId } from 'redux/Investigation/investigationActionCreators';
@@ -26,81 +26,47 @@ const usePersonalInfoTab = (parameters: usePersonalInfoTabParameters): usePerson
     const fetchPersonalInfo = (reset: (values?: Record<string, any>, omitResetState?: Record<string, boolean>) => void,
                                trigger: (payload?: string | string[]) => Promise<boolean>
                               ) => {
-        logger.info({
-            service: Service.CLIENT,
-            severity: Severity.LOW,
+        const occupationsLogger = logger.setup({
             workflow: 'Fetching Occupations',
-            step: 'launching occupations request',
             user: userId,
             investigation: epidemiologyNumber
         });
+        occupationsLogger.info('launching occupations request', Severity.LOW);
         axios.get('/personalDetails/occupations').then((res: any) => {
-            logger.info({
-                service: Service.CLIENT,
-                severity: Severity.LOW,
-                workflow: 'Fetching Occupations',
-                step: 'got results back from the server',
-                user: userId,
-                investigation: epidemiologyNumber
-            });
+            occupationsLogger.info('got results back from the server', Severity.LOW);
             occupationsStateContext.occupations = res?.data?.data?.allOccupations?.nodes?.map((node: any) => node.displayName);
         });
-        logger.info({
-            service: Service.CLIENT,
-            severity: Severity.LOW,
+        const hmosLogger = logger.setup({
             workflow: 'Fetching HMOs',
-            step: 'launching HMOs request',
             user: userId,
             investigation: epidemiologyNumber
         });
+        hmosLogger.info('launching HMOs request', Severity.LOW);
         axios.get('/personalDetails/hmos').then((res: any) => {
-            logger.info({
-                service: Service.CLIENT,
-                severity: Severity.LOW,
-                workflow: 'Fetching HMOs',
-                step: 'got results back from the server',
-                user: userId,
-                investigation: epidemiologyNumber
-            });
+            hmosLogger.info('got results back from the server', Severity.LOW);
             res && res.data && res.data.data && setInsuranceCompanies(res.data.data.allHmos.nodes.map((node: any) => node.displayName));
         });
-        logger.info({
-            service: Service.CLIENT,
-            severity: Severity.LOW,
+
+        const investigatedPatientRolesLogger = logger.setup({
             workflow: 'Fetching investigated patient roles',
-            step: 'launching investigated patient roles request',
             user: userId,
             investigation: epidemiologyNumber
         });
+        investigatedPatientRolesLogger.info('launching investigated patient roles request', Severity.LOW);
         axios.get('/personalDetails/investigatedPatientRoles').then((res: any) => {
-            logger.info({
-                service: Service.CLIENT,
-                severity: Severity.LOW,
-                workflow: 'Fetching investigated patient roles',
-                step: 'got results back from the server',
-                user: userId,
-                investigation: epidemiologyNumber
-            });
+            investigatedPatientRolesLogger.info('got results back from the server', Severity.LOW);
             setInvestigatedPatientRoles(res?.data);
         });
-        logger.info({
-            service: Service.CLIENT,
-            severity: Severity.LOW,
+
+        const personalDetailsLogger = logger.setup({
             workflow: 'Fetching Personal Details',
-            step: 'launching personal data request',
             user: userId,
             investigation: epidemiologyNumber
         });
+        personalDetailsLogger.info('launching personal data request', Severity.LOW);
         axios.get('/personalDetails/investigatedPatientPersonalInfoFields?epidemioligyNumber=' + epidemiologyNumber).then((res: any) => {
             if (res && res.data && res.data) {
-                logger.info({
-                    service: Service.CLIENT,
-                    severity: Severity.LOW,
-                    workflow: 'Fetching Personal Details',
-                    step: 'got results back from the server',
-                    user: userId,
-                    investigation: epidemiologyNumber
-                });
+                personalDetailsLogger.info('got results back from the server', Severity.LOW);
                 const investigatedPatient = res.data;
                 setInvestigatedPatientId(investigatedPatient.id);
                 const patientAddress = investigatedPatient.addressByAddress;
@@ -149,25 +115,11 @@ const usePersonalInfoTab = (parameters: usePersonalInfoTabParameters): usePerson
                     setInsuranceCompany(investigatedPatient.hmo);
                 }
             } else {
-                logger.error({
-                    service: Service.CLIENT,
-                    severity: Severity.HIGH,
-                    workflow: 'Fetching Personal Details',
-                    step: `got errors in server result: ${JSON.stringify(res)}`,
-                    user: userId,
-                    investigation: epidemiologyNumber
-                });
+                personalDetailsLogger.error(`got errors in server result: ${JSON.stringify(res)}`, Severity.HIGH);
             }
         }).catch((error) => {
             if (epidemiologyNumber !== -1) {
-                logger.error({
-                    service: Service.CLIENT,
-                    severity: Severity.HIGH,
-                    workflow: 'Fetching Personal Details',
-                    step: `got errors in server request ${error}`,
-                    user: userId,
-                    investigation: epidemiologyNumber
-                });
+                personalDetailsLogger.error(`got errors in server request ${error}`, Severity.HIGH);
                 Swal.fire({
                     title: 'הייתה שגיאה בטעינת הפרטים האישיים',
                     icon: 'error',
@@ -180,24 +132,15 @@ const usePersonalInfoTab = (parameters: usePersonalInfoTabParameters): usePerson
     }
 
     const getSubOccupations = (parentOccupation: string) => {
-        logger.info({
-            service: Service.CLIENT,
-            severity: Severity.LOW,
+        const subOccupationsLogger = logger.setup({
             workflow: 'Fetching Sub Occupation by Parent Occupation',
-            step: `launching sub occupations request with parameter: ${parentOccupation}`,
             user: userId,
             investigation: epidemiologyNumber
         });
+        subOccupationsLogger.info(`launching sub occupations request with parameter: ${parentOccupation}`, Severity.LOW);
         axios.get('/personalDetails/subOccupations?parentOccupation=' + parentOccupation).then((res: any) => {
             if (res && res.data && res.data.data) {
-                logger.info({
-                    service: Service.CLIENT,
-                    severity: Severity.LOW,
-                    workflow: 'Fetching Sub Occupation by Parent Occupation',
-                    step: 'got result from the DB',
-                    user: userId,
-                    investigation: epidemiologyNumber
-                });
+                subOccupationsLogger.info('got result from the DB', Severity.LOW);
                 setSubOccupations(res.data.data.allSubOccupations.nodes.map((node: any) => {
                     return {
                         id: node.id,
@@ -205,37 +148,21 @@ const usePersonalInfoTab = (parameters: usePersonalInfoTabParameters): usePerson
                     }
                 }));
             } else {
-                logger.error({
-                    service: Service.CLIENT,
-                    severity: Severity.HIGH,
-                    workflow: 'Fetching Sub Occupation by Parent Occupation',
-                    step: `got error in query result ${JSON.stringify(res)}`,
-                    user: userId,
-                    investigation: epidemiologyNumber
-                });
+                subOccupationsLogger.error(`got error in query result ${JSON.stringify(res)}`, Severity.HIGH);
             }
         });
     }
 
     const getEducationSubOccupations = (city: string) => {
-        logger.info({
-            service: Service.CLIENT,
-            severity: Severity.LOW,
+        const educationSubOccupationsLogger = logger.setup({
             workflow: 'Fetching Education Sub Occupation by City',
-            step: `launching education sub occupations request with parameter: ${city}`,
             user: userId,
             investigation: epidemiologyNumber
         });
+        educationSubOccupationsLogger.info(`launching education sub occupations request with parameter: ${city}`, Severity.LOW);
         axios.get('/personalDetails/educationSubOccupations?city=' + city).then((res: any) => {
             if (res && res.data && res.data.data) {
-                logger.info({
-                    service: Service.CLIENT,
-                    severity: Severity.LOW,
-                    workflow: 'Fetching Education Sub Occupation by City',
-                    step: `got results from the server`,
-                    user: userId,
-                    investigation: epidemiologyNumber
-                });
+                educationSubOccupationsLogger.info(`got results from the server`, Severity.LOW);
                 setSubOccupations(res.data.data.allSubOccupations.nodes.map((node: any) => {
                     return {
                         id: node.id,
@@ -244,35 +171,21 @@ const usePersonalInfoTab = (parameters: usePersonalInfoTabParameters): usePerson
                     }
                 }));
             } else {
-                logger.warn({
-                    service: Service.CLIENT,
-                    severity: Severity.HIGH,
-                    workflow: 'Fetching Education Sub Occupation by City',
-                    step: 'got status 200 but got invalid outcome'
-                })
+                educationSubOccupationsLogger.warn('got status 200 but got invalid outcome', Severity.HIGH);
             }
         });
     }
 
     const getStreetsByCity = (cityId: string) => {
-        logger.info({
-            service: Service.CLIENT,
-            severity: Severity.LOW,
+        const streetsByCityLogger = logger.setup({
             workflow: 'Getting streets of city',
-            step: `launching request to server with parameter ${cityId}`,
             user: userId,
             investigation: epidemiologyNumber
-        })
+        });
+        streetsByCityLogger.info(`launching request to server with parameter ${cityId}`, Severity.LOW);
         axios.get('/addressDetails/city/' + cityId + '/streets').then((res: any) => {
             if (res && res.data) {
-                logger.info({
-                    service: Service.CLIENT,
-                    severity: Severity.LOW,
-                    workflow: 'Getting streets of city',
-                    step: 'got data from the server',
-                    user: userId,
-                    investigation: epidemiologyNumber
-                })
+                streetsByCityLogger.info('got data from the server', Severity.LOW);
                 setStreets(res.data.map((node: any) => (
                     {
                         displayName: node.displayName,
@@ -280,12 +193,7 @@ const usePersonalInfoTab = (parameters: usePersonalInfoTabParameters): usePerson
                     }
                 )));
             } else {
-                logger.warn({
-                    service: Service.CLIENT,
-                    severity: Severity.HIGH,
-                    workflow: 'Getting streets of city',
-                    step: 'got status 200 but wrong data'
-                });
+                streetsByCityLogger.warn('got status 200 but wrong data', Severity.HIGH);
             }
         });
     }

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/usePersonalInfoTab.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/usePersonalInfoTab.ts
@@ -178,7 +178,7 @@ const usePersonalInfoTab = (parameters: usePersonalInfoTabParameters): usePerson
         educationSubOccupationsLogger.info(`launching education sub occupations request with parameter: ${city}`, Severity.LOW);
         axios.get('/personalDetails/educationSubOccupations?city=' + city).then((res: any) => {
             if (res && res.data && res.data.data) {
-                educationSubOccupationsLogger.info(`got results from the server`, Severity.LOW);
+                educationSubOccupationsLogger.info('got results from the server', Severity.LOW);
                 setSubOccupations(res.data.data.allSubOccupations.nodes.map((node: any) => {
                     return {
                         id: node.id,

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/usePersonalInfoTab.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/usePersonalInfoTab.ts
@@ -221,6 +221,7 @@ const usePersonalInfoTab = (parameters: usePersonalInfoTabParameters): usePerson
             user: userId
         });
         savePersonalDataLogger.info('launching the server request', Severity.LOW);
+        setIsLoading(true);
         axios.post('/personalDetails/updatePersonalDetails',
             {
                 id: investigatedPatientId,
@@ -238,6 +239,7 @@ const usePersonalInfoTab = (parameters: usePersonalInfoTabParameters): usePerson
                 complexityErrorAlert(error);
             })
             .finally(() => {
+                setIsLoading(false);
                 personalInfoValidationSchema.isValid(data).then(valid => {
                     setFormState(epidemiologyNumber, id, valid);
                 })

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/usePersonalInfoTab.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/PersonalInfoTab/usePersonalInfoTab.ts
@@ -1,7 +1,7 @@
 import Swal from 'sweetalert2';
 import { useSelector } from 'react-redux';
+import axios from 'axios';
 
-import axios from 'Utils/axios';
 import logger from 'logger/logger';
 import { initDBAddress } from 'models/DBAddress';
 import { Severity } from 'models/Logger';
@@ -13,6 +13,7 @@ import InvestigationMainStatus from 'models/enums/InvestigationMainStatus';
 import { setFormState } from 'redux/Form/formActionCreators';
 import useComplexitySwal from 'commons/InvestigationComplexity/ComplexityUtils/ComplexitySwal';
 import { InvestigationStatus } from 'models/InvestigationStatus';
+import { setIsLoading } from 'redux/IsLoading/isLoadingActionCreators';
 
 import useStyles from './PersonalInfoTabStyles';
 import { usePersonalInfoTabParameters, usePersonalInfoTabOutcome } from './PersonalInfoTabInterfaces';
@@ -74,6 +75,7 @@ const usePersonalInfoTab = (parameters: usePersonalInfoTabParameters): usePerson
             investigation: epidemiologyNumber
         });
         personalDetailsLogger.info('launching personal data request', Severity.LOW);
+        setIsLoading(true);
         axios.get('/personalDetails/investigatedPatientPersonalInfoFields?epidemioligyNumber=' + epidemiologyNumber).then((res: any) => {
             if (res && res.data && res.data) {
                 personalDetailsLogger.info('got results back from the server', Severity.LOW);
@@ -120,14 +122,18 @@ const usePersonalInfoTab = (parameters: usePersonalInfoTabParameters): usePerson
                 setPersonalInfoData(PersonalInfoData);
                 reset(PersonalInfoData);
                 trigger();
+                setIsLoading(false);
                 investigatedPatient.subOccupationBySubOccupation && setSubOccupationName(investigatedPatient.subOccupationBySubOccupation.displayName);
                 if (investigatedPatient.hmo !== null) {
                     setInsuranceCompany(investigatedPatient.hmo);
                 }
             } else {
                 personalDetailsLogger.error(`got errors in server result: ${JSON.stringify(res)}`, Severity.HIGH);
+                setIsLoading(false);
             }
         }).catch((error) => {
+            setIsLoading(false);
+
             if (epidemiologyNumber !== -1) {
                 personalDetailsLogger.error(`got errors in server request ${error}`, Severity.HIGH);
                 Swal.fire({

--- a/client/src/components/App/Content/InvestigationForm/useInvestigationForm.ts
+++ b/client/src/components/App/Content/InvestigationForm/useInvestigationForm.ts
@@ -1,8 +1,8 @@
 import { useSelector } from 'react-redux';
 import { useEffect, useState } from 'react';
+import axios from 'axios';
 
 import City from 'models/City';
-import axios from 'Utils/axios';
 import logger from 'logger/logger';
 import theme from 'styles/theme';
 import Country from 'models/Country';

--- a/client/src/components/App/Content/InvestigationForm/useInvestigationForm.ts
+++ b/client/src/components/App/Content/InvestigationForm/useInvestigationForm.ts
@@ -32,7 +32,7 @@ const useInvestigationForm = (): useInvestigationFormOutcome => {
 
     const { alertError, alertWarning, alertSuccess } = useCustomSwal();
 
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
     const cities = useSelector<StoreStateType, Map<string, City>>(state => state.cities);
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
     const investigationStatus = useSelector<StoreStateType, InvestigationStatus>(state => state.investigation.investigationStatus);

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationStatusColumn/InvestigationStatusColumn.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationStatusColumn/InvestigationStatusColumn.tsx
@@ -16,7 +16,7 @@ const InvestigationStatusColumn = (props: Props) => {
 
     const { investigationStatus, investigationSubStatus, epidemiologyNumber, moveToTheInvestigationForm, statusReason } = props;
     
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
 
     const { alertError } = useCustomSwal();
 

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -94,7 +94,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
         setAllCounties, setAllStatuses, setAllDesks, checkedRowsIds
     });
 
-    const user = useSelector<StoreStateType, User>(state => state.user);
+    const user = useSelector<StoreStateType, User>(state => state.user.data);
 
     const isRowSelected = (epidemiologyNumber: number) => checkedRowsIds.includes(epidemiologyNumber);
 

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableFooter/useInvestigationTableFooter.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableFooter/useInvestigationTableFooter.ts
@@ -17,7 +17,7 @@ const useInvestigationTableFooter = (parameters: InvestigationTableFooterParamet
 
     const { alertError } = useCustomSwal();
 
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
 
     const handleOpenDesksDialog = () => setOpenDesksDialog(true);
 

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -98,7 +98,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
     const [isDefaultOrder, setIsDefaultOrder] = useState<boolean>(true);
     const [orderBy, setOrderBy] = useState<string>(defaultOrderBy);
 
-    const user = useSelector<StoreStateType, User>(state => state.user);
+    const user = useSelector<StoreStateType, User>(state => state.user.data);
     const isCurrentlyLoadingInvestigation = useSelector<StoreStateType, boolean>(state => state.investigation.isCurrentlyLoading);
     const isLoading = useSelector<StoreStateType, boolean>(state => state.isLoading);
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
@@ -318,7 +318,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             fetchAllCountyUsers();
             fetchAllCounties();
         }
-        if (user.userName !== initialUserState.userName) {
+        if (user.userName !== initialUserState.data.userName) {
             logger.info({
                 service: Service.CLIENT,
                 severity: Severity.LOW,

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -8,14 +8,13 @@ import User from 'models/User';
 import theme from 'styles/theme';
 import County from 'models/County';
 import logger from 'logger/logger';
-import { store } from 'redux/store';
+import { persistor, store } from 'redux/store';
 import userType from 'models/enums/UserType';
 import Investigator from 'models/Investigator';
 import { timeout } from 'Utils/Timeout/Timeout';
 import { activateIsLoading } from 'Utils/axios';
 import { Service, Severity } from 'models/Logger';
 import StoreStateType from 'redux/storeStateType';
-import { defaultEpidemiologyNumber } from 'Utils/consts';
 import usePageRefresh from 'Utils/vendor/usePageRefresh';
 import { initialUserState } from 'redux/User/userReducer';
 import InvestigationTableRow from 'models/InvestigationTableRow';
@@ -190,7 +189,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         startWaiting();
     }, [])
 
-    const moveToTheInvestigationForm = (epidemiologyNumberVal: number) => {
+    const moveToTheInvestigationForm = async (epidemiologyNumberVal: number) => {
         setLastOpenedEpidemiologyNum(epidemiologyNumberVal);
         logger.info({
             service: Service.CLIENT,
@@ -200,8 +199,9 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             investigation: epidemiologyNumberVal
         })
         setIsInInvestigation(true);
-        epidemiologyNumberVal !== defaultEpidemiologyNumber && window.open(investigationURL);
         setIsCurrentlyLoading(true);
+        await persistor.flush();
+        window.open(investigationURL);
         timeout(15000).then(() => {
             store.getState().investigation.isCurrentlyLoading && setIsCurrentlyLoading(false);
         });

--- a/client/src/components/App/Content/SignUp/SignUp.tsx
+++ b/client/src/components/App/Content/SignUp/SignUp.tsx
@@ -25,7 +25,7 @@ const SignUp : React.FC<Props> = ({ open, handleSaveUser, handleCloseSignUp }) =
 
     const classes = useStyles();
 
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
 
     const defaultValues : SignUpUser = {
         ...UserInitialValues,

--- a/client/src/components/App/Content/SignUp/SignUpForm/useSignUpForm.ts
+++ b/client/src/components/App/Content/SignUp/SignUpForm/useSignUpForm.ts
@@ -21,7 +21,7 @@ const useSignUp = ({ handleSaveUser }: useSignUpFormInCome) : useSignUpFormOutCo
     const [desks, setDesks] = useState<Desk[]>([]);
     const [sourcesOrganization, setSourcesOrganization] = useState<SourceOrganization[]>([])
 
-    const userId = useSelector<StoreStateType, string>(state => state.user.id);
+    const userId = useSelector<StoreStateType, string>(state => state.user.data.id);
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
 
     const fetchCities = () => {

--- a/client/src/components/App/Content/UsersManagement/UsersFilter/UsersFilter.tsx
+++ b/client/src/components/App/Content/UsersManagement/UsersFilter/UsersFilter.tsx
@@ -68,7 +68,7 @@ const GenericAutoComplete: React.FC<GenericAutoCompleteProps> = (props: GenericA
 const UsersFilter:React.FC<Props> = ( props : Props ) => {
     const { sourcesOrganization, languages, counties, userTypes, handleFilterChange, handleCloseFitler } = props;
 
-    const userType = useSelector<StoreStateType, number>(state => state.user.userType);
+    const userType = useSelector<StoreStateType, number>(state => state.user.data.userType);
 
     const classes = useStyles();
     

--- a/client/src/components/App/Content/UsersManagement/useUsersManagement.ts
+++ b/client/src/components/App/Content/UsersManagement/useUsersManagement.ts
@@ -40,7 +40,7 @@ const useUsersManagement = ({ page, rowsPerPage, cellNameSort }: useUsersManagem
     const [filterRules, setFitlerRules] = useState<any>({});
     const [isBadgeInVisible, setIsBadgeInVisible] = useState<boolean>(true);
     
-    const user = useSelector<StoreStateType, User>(state => state.user);
+    const user = useSelector<StoreStateType, User>(state => state.user.data);
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
 
     const getUsersRoute = () => {

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -10,11 +10,12 @@ import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import DateFnsUtils from '@date-io/date-fns';
 import heLocale from 'date-fns/locale/he';
 import axios from 'axios';
+import { PersistGate } from 'redux-persist/integration/react'
 
 import './index.css';
 import './styles/fonts.css';
 import theme from './styles/theme';
-import { store } from './redux/store';
+import { store, persistor } from './redux/store';
 import App from './components/App/App';
 
 axios.defaults.baseURL = '/db';
@@ -22,11 +23,11 @@ axios.defaults.headers['content-type'] = 'text/plain';
 axios.defaults.headers['Access-Control-Allow-Origin'] = '*';
 
 axios.interceptors.request.use(
-    async (config) => {
-        config.headers.EpidemiologyNumber = store.getState().investigation.epidemiologyNumber;
-        return config;
-    }, 
-    (error) => Promise.reject(error)
+  async (config) => {
+    config.headers.EpidemiologyNumber = store.getState().investigation.epidemiologyNumber;
+    return config;
+  },
+  (error) => Promise.reject(error)
 );
 
 const jss = create({ plugins: [...jssPreset().plugins, rtl()] });
@@ -35,9 +36,11 @@ ReactDOM.render(
     <MuiThemeProvider theme={theme}>
       <MuiPickersUtilsProvider utils={DateFnsUtils} locale={heLocale}>
         <StylesProvider jss={jss}>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
+          <PersistGate loading={null} persistor={persistor}>
+            <BrowserRouter>
+              <App />
+            </BrowserRouter>
+          </PersistGate>
         </StylesProvider>
       </MuiPickersUtilsProvider>
     </MuiThemeProvider>

--- a/client/src/redux/User/userReducer.ts
+++ b/client/src/redux/User/userReducer.ts
@@ -3,27 +3,42 @@ import userType from 'models/enums/UserType';
 
 import * as Actions from './userActionTypes';
 
-export const initialUserState: User = {
-    id: '1',
-    userName: 'XXXXXX',
-    investigationGroup: -1,
-    isActive: false,
-    phoneNumber: '',
-    serialNumber: -1,
-    activeInvestigationsCount: 0,
-    newInvestigationsCount: 0,
-    userType: userType.INVESTIGATOR,
-    sourceOrganization: '',
-    deskName: '',
-    countyByInvestigationGroup: {
-        districtId: -1
-    }
+export interface UserState {
+    data: User;
+    isLoggedIn: boolean;
 }
 
-const userReducer = (state = initialUserState, action: Actions.UserAction): User => {
+export const initialUserState: UserState = {
+    data: {
+        id: '1',
+        userName: 'XXXXXX',
+        investigationGroup: -1,
+        isActive: false,
+        phoneNumber: '',
+        serialNumber: -1,
+        activeInvestigationsCount: 0,
+        newInvestigationsCount: 0,
+        userType: userType.INVESTIGATOR,
+        sourceOrganization: '',
+        deskName: '',
+        countyByInvestigationGroup: {
+            districtId: -1
+        }
+    },
+    isLoggedIn: false
+}
+
+const userReducer = (state = initialUserState, action: Actions.UserAction): UserState => {
     switch (action.type) {
-        case Actions.SET_USER: return { ...state, ...action.payload.user };
-        case Actions.SET_IS_ACTIVE: return { ...state, isActive: action.payload.isActive };
+        case Actions.SET_USER: return {
+            ...state,
+            data: action.payload.user,
+            isLoggedIn: true
+        };
+        case Actions.SET_IS_ACTIVE: return {
+            ...state,
+            data: { ...state.data, isActive: action.payload.isActive }
+        };
         default: return state;
     }
 }

--- a/client/src/redux/rootReducers.ts
+++ b/client/src/redux/rootReducers.ts
@@ -1,4 +1,3 @@
-import { withReduxStateSync } from 'redux-state-sync';
 import { combineReducers, Reducer, CombinedState, AnyAction } from 'redux';
 
 import formReducer from './Form/formReducer';
@@ -15,7 +14,7 @@ import subStatusesReducer from './SubStatuses/subStatusesReducer';
 import investigationReducer from './Investigation/investigationReducer';
 import isInInvestigationReducer from './IsInInvestigations/isInInvestigationReducer';
 
-export default withReduxStateSync(combineReducers<StoreStateType>({
+export default combineReducers<StoreStateType>({
      user: userReducer,
      isLoading: isLoadingReducer,
      isInInvestigation: isInInvestigationReducer,
@@ -28,4 +27,4 @@ export default withReduxStateSync(combineReducers<StoreStateType>({
      subStatuses: subStatusesReducer,
      formsValidations: formReducer,
      address: addressReducer,
-})) as unknown as Reducer<CombinedState<StoreStateType>, AnyAction>;
+}) as unknown as Reducer<CombinedState<StoreStateType>, AnyAction>;

--- a/client/src/redux/store.ts
+++ b/client/src/redux/store.ts
@@ -1,21 +1,18 @@
 import thunk from 'redux-thunk';
-import {createStore, applyMiddleware, compose} from 'redux';
-import { createStateSyncMiddleware, initStateWithPrevTab } from 'redux-state-sync';
+import { createStore, applyMiddleware, compose } from 'redux';
+import { persistStore, persistReducer } from 'redux-persist'
+import storageSession from 'redux-persist/lib/storage/session'
 
 import reducers from './rootReducers';
-import * as userActionTypes from '../redux/User/userActionTypes';
-import * as investigationActionTypes from '../redux/Investigation/investigationActionTypes';
-import * as isInInvestigationActionTypes from '../redux/IsInInvestigations/isInInvestigationActionTypes';
 
-const config = {
-    predicate: (action: any) => (action.type === investigationActionTypes.SET_LAST_OPENED_EPIDEMIOLOGY_NUM || 
-        action.type === investigationActionTypes.SET_IS_CURRENTLY_LOADING || 
-        action.type === isInInvestigationActionTypes.SET_IS_IN_INVESTIGATION ||
-        action.type === userActionTypes.SET_IS_ACTIVE),
+
+const persistConfig = {
+    key: 'root',
+    storage: storageSession,
 };
-const middlewares = [createStateSyncMiddleware(config)];
 
+const persistedReducer = persistReducer(persistConfig, reducers)
 const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
-export const store = createStore(reducers, composeEnhancers(applyMiddleware(thunk, ...middlewares)));
-initStateWithPrevTab(store);
+export const store = createStore(persistedReducer, composeEnhancers(applyMiddleware(thunk)));
+export const persistor = persistStore(store);

--- a/client/src/redux/storeStateType.ts
+++ b/client/src/redux/storeStateType.ts
@@ -1,12 +1,13 @@
-import User from 'models/User';
 import City from 'models/City';
 import Country from 'models/Country';
 import DBAddress from 'models/DBAddress';
 import ContactType from 'models/ContactType';
 import InvestigationRedux from 'models/InvestigationRedux';
 
+import { UserState } from './User/userReducer';
+
 export default interface StoreStateType {
-    user: User;
+    user: UserState;
     isLoading: boolean;
     isInInvestigation: boolean;
     investigation: InvestigationRedux;


### PR DESCRIPTION
This PR is the first iteration of improving the loading times in this project- specifically in the personal info tab.
## The problem
Currently the biggest issue lies with having a single global loading indicator which is turned on and off by each Axios request sent to the server.
## The ideal solution
The ideal solution is handling the project's asynchronous data using redux ([see Redux's Async Logic and Data Fetching](https://redux.js.org/tutorials/essentials/part-5-async-logic)). This solution requires a lot of work and refactoring so starting with this may prove difficult for the time being.
## The less ideal but still ok-ish solution
The current solution which will bring us closer to the ideal solution is stopping the usage of the Axios instance created for this project and using the default Axios object instead. While doing that we will decide which Axios requests requires the global loading indicator (ex. form data). Eventually we will reach a point where the whole project's global loading indicator is handled manually instead of automatically by the Axios instance and then it will become easier implementing a "local" loading indicator for each section in the project.

## So what does this PR contain?
This PR does a multitude of things:
* Changes `usePersonalInfoTab.ts` to use the new logger syntax
* Replace `redux-state-sync` with `redux-persist` ([you should read about it](https://github.com/rt2zz/redux-persist)); don't forget to run npm install for it 😉 
* Prevent user re-loading when entering an investigation.
* Show the loading indicator when entering investigation only when loading the form data.
* Show the loading indicator when leaving the personal info tab only when saving the form data.