### PR TITLE
feat(main table) save filter values on refresh

### DIFF
--- a/client/src/components/App/AppToolbar/AppToolbar.tsx
+++ b/client/src/components/App/AppToolbar/AppToolbar.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { NavLink } from 'react-router-dom';
-import { useLocation } from 'react-router-dom';
+import {NavLink, NavLinkProps, useLocation, useHistory} from 'react-router-dom';
 import { ExitToApp, Home, SupervisorAccount } from '@material-ui/icons';
 import { AppBar, Toolbar, Typography, Tooltip, IconButton } from '@material-ui/core';
 
@@ -14,6 +13,24 @@ const toggleMessage = 'מה הסטטוס שלך?';
 const navButtonsWhitelist = {
   allowedUserTypes: [UserType.ADMIN, UserType.SUPER_ADMIN],
   allowedRoutes: [landingPageRoute, usersManagementRoute]
+};
+
+const StatePersistentNavLink = (props: NavLinkProps) => {
+  const history = useHistory();
+  const { classes } = useAppToolbar();
+
+  const handleNavClick: NavLinkProps['onClick'] = (event) => {
+    event.preventDefault(); // prevent state reset on reroute
+    history.push(props.to as string, history.location.state);
+  };
+
+  return (
+      <NavLink {...props} location={history.location}
+               onClick={handleNavClick}
+               activeClassName={classes.activeItem} className={classes.menuItem}>
+        {props.children}
+      </NavLink>
+  )
 };
 
 const AppToolbar: React.FC = (): JSX.Element => {
@@ -30,14 +47,14 @@ const AppToolbar: React.FC = (): JSX.Element => {
             navButtonsWhitelist.allowedUserTypes.includes(user.userType) &&
             navButtonsWhitelist.allowedRoutes.includes(location.pathname) &&
             <div className={classes.navButtons}>
-              <NavLink activeClassName={classes.activeItem} className={classes.menuItem} exact to={landingPageRoute}>
+              <StatePersistentNavLink exact to={landingPageRoute}>
                 <Home className={classes.menuIcon} />
                 <Typography className={classes.menuTypo}> עמוד הבית</Typography>
-              </NavLink>
-              <NavLink activeClassName={classes.activeItem} className={classes.menuItem} exact to={usersManagementRoute}>
+              </StatePersistentNavLink>
+              <StatePersistentNavLink exact to={usersManagementRoute}>
                 <SupervisorAccount className={classes.menuIcon} />
                 <Typography className={classes.menuTypo}> ניהול משתמשים</Typography>
-              </NavLink>
+              </StatePersistentNavLink>
             </div>
           }
         </div>

--- a/client/src/components/App/AppToolbar/useAppToolbar.tsx
+++ b/client/src/components/App/AppToolbar/useAppToolbar.tsx
@@ -7,6 +7,7 @@ import { persistor } from 'redux/store';
 import User from 'models/User';
 import logger from 'logger/logger';
 import { Severity } from 'models/Logger';
+import { indexRoute } from 'Utils/Routes/Routes';
 import StoreStateType from 'redux/storeStateType';
 import { setIsActive } from 'redux/User/userActionCreators';
 import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
@@ -62,7 +63,7 @@ const useAppToolbar = () :  useTopToolbarOutcome => {
         await setUserActivityStatus(false);
         await persistor.purge();
         history.replace({state: {}});
-        window.location.href = `${window.location.protocol}//${window.location.hostname}/.auth/logout`;
+        window.location.href = `${window.location.protocol}//${window.location.hostname}/.auth/logout?post_logout_redirect_uri=${indexRoute}`;
     }
 
     const setUserActivityStatus = (isActive: boolean) : Promise<any> => {

--- a/client/src/components/App/AppToolbar/useAppToolbar.tsx
+++ b/client/src/components/App/AppToolbar/useAppToolbar.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import axios from 'axios';
 import { persistor } from 'redux/store';
 
 import User from 'models/User';
 import logger from 'logger/logger';
 import { Severity } from 'models/Logger';
-import { indexRoute } from 'Utils/Routes/Routes';
 import StoreStateType from 'redux/storeStateType';
 import { setIsActive } from 'redux/User/userActionCreators';
 import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
@@ -25,6 +25,7 @@ export interface useTopToolbarOutcome  {
 
 const useAppToolbar = () :  useTopToolbarOutcome => {
     const user = useSelector<StoreStateType, User>(state => state.user.data);
+    const history = useHistory();
     const classes = useStyles();
     const { alertError } = useCustomSwal();
     
@@ -60,7 +61,8 @@ const useAppToolbar = () :  useTopToolbarOutcome => {
     const logout = async () => {
         await setUserActivityStatus(false);
         await persistor.purge();
-        window.location.href = `${window.location.protocol}//${window.location.hostname}/.auth/logout?post_logout_redirect_uri=${indexRoute}`;
+        history.replace({state: {}});
+        window.location.href = `${window.location.protocol}//${window.location.hostname}/.auth/logout`;
     }
 
     const setUserActivityStatus = (isActive: boolean) : Promise<any> => {

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -498,7 +498,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
 
     const onFiltersChange = (selectedDesks: DeskFilter, selectedStatuses: StatusFilter) => {
         const nextFilterByStatuses = generateStatusFilterBySelectedStatues(selectedStatuses);
-        const statusFilter = filterCreators[InvestigationsFilterByFields.STATUS](nextFilterByStatuses);
+        const statusFilter = filterCreators[InvestigationsFilterByFields.STATUS](nextFilterByStatuses.map(status => status.id));
         const desksFilter = filterCreators[InvestigationsFilterByFields.DESK_ID](selectedDesks.map(desk => desk.id));
 
         setFilterByStatuses(nextFilterByStatuses);
@@ -508,18 +508,18 @@ const InvestigationTable: React.FC = (): JSX.Element => {
     };
 
     const generateStatusFilterBySelectedStatues = (selectedStatuses: StatusFilter) => {
-        return selectedStatuses.map(status => status.id).includes(ALL_STATUSES_FILTER_OPTIONS)
+        return selectedStatuses.map(status => status.id).includes(allStatusesOption.id)
             ? [] : selectedStatuses;
     };
 
-    const onSelectedStatusesChange = (event: React.ChangeEvent<{}>, selectedStatuses: string[]) => {
+    const onSelectedStatusesChange = (event: React.ChangeEvent<{}>, selectedStatuses: StatusFilter) => {
         const nextFilterByStatuses = generateStatusFilterBySelectedStatues(selectedStatuses);
         setFilterByStatuses(nextFilterByStatuses);
         console.log('onSelectedStatusesChange', nextFilterByStatuses)
-        handleFilterChange(filterCreators[InvestigationsFilterByFields.STATUS](nextFilterByStatuses));
+        handleFilterChange(filterCreators[InvestigationsFilterByFields.STATUS](nextFilterByStatuses.map(status => status.id)));
     }
 
-    const onSelectedDesksChange = (event: React.ChangeEvent<{}>, selectedDesks: Desk[]) => {
+    const onSelectedDesksChange = (event: React.ChangeEvent<{}>, selectedDesks: DeskFilter) => {
         console.log('onSelectedDesksChange', selectedDesks);
 
         setFilterByDesks(selectedDesks);

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -75,13 +75,13 @@ const hideInvestigationGroupText = 'הסתר חקירות קשורות';
 type StatusFilter = InvestigationMainStatus[];
 type DeskFilter = Desk[];
 
-interface SandyM {
+interface HistoryState {
     statusFilter?: StatusFilter;
     deskFilter?: DeskFilter
 }
 
 const InvestigationTable: React.FC = (): JSX.Element => {
-    const history = useHistory<SandyM>();
+    const history = useHistory<HistoryState>();
     const isScreenWide = useMediaQuery('(min-width: 1680px)');
     const classes = useStyles(isScreenWide)();
 
@@ -110,19 +110,12 @@ const InvestigationTable: React.FC = (): JSX.Element => {
     useEffect(() => {
         const {location: {state}} = history;
         const {statusFilter = [], deskFilter = []} = state || {};
-        console.log('loaded state:', statusFilter, deskFilter)
 
         onFiltersChange(deskFilter, statusFilter)
     }, []);
 
     useEffect(() => {
-        console.log('filterByStatuses', filterByStatuses, 'filterByDesks', filterByDesks)
         const {location: {state, pathname}} = history;
-        console.log('state', state, 'state to be pushed', {
-            ...state,
-            statusFilter: filterByStatuses,
-            deskFilter: filterByDesks,
-        })
 
         history.push(pathname, {
             ...state,
@@ -515,13 +508,10 @@ const InvestigationTable: React.FC = (): JSX.Element => {
     const onSelectedStatusesChange = (event: React.ChangeEvent<{}>, selectedStatuses: StatusFilter) => {
         const nextFilterByStatuses = generateStatusFilterBySelectedStatues(selectedStatuses);
         setFilterByStatuses(nextFilterByStatuses);
-        console.log('onSelectedStatusesChange', nextFilterByStatuses)
         handleFilterChange(filterCreators[InvestigationsFilterByFields.STATUS](nextFilterByStatuses.map(status => status.id)));
     }
 
     const onSelectedDesksChange = (event: React.ChangeEvent<{}>, selectedDesks: DeskFilter) => {
-        console.log('onSelectedDesksChange', selectedDesks);
-
         setFilterByDesks(selectedDesks);
         handleFilterChange(filterCreators[InvestigationsFilterByFields.DESK_ID](selectedDesks.map(desk => desk.id)));
     }

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -115,12 +115,14 @@ const InvestigationTable: React.FC = (): JSX.Element => {
     }, []);
 
     useEffect(() => {
-        const {location: {state, pathname}} = history;
+        const {location: {state}} = history;
 
-        history.push(pathname, {
-            ...state,
-            statusFilter: filterByStatuses,
-            deskFilter: filterByDesks,
+        history.replace({
+            state: {
+                ...state,
+                statusFilter: filterByStatuses,
+                deskFilter: filterByDesks,
+            }
         });
 
     }, [filterByStatuses, filterByDesks]);

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux';
 import React, { useMemo, useState, useRef } from 'react';
+import { useHistory } from 'react-router-dom';
 import { Autocomplete, Pagination } from '@material-ui/lab';
 import {
     Paper, Table, TableRow, TableBody, TableCell, Typography,
@@ -71,8 +72,16 @@ const unassignedToDesk = 'לא שוייך לדסק';
 const showInvestigationGroupText = 'הצג חקירות קשורות';
 const hideInvestigationGroupText = 'הסתר חקירות קשורות';
 
-const InvestigationTable: React.FC = (): JSX.Element => {
+type StatusFilter = InvestigationMainStatus[];
+type DeskFilter = Desk[];
 
+interface SandyM {
+    statusFilter?: StatusFilter;
+    deskFilter?: DeskFilter
+}
+
+const InvestigationTable: React.FC = (): JSX.Element => {
+    const history = useHistory<SandyM>();
     const isScreenWide = useMediaQuery('(min-width: 1680px)');
     const classes = useStyles(isScreenWide)();
 
@@ -91,12 +100,36 @@ const InvestigationTable: React.FC = (): JSX.Element => {
     const [showFilterRow, setShowFilterRow] = useState<boolean>(false);
     const [allDesks, setAllDesks] = useState<Desk[]>([]);
     const [currentPage, setCurrentPage] = useState<number>(defaultPage);
-    const [filterByStatuses, setFilterByStatuses] = useState<InvestigationMainStatus[]>([]);
-    const [filterByDesks, setFilterByDesks] = useState<Desk[]>([]);
+    const [filterByStatuses, setFilterByStatuses] = useState<StatusFilter>([]);
+    const [filterByDesks, setFilterByDesks] = useState<DeskFilter>([]);
     const [searchBarQuery, setSearchBarQuery] = useState<string>('');
     const [isSearchBarValid, setIsSearchBarValid] = useState<boolean>(true);
     const [checkGroupedInvestigationOpen, setCheckGroupedInvestigationOpen] = React.useState<number[]>([])
     const [allGroupedInvestigations, setAllGroupedInvestigations] = useState<Map<string, InvestigationTableRow[]>>(new Map());
+
+    useEffect(() => {
+        const {location: {state: {statusFilter = [], deskFilter = []} = {}}} = history;
+        console.log('loaded state:', statusFilter, deskFilter)
+
+        onFiltersChange(deskFilter, statusFilter)
+    }, []);
+
+    useEffect(() => {
+        console.log('filterByStatuses', filterByStatuses, 'filterByDesks', filterByDesks)
+        const {location: {state, pathname}} = history;
+        console.log('state', state, 'state to be pushed', {
+            ...state,
+            statusFilter: filterByStatuses,
+            deskFilter: filterByDesks,
+        })
+
+        history.push(pathname, {
+            ...state,
+            statusFilter: filterByStatuses,
+            deskFilter: filterByDesks,
+        });
+
+    }, [filterByStatuses, filterByDesks]);
 
     const closeDropdowns = () => {
         setInvestigatorAutoCompleteClicked(false);
@@ -376,7 +409,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                 event.stopPropagation();
                                 openGroupedInvestigation(indexedRow.epidemiologyNumber)
                                 if (!allGroupedInvestigations.get(indexedRow.groupId)) {
-                                    fetchInvestigationsByGroupId(indexedRow.groupId)      
+                                    fetchInvestigationsByGroupId(indexedRow.groupId)
                                 }
                             }}>
                                 {isGroupShown ?
@@ -387,7 +420,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                         }
                     </>
                 )
-            case TableHeadersNames.settings: 
+            case TableHeadersNames.settings:
                 return <SettingsActions
                             epidemiologyNumber={indexedRow.epidemiologyNumber}
                             groupId={indexedRow.groupId}
@@ -462,16 +495,32 @@ const InvestigationTable: React.FC = (): JSX.Element => {
             setCheckGroupedInvestigationOpen([...checkGroupedInvestigationOpen, epidemiologyNumber])
     }
 
-    const onSelectedStatusesChange = (event: React.ChangeEvent<{}>, selectedStatuses: InvestigationMainStatus[]) => {
-        const nextFilterByStatuses = selectedStatuses.map(status => status.id).includes(allStatusesOption.id) ?
-            []
-            :
-            selectedStatuses;
+    const onFiltersChange = (selectedDesks: DeskFilter, selectedStatuses: StatusFilter) => {
+        const nextFilterByStatuses = generateStatusFilterBySelectedStatues(selectedStatuses);
+        const statusFilter = filterCreators[InvestigationsFilterByFields.STATUS](nextFilterByStatuses);
+        const desksFilter = filterCreators[InvestigationsFilterByFields.DESK_ID](selectedDesks.map(desk => desk.id));
+
         setFilterByStatuses(nextFilterByStatuses);
-        handleFilterChange(filterCreators[InvestigationsFilterByFields.STATUS](nextFilterByStatuses.map(status => status.id)));
+        setFilterByDesks(selectedDesks);
+
+        handleFilterChange({...statusFilter, ...desksFilter})
+    };
+
+    const generateStatusFilterBySelectedStatues = (selectedStatuses: StatusFilter) => {
+        return selectedStatuses.map(status => status.id).includes(ALL_STATUSES_FILTER_OPTIONS)
+            ? [] : selectedStatuses;
+    };
+
+    const onSelectedStatusesChange = (event: React.ChangeEvent<{}>, selectedStatuses: string[]) => {
+        const nextFilterByStatuses = generateStatusFilterBySelectedStatues(selectedStatuses);
+        setFilterByStatuses(nextFilterByStatuses);
+        console.log('onSelectedStatusesChange', nextFilterByStatuses)
+        handleFilterChange(filterCreators[InvestigationsFilterByFields.STATUS](nextFilterByStatuses));
     }
 
     const onSelectedDesksChange = (event: React.ChangeEvent<{}>, selectedDesks: Desk[]) => {
+        console.log('onSelectedDesksChange', selectedDesks);
+
         setFilterByDesks(selectedDesks);
         handleFilterChange(filterCreators[InvestigationsFilterByFields.DESK_ID](selectedDesks.map(desk => desk.id)));
     }

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from 'react-redux';
-import React, { useMemo, useState, useRef } from 'react';
+import React, { useMemo, useState, useRef, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Autocomplete, Pagination } from '@material-ui/lab';
 import {
@@ -108,7 +108,8 @@ const InvestigationTable: React.FC = (): JSX.Element => {
     const [allGroupedInvestigations, setAllGroupedInvestigations] = useState<Map<string, InvestigationTableRow[]>>(new Map());
 
     useEffect(() => {
-        const {location: {state: {statusFilter = [], deskFilter = []} = {}}} = history;
+        const {location: {state}} = history;
+        const {statusFilter = [], deskFilter = []} = state || {};
         console.log('loaded state:', statusFilter, deskFilter)
 
         onFiltersChange(deskFilter, statusFilter)
@@ -571,6 +572,9 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                             getOptionLabel={(option) => option.deskName}
                             onChange={onSelectedDesksChange}
                             value={filterByDesks}
+                            getOptionSelected={(option) =>
+                                filterByDesks.map(desk => desk.id)
+                                    .includes(option.id)}
                             renderInput={(params) =>
                                 <TextField
                                     {...params}

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -375,22 +375,6 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
 
     const { startWaiting, onCancel, onOk, snackbarOpen } = usePageRefresh(fetchTableData, TABLE_REFRESH_INTERVAL);
 
-    /*
-      return involvedContacts.reduce<GroupedInvolvedGroups>((previous, contact) => {
-            if (contact.involvementReason === InvolvementReason.FAMILY) {
-                return {
-                    familyMembers: [...previous.familyMembers, contact],
-                    educationMembers: previous.educationMembers
-                }
-            } else if (contact.involvementReason === InvolvementReason.EDUCATION) {
-                return {
-                    educationMembers: [...previous.educationMembers, contact],
-                    familyMembers: previous.familyMembers
-                }
-            }
-            return previous;
-        }, {familyMembers: [], educationMembers: []});
-     */
     const handleFilterChange = (filterBy: any) => {
         const nextFilterRules = Object.entries(filterBy).reduce((previousValue, [filterKey, filterValue]) => {
             if (filterValue) {
@@ -404,15 +388,6 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             return previousValue;
         }, {...filterRules});
 
-        // if (Object.values(filterBy)[0] !== null) {
-        //     nextFilterRules = {
-        //         ...nextFilterRules,
-        //         ...filterBy
-        //     }
-        // } else {
-        //     delete nextFilterRules[Object.keys(filterBy)[0]];
-        // }
-        console.log('filterRules', filterRules, 'nextFilterRules', nextFilterRules);
         setFilterRules(nextFilterRules);
     }
 

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -392,25 +392,17 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         }, {familyMembers: [], educationMembers: []});
      */
     const handleFilterChange = (filterBy: any) => {
-        console.log('handleFilterChange', filterBy);
-        // let nextFilterRules = { ...filterRules };
-        // Object.entries(filterBy).reduce((prevObject, [filterKey, filterValue]) => (Boolean(filterValue) ? prevObject : (prevObject[filterKey] = filterValue, prevObject)), {})
-
-        const nextFilterRules = Object.entries(filterBy).reduce((previousValue, [filterKey,filterValue ]) => {
-            // if(filterValue === null) {
-            //     return {
-            //         ...previousValue,
-            //         [filterKey]: []
-            //     }
-            // }
+        const nextFilterRules = Object.entries(filterBy).reduce((previousValue, [filterKey, filterValue]) => {
             if (filterValue) {
                 return {
                     ...previousValue,
-                   [filterKey]: filterValue
+                    [filterKey]: filterValue
                 }
             }
+
+            delete previousValue[filterKey as any];
             return previousValue;
-        }, filterRules);
+        }, {...filterRules});
 
         // if (Object.values(filterBy)[0] !== null) {
         //     nextFilterRules = {

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -375,16 +375,52 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
 
     const { startWaiting, onCancel, onOk, snackbarOpen } = usePageRefresh(fetchTableData, TABLE_REFRESH_INTERVAL);
 
-    const handleFilterChange = (filterBy: any) => {
-        let nextFilterRules = {...filterRules};
-        if (Boolean(Object.values(filterBy)[0])) {
-            nextFilterRules = {
-                ...nextFilterRules,
-                ...filterBy
+    /*
+      return involvedContacts.reduce<GroupedInvolvedGroups>((previous, contact) => {
+            if (contact.involvementReason === InvolvementReason.FAMILY) {
+                return {
+                    familyMembers: [...previous.familyMembers, contact],
+                    educationMembers: previous.educationMembers
+                }
+            } else if (contact.involvementReason === InvolvementReason.EDUCATION) {
+                return {
+                    educationMembers: [...previous.educationMembers, contact],
+                    familyMembers: previous.familyMembers
+                }
             }
-        } else {
-            delete nextFilterRules[Object.keys(filterBy)[0]];
-        }
+            return previous;
+        }, {familyMembers: [], educationMembers: []});
+     */
+    const handleFilterChange = (filterBy: any) => {
+        console.log('handleFilterChange', filterBy);
+        // let nextFilterRules = { ...filterRules };
+        // Object.entries(filterBy).reduce((prevObject, [filterKey, filterValue]) => (Boolean(filterValue) ? prevObject : (prevObject[filterKey] = filterValue, prevObject)), {})
+
+        const nextFilterRules = Object.entries(filterBy).reduce((previousValue, [filterKey,filterValue ]) => {
+            // if(filterValue === null) {
+            //     return {
+            //         ...previousValue,
+            //         [filterKey]: []
+            //     }
+            // }
+            if (filterValue) {
+                return {
+                    ...previousValue,
+                   [filterKey]: filterValue
+                }
+            }
+            return previousValue;
+        }, filterRules);
+
+        // if (Object.values(filterBy)[0] !== null) {
+        //     nextFilterRules = {
+        //         ...nextFilterRules,
+        //         ...filterBy
+        //     }
+        // } else {
+        //     delete nextFilterRules[Object.keys(filterBy)[0]];
+        // }
+        console.log('filterRules', filterRules, 'nextFilterRules', nextFilterRules);
         setFilterRules(nextFilterRules);
     }
 


### PR DESCRIPTION
- now pages refreshes and reroutes don't reset the filters applied to the investigation table
(new tabs **do** reset filters)