### PR TITLE
Add Dependabot™ to the project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/server
+    schedule:
+      interval: "daily
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/client" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR adds a depndabot.yml config file for automatically creating PRs for dependency updates.
## The problem
Currently the process of updating our dependencies is dependent on our own discipline which is not enough considering we have two different package.json files (client/server) with many dependencies in each of them.
## The solution
Dependabot™ is a github app bot which watches our package.json files and creates PRs when new versions of dependencies are available.
## Changes
* Create `dependabot.yml` file in `.github` directory which updates npm packages daily.