### PR TITLE
Fix/multiple axios calls

### DIFF
--- a/client/src/components/App/AppToolbar/AppToolbar.tsx
+++ b/client/src/components/App/AppToolbar/AppToolbar.tsx
@@ -8,6 +8,7 @@ import IsActiveToggle from 'commons/IsActiveToggle/IsActiveToggle';
 import { landingPageRoute, usersManagementRoute } from 'Utils/Routes/Routes';
 
 import useAppToolbar from './useAppToolbar';
+import useStyles, { AppToolbarClasses } from './AppToolbarStyles';
 
 const toggleMessage = 'מה הסטטוס שלך?';
 const navButtonsWhitelist = {
@@ -15,9 +16,12 @@ const navButtonsWhitelist = {
   allowedRoutes: [landingPageRoute, usersManagementRoute]
 };
 
-const StatePersistentNavLink = (props: NavLinkProps) => {
+interface StatePersistentNavLinkProps extends NavLinkProps {
+  classes: AppToolbarClasses;
+}
+
+const StatePersistentNavLink = (props: StatePersistentNavLinkProps) => {
   const history = useHistory();
-  const { classes } = useAppToolbar();
 
   const handleNavClick: NavLinkProps['onClick'] = (event) => {
     event.preventDefault(); // prevent state reset on reroute
@@ -27,14 +31,16 @@ const StatePersistentNavLink = (props: NavLinkProps) => {
   return (
       <NavLink {...props} location={history.location}
                onClick={handleNavClick}
-               activeClassName={classes.activeItem} className={classes.menuItem}>
+               activeClassName={props.classes.activeItem} className={props.classes.menuItem}>
         {props.children}
       </NavLink>
   )
 };
 
 const AppToolbar: React.FC = (): JSX.Element => {
-  const { user, isActive, logout, setUserActivityStatus, classes, countyDisplayName } = useAppToolbar();
+  const { user, isActive, logout, setUserActivityStatus, countyDisplayName } = useAppToolbar();
+  
+  const classes = useStyles();
   const location = useLocation();
 
   return (
@@ -47,11 +53,11 @@ const AppToolbar: React.FC = (): JSX.Element => {
             navButtonsWhitelist.allowedUserTypes.includes(user.userType) &&
             navButtonsWhitelist.allowedRoutes.includes(location.pathname) &&
             <div className={classes.navButtons}>
-              <StatePersistentNavLink exact to={landingPageRoute}>
+              <StatePersistentNavLink classes={classes} exact to={landingPageRoute}>
                 <Home className={classes.menuIcon} />
                 <Typography className={classes.menuTypo}> עמוד הבית</Typography>
               </StatePersistentNavLink>
-              <StatePersistentNavLink exact to={usersManagementRoute}>
+              <StatePersistentNavLink classes={classes} exact to={usersManagementRoute}>
                 <SupervisorAccount className={classes.menuIcon} />
                 <Typography className={classes.menuTypo}> ניהול משתמשים</Typography>
               </StatePersistentNavLink>

--- a/client/src/components/App/AppToolbar/AppToolbar.tsx
+++ b/client/src/components/App/AppToolbar/AppToolbar.tsx
@@ -50,7 +50,7 @@ const AppToolbar: React.FC = (): JSX.Element => {
             navButtonsWhitelist.allowedUserTypes.includes(user.userType) &&
             navButtonsWhitelist.allowedRoutes.includes(location.pathname) &&
             <div className={classes.navButtons}>
-              <StatePersistentNavLink classes={classes} exact to={landingPageRoute}>
+              <StatePersistentNavLink exact to={landingPageRoute}>
                 <Home className={classes.menuIcon} />
                 <Typography className={classes.menuTypo}> עמוד הבית</Typography>
               </StatePersistentNavLink>

--- a/client/src/components/App/AppToolbar/AppToolbar.tsx
+++ b/client/src/components/App/AppToolbar/AppToolbar.tsx
@@ -8,7 +8,7 @@ import IsActiveToggle from 'commons/IsActiveToggle/IsActiveToggle';
 import { landingPageRoute, usersManagementRoute } from 'Utils/Routes/Routes';
 
 import useAppToolbar from './useAppToolbar';
-import useStyles, { AppToolbarClasses } from './AppToolbarStyles';
+import useStyles from './AppToolbarStyles';
 
 const toggleMessage = 'מה הסטטוס שלך?';
 const navButtonsWhitelist = {
@@ -16,11 +16,8 @@ const navButtonsWhitelist = {
   allowedRoutes: [landingPageRoute, usersManagementRoute]
 };
 
-interface StatePersistentNavLinkProps extends NavLinkProps {
-  classes: AppToolbarClasses;
-}
-
-const StatePersistentNavLink = (props: StatePersistentNavLinkProps) => {
+const StatePersistentNavLink = (props: NavLinkProps) => {
+  const classes = useStyles();
   const history = useHistory();
 
   const handleNavClick: NavLinkProps['onClick'] = (event) => {
@@ -31,7 +28,7 @@ const StatePersistentNavLink = (props: StatePersistentNavLinkProps) => {
   return (
       <NavLink {...props} location={history.location}
                onClick={handleNavClick}
-               activeClassName={props.classes.activeItem} className={props.classes.menuItem}>
+               activeClassName={classes.activeItem} className={classes.menuItem}>
         {props.children}
       </NavLink>
   )

--- a/client/src/components/App/AppToolbar/AppToolbar.tsx
+++ b/client/src/components/App/AppToolbar/AppToolbar.tsx
@@ -54,7 +54,7 @@ const AppToolbar: React.FC = (): JSX.Element => {
                 <Home className={classes.menuIcon} />
                 <Typography className={classes.menuTypo}> עמוד הבית</Typography>
               </StatePersistentNavLink>
-              <StatePersistentNavLink classes={classes} exact to={usersManagementRoute}>
+              <StatePersistentNavLink exact to={usersManagementRoute}>
                 <SupervisorAccount className={classes.menuIcon} />
                 <Typography className={classes.menuTypo}> ניהול משתמשים</Typography>
               </StatePersistentNavLink>

--- a/client/src/components/App/AppToolbar/useAppToolbar.tsx
+++ b/client/src/components/App/AppToolbar/useAppToolbar.tsx
@@ -11,23 +11,21 @@ import { indexRoute } from 'Utils/Routes/Routes';
 import StoreStateType from 'redux/storeStateType';
 import { setIsActive } from 'redux/User/userActionCreators';
 import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
+import { UserState } from 'redux/User/userReducer';
 
-import useStyles, { AppToolbarClasses } from './AppToolbarStyles';
 
 export interface useTopToolbarOutcome  {
     logout: () => void;
     setUserActivityStatus: (isActive: boolean) => Promise<any>;
     getCountyByUser: () => void;
-    classes: AppToolbarClasses;
     user: User;
     isActive: boolean | null;
     countyDisplayName: string;
 }
 
 const useAppToolbar = () :  useTopToolbarOutcome => {
-    const user = useSelector<StoreStateType, User>(state => state.user.data);
+    const user = useSelector<StoreStateType, UserState>(state => state.user);
     const history = useHistory();
-    const classes = useStyles();
     const { alertError } = useCustomSwal();
     
     const [countyDisplayName, setCountyDisplayName] = React.useState<string>('');
@@ -37,11 +35,11 @@ const useAppToolbar = () :  useTopToolbarOutcome => {
     });
 
     React.useEffect(() => {
-        if (user.investigationGroup !== -1) {
+        if (user.isLoggedIn) {
             getCountyByUser();
             getUserActivityStatus();
         }
-    }, [user.investigationGroup]);
+    }, [user.isLoggedIn]);
 
     const getUserActivityStatus = () => {
         getUserActivityStatusLogger.info('started user activity status fetching', Severity.LOW);
@@ -97,11 +95,10 @@ const useAppToolbar = () :  useTopToolbarOutcome => {
     }
 
     return {
-        user,
-        isActive: user.isActive,
+        user: user.data,
+        isActive: user.data.isActive,
         logout,
         setUserActivityStatus,
-        classes,
         getCountyByUser,
         countyDisplayName
     }

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -23,7 +23,6 @@ import InvestigationMainStatus from 'models/InvestigationMainStatus';
 import { setIsLoading } from 'redux/IsLoading/isLoadingActionCreators';
 import InvestigationMainStatusCodes from 'models/enums/InvestigationMainStatusCodes';
 import { setLastOpenedEpidemiologyNum } from 'redux/Investigation/investigationActionCreators';
-import { setIsInInvestigation } from 'redux/IsInInvestigations/isInInvestigationActionCreators';
 import { setInvestigationStatus, setCreator } from 'redux/Investigation/investigationActionCreators';
 import { setAxiosInterceptorId } from 'redux/Investigation/investigationActionCreators';
 import InvestigatorOption from 'models/InvestigatorOption';
@@ -38,8 +37,6 @@ import {
     investigatorIdPropertyName
 } from './InvestigationTablesHeaders';
 import { useInvestigationTableOutcome, useInvestigationTableParameters } from './InvestigationTableInterfaces';
-import useInvestigatedPersonInfo
-    from '../../InvestigationForm/InvestigationInfo/InvestigatedPersonInfo/useInvestigatedPersonInfo';
 
 const investigationURL = '/investigation';
 const getFlooredRandomNumber = (min: number, max: number): number => (
@@ -123,7 +120,6 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
     const isLoading = useSelector<StoreStateType, boolean>(state => state.isLoading);
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
     const axiosInterceptorId = useSelector<StoreStateType, number>(state => state.investigation.axiosInterceptorId);
-    const isInInvestigations = useSelector<StoreStateType, boolean>(state => state.isInInvestigation);
     const windowTabsBroadcatChannel = useRef(new BroadcastChannel(BC_TABS_NAME));
 
     const fetchAllDesksByCountyId = () => {
@@ -175,8 +171,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         fetchAllInvestigationStatuses();
         fetchAllDesksByCountyId();
         startWaiting();
-        windowTabsBroadcatChannel.current.onmessage = (broadcastEvent: MessageEvent) =>
-            setIsInInvestigation(broadcastEvent.data.isInInvestigation);
+        windowTabsBroadcatChannel.current.onmessage = () => fetchTableData();
     }, [])
 
     const moveToTheInvestigationForm = async (epidemiologyNumberVal: number) => {
@@ -186,9 +181,9 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         });
         setLastOpenedEpidemiologyNum(epidemiologyNumberVal);
         investigationClickLogger.info(`Entered investigation: ${epidemiologyNumberVal}`, Severity.LOW);
-        setIsInInvestigation(true);
         await persistor.flush();
         window.open(investigationURL);
+        fetchTableData();
     }
 
     const getInvestigationsAxiosRequest = (orderBy: string): any => {
@@ -396,7 +391,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         if (isLoggedIn) {
             fetchTableData();
         }
-    }, [isLoggedIn, isInInvestigations, currentPage, orderBy, filterRules]);
+    }, [isLoggedIn, currentPage, orderBy, filterRules]);
 
     const onInvestigationRowClick = (investigationRow: { [T in keyof IndexedInvestigationData]: any }) => {
         const investigationClickLogger = logger.setup({

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -10,9 +10,8 @@ import County from 'models/County';
 import logger from 'logger/logger';
 import { Severity } from 'models/Logger';
 import userType from 'models/enums/UserType';
-import { persistor, store } from 'redux/store';
+import { persistor } from 'redux/store';
 import Investigator from 'models/Investigator';
-import { timeout } from 'Utils/Timeout/Timeout';
 import { activateIsLoading } from 'Utils/axios';
 import StoreStateType from 'redux/storeStateType';
 import { BC_TABS_NAME } from 'models/BroadcastMessage';
@@ -26,7 +25,7 @@ import InvestigationMainStatusCodes from 'models/enums/InvestigationMainStatusCo
 import { setLastOpenedEpidemiologyNum } from 'redux/Investigation/investigationActionCreators';
 import { setIsInInvestigation } from 'redux/IsInInvestigations/isInInvestigationActionCreators';
 import { setInvestigationStatus, setCreator } from 'redux/Investigation/investigationActionCreators';
-import { setAxiosInterceptorId, setIsCurrentlyLoading } from 'redux/Investigation/investigationActionCreators';
+import { setAxiosInterceptorId } from 'redux/Investigation/investigationActionCreators';
 import InvestigatorOption from 'models/InvestigatorOption';
 import Desk from 'models/Desk';
 
@@ -121,7 +120,6 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
 
     const user = useSelector<StoreStateType, User>(state => state.user.data);
     const isLoggedIn = useSelector<StoreStateType, boolean>(state => state.user.isLoggedIn);
-    const isCurrentlyLoadingInvestigation = useSelector<StoreStateType, boolean>(state => state.investigation.isCurrentlyLoading);
     const isLoading = useSelector<StoreStateType, boolean>(state => state.isLoading);
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
     const axiosInterceptorId = useSelector<StoreStateType, number>(state => state.investigation.axiosInterceptorId);
@@ -174,10 +172,6 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
     }
 
     useEffect(() => {
-        setIsLoading(isCurrentlyLoadingInvestigation);
-    }, [isCurrentlyLoadingInvestigation])
-
-    useEffect(() => {
         fetchAllInvestigationStatuses();
         fetchAllDesksByCountyId();
         startWaiting();
@@ -193,12 +187,8 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         setLastOpenedEpidemiologyNum(epidemiologyNumberVal);
         investigationClickLogger.info(`Entered investigation: ${epidemiologyNumberVal}`, Severity.LOW);
         setIsInInvestigation(true);
-        setIsCurrentlyLoading(true);
         await persistor.flush();
         window.open(investigationURL);
-        timeout(15000).then(() => {
-            store.getState().investigation.isCurrentlyLoading && setIsCurrentlyLoading(false);
-        });
     }
 
     const getInvestigationsAxiosRequest = (orderBy: string): any => {
@@ -399,11 +389,8 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         }, { ...filterRules });
 
         setFilterRules(nextFilterRules);
-    }
-
-    useEffect(() => {
         setCurrentPage(defaultPage);
-    }, [filterRules, orderBy]);
+    }
 
     useEffect(() => {
         if (isLoggedIn) {
@@ -677,6 +664,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
     const sortInvestigationTable = (orderByValue: string) => {
         setIsDefaultOrder(orderByValue === defaultOrderBy);
         setOrderBy(orderByValue);
+        setCurrentPage(defaultPage);
     }
 
     const fetchInvestigationsByGroupId = async (groupId: string) => {

--- a/client/src/redux/store.ts
+++ b/client/src/redux/store.ts
@@ -15,7 +15,7 @@ const persistConfig: PersistConfig<StoreStateType> = {
 };
 
 const persistedReducer = persistReducer(persistConfig, reducers)
-const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({trace: true}) || compose;
+const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 export const store = createStore(persistedReducer, composeEnhancers(applyMiddleware(thunk)));
 export const persistor = persistStore(store);

--- a/client/src/redux/store.ts
+++ b/client/src/redux/store.ts
@@ -15,7 +15,7 @@ const persistConfig: PersistConfig<StoreStateType> = {
 };
 
 const persistedReducer = persistReducer(persistConfig, reducers)
-const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({trace: true}) || compose;
 
 export const store = createStore(persistedReducer, composeEnhancers(applyMiddleware(thunk)));
 export const persistor = persistStore(store);


### PR DESCRIPTION
This PR prevents the [multiple axios calls problem](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1139/).

## Changes
* Remove double usage of usAppToolbar which caused getCountyByUser and getUserActivityStatus to be called twice.
* Change the table filters saved in history to be assigned as default value instead of after first render to prevent the table to fetch the data twice.
* Change some instances in the table hook where it is possible to call the fetchTableData directly instead of through the useEffect.