### PR TITLE
Revert "build(deps): bump react-hook-form from 6.8.4 to 6.12.2 in /client"

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11684,9 +11684,9 @@
             "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
         },
         "react-hook-form": {
-            "version": "6.12.2",
-            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.12.2.tgz",
-            "integrity": "sha512-O72E2DXyk7djFqyy6eYi5yESGweKe0CNHHPS0Mx4JazpLbE4Ox+66ldZ23f0J5ZN/krEjDWRD+hUfg5Shvfhtw=="
+            "version": "6.8.4",
+            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.8.4.tgz",
+            "integrity": "sha512-qFd5SPPQUZWe+yXF6yjuJXKK8cLXywrzQuw74nL1jptW9Fad4HsEzfh+53Jg3c5TFPIwdIxrMNUvQfd0/p1y/w=="
         },
         "react-is": {
             "version": "16.13.1",

--- a/client/package.json
+++ b/client/package.json
@@ -51,7 +51,7 @@
         "jwt-decode": "^3.0.0",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
-        "react-hook-form": "^6.12.2",
+        "react-hook-form": "^6.8.4",
         "react-redux": "^7.2.1",
         "react-router-dom": "^5.2.0",
         "react-scripts": "3.4.3",


### PR DESCRIPTION
Reverts CoronaTeamMOD/CoronaInvestigation#884

There are type errors being caused by this version of react-hook-form that needs to be investigated further.