### PR TITLE
Feat/group inv color

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -99,7 +99,6 @@ const InvestigationTable: React.FC = (): JSX.Element => {
 
     const tableContainerRef = React.useRef<HTMLElement>();
     const investigationColor = React.useRef<Map<string, string>>(new Map())
-    const coloredGroupedRows = useRef<number[]>([]);
 
     const {
         onCancel, onOk, snackbarOpen, tableRows, onInvestigationRowClick, convertToIndexedRow, getCountyMapKeyByValue,
@@ -108,7 +107,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
     } = useInvestigationTable({
         selectedInvestigator, setSelectedRow, setAllUsersOfCurrCounty, allGroupedInvestigations,
         setAllCounties, setAllStatuses, setAllDesks, checkedRowsIds, currentPage, setCurrentPage, setAllGroupedInvestigations, 
-        coloredGroupedRows, investigationColor
+        investigationColor
     });
 
     const user = useSelector<StoreStateType, User>(state => state.user.data);

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
@@ -20,7 +20,6 @@ export interface useInvestigationTableParameters {
     setAllDesks: React.Dispatch<React.SetStateAction<Desk[]>>;
     setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
     setAllGroupedInvestigations: React.Dispatch<React.SetStateAction<Map<string, InvestigationTableRow[]>>>;
-    coloredGroupedRows: MutableRefObject<number[]>;
     investigationColor: MutableRefObject<Map<string, string>>;
 }
 

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -40,7 +40,9 @@ import useInvestigatedPersonInfo
     from '../../InvestigationForm/InvestigationInfo/InvestigatedPersonInfo/useInvestigatedPersonInfo';
 
 const investigationURL = '/investigation';
-const groupedInvestigationsColors = ['#f05454', '#30475e', '#9ddfd3', '#ea86b6', '#ffa36c', '#ffe05d', '#c56183', '#794c74', '#158467', '#a8dda8'];
+const getFlooredRandomNumber = (min: number, max: number): number => (
+    Math.floor(Math.random() * (max - min) + min)
+)
 
 export const createRowData = (
     epidemiologyNumber: number,
@@ -98,7 +100,7 @@ export const transferredSubStatus = 'נדרשת העברה';
 const useInvestigationTable = (parameters: useInvestigationTableParameters): useInvestigationTableOutcome => {
     const { selectedInvestigator, setSelectedRow, setAllCounties, setAllUsersOfCurrCounty,
         setAllStatuses, setAllDesks, currentPage, setCurrentPage, setAllGroupedInvestigations, allGroupedInvestigations,
-        coloredGroupedRows, investigationColor } = parameters;
+        investigationColor } = parameters;
 
     const { shouldUpdateInvestigationStatus } = useInvestigatedPersonInfo();
 
@@ -349,9 +351,13 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
                         investigationRows
                             .filter((row) => row.groupId !== null || !investigationColor.current.has(row.groupId))
                             .forEach((row) => {
-                                const colorIndex = getRandomIndex(0, groupedInvestigationsColors.length - 1);
-                                coloredGroupedRows.current.push(colorIndex);
-                                investigationColor.current.set(row.groupId, groupedInvestigationsColors[colorIndex]);
+                                // We have this color range so the group colors aren't too dark nor bright
+                                const minColorValue = 50;
+                                const maxColorValue = 200;
+                                const red = getFlooredRandomNumber(minColorValue, maxColorValue);
+                                const green = getFlooredRandomNumber(minColorValue, maxColorValue);
+                                const blue = getFlooredRandomNumber(minColorValue, maxColorValue);
+                                investigationColor.current.set(row.groupId, `rgb(${red}, ${green}, ${blue})`);
                             });
                         setIsLoading(false);
                     } else {
@@ -627,21 +633,6 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
                 }
             })
         }
-    }
-
-    const getRandomIndex = (min: number, max: number) => {
-        let randomIndex = Math.floor(Math.random() * (max - min + 1) + min);
-        while (
-            coloredGroupedRows.current.includes(randomIndex) &&
-            coloredGroupedRows.current.length < max
-        ) {
-            if (randomIndex < max) {
-                randomIndex++;
-            } else {
-                randomIndex = 0;
-            }
-        }
-        return randomIndex;
     }
 
     const getTableCellStyles = (rowIndex: number, cellKey: string) => {


### PR DESCRIPTION
Currently the group colors are picked randomly from an array of hard coded color values. Increasing the number of investigations per page can cause a problem when there will be more groups than group colors.
## The solution
I wrote (with some help by our new programmer Yonatan) a random color generator for investigation groups.
## Changes
* Group colors are now randomly generated.
* Fixed issue with investigation table fetching data twice on startup.