### PR TITLE
fix condition for not overriding existing group colors

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -361,7 +361,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
                             });
                         setRows(investigationRows);
                         investigationRows
-                            .filter((row) => row.groupId !== null || !investigationColor.current.has(row.groupId))
+                            .filter((row) => row.groupId !== null && !investigationColor.current.has(row.groupId))
                             .forEach((row) => {
                                 // We have this color range so the group colors aren't too dark nor bright
                                 const minColorValue = 50;


### PR DESCRIPTION
This PR fixes the condition for not creating a new color for a group that was already assigned one.