### PR TITLE
fix(unnecessary-is-loading): infinity spinner after changing county

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigatedPersonInfo/useInvestigatedPersonInfo.ts
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigatedPersonInfo/useInvestigatedPersonInfo.ts
@@ -32,8 +32,7 @@ const useInvestigatedPersonInfo = (): InvestigatedPersonInfoOutcome => {
         alertSuccess('בחרת לצאת מהחקירה לפני השלמתה! הנך מועבר לעמוד הנחיתה', {
             timer: 1750,
             showConfirmButton: false
-        });
-        timeout(1500).then(() => {
+        }).then(() => {
             const windowTabsBroadcatChannel = new BroadcastChannel(BC_TABS_NAME);
             const closingBroadcastMessage : BroadcastMessage = {
                 message: 'Investigation closed',

--- a/client/src/components/App/Content/InvestigationForm/useInvestigationForm.ts
+++ b/client/src/components/App/Content/InvestigationForm/useInvestigationForm.ts
@@ -224,8 +224,7 @@ const useInvestigationForm = (): useInvestigationFormOutcome => {
         alertSuccess('החקירה הסתיימה! הנך מועבר לעמוד הנחיתה', {
             timer: 1750,
             showConfirmButton: false
-        });
-        timeout(LandingPageTimer).then(() => {
+        }).then(() => {
             const windowTabsBroadcatChannel = new BroadcastChannel(BC_TABS_NAME);
             const finishingBroadcastMessage : BroadcastMessage = {
                 message: 'Investigaion finished',

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -403,15 +403,15 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             user: user.id
         });
 
-        axios.interceptors.request.use(
-            (config) => {
-                config.headers.EpidemiologyNumber = investigationRow.epidemiologyNumber;
-                setIsLoading(true);
-                activateIsLoading(config);
-                return config;
-            },
-            (error) => Promise.reject(error)
-        );
+        // axios.interceptors.request.use(
+        //     (config) => {
+        //         config.headers.EpidemiologyNumber = investigationRow.epidemiologyNumber;
+        //         //setIsLoading(true);
+        //         activateIsLoading(config);
+        //         return config;
+        //     },
+        //     (error) => Promise.reject(error)
+        // );
         if (epidemiologyNumber !== investigationRow.epidemiologyNumber) {
             investigationClickLogger.info('the clicked investigation is not the first one', Severity.LOW);
             const newInterceptor = axios.interceptors.request.use(

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -403,15 +403,6 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             user: user.id
         });
 
-        // axios.interceptors.request.use(
-        //     (config) => {
-        //         config.headers.EpidemiologyNumber = investigationRow.epidemiologyNumber;
-        //         //setIsLoading(true);
-        //         activateIsLoading(config);
-        //         return config;
-        //     },
-        //     (error) => Promise.reject(error)
-        // );
         if (epidemiologyNumber !== investigationRow.epidemiologyNumber) {
             investigationClickLogger.info('the clicked investigation is not the first one', Severity.LOW);
             const newInterceptor = axios.interceptors.request.use(


### PR DESCRIPTION
# infinite spinner is no longer Infinite
a problem that happened after changing county/investigator/desk in investigations table

what we did to solve this problem:
* remove unnecessary axios interceptors in investigation table that caused the problem 
(set is loading = true and never make it false).
* remove unnecessary timeouts after sweet alert  and use then after the alert instead.