### PR TITLE
fix(): fix error comment indication and remove spinner in case of investigation fetch error

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigatedPersonInfo/InvestigationMenu/CommentDialog/CommentInput.tsx
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigatedPersonInfo/InvestigationMenu/CommentDialog/CommentInput.tsx
@@ -15,7 +15,7 @@ const MAX_CHARS_ALLOWED = 500;
 const stringAlphabet = yup
     .string()
     .matches(/^[a-zA-Z\u0590-\u05fe\s0-9-+*!?'"():_,.\/\\]*$/, errorMessage)
-    .max(500, maxLengthErrorMessage);
+    .max(MAX_CHARS_ALLOWED, maxLengthErrorMessage);
 
 const commentFieldName = 'comment';
 const commentSchema = yup.object().shape({ [commentFieldName]: yup.string() });
@@ -33,7 +33,6 @@ const CommentInput = ({ commentInput, handleInput }: Props) => {
                 name={commentFieldName}
                 multiline fullWidth
                 validationSchema={stringAlphabet}
-                inputProps={{ maxLength: MAX_CHARS_ALLOWED }}
                 placeholder={COMMENT_PLACEHOLDER}
                 value={commentInput} onChange={handleInput}
             />

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableStyles.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableStyles.ts
@@ -1,6 +1,8 @@
 import { Theme } from '@material-ui/core';
 import { makeStyles } from '@material-ui/styles';
 
+const tableWidth = '96vw';
+
 const useStyles = (isWide: boolean) => makeStyles((theme: Theme) => ({
     content: {
         height: '80vh',
@@ -23,10 +25,10 @@ const useStyles = (isWide: boolean) => makeStyles((theme: Theme) => ({
     title: {
         margin: 'auto',
         height: '14vh',
-        width: '90vw',
+        width: tableWidth,
     },
     tableContainer: {
-        width: '90vw',
+        width: tableWidth,
         height: isWide ? '67vh' : '61vh',
         marginBottom: '2vh'
     },
@@ -64,7 +66,7 @@ const useStyles = (isWide: boolean) => makeStyles((theme: Theme) => ({
         fontSize: '1.2vw',
     },
     tableHeaderRow: {
-        width: '90vw',
+        width: tableWidth,
         alignItems: 'center',
         flexDirection: 'row',
         justifyContent: 'space-between',
@@ -86,7 +88,7 @@ const useStyles = (isWide: boolean) => makeStyles((theme: Theme) => ({
         height: '8vh',
     },
     filterTableRow: {
-        width: '90vw',
+        width: tableWidth,
         alignItems: 'center',
         justifyContent: 'flex-end',
         display: 'flex'

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -363,7 +363,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
                     alertError('אופס... לא הצלחנו לשלוף');
                     setIsLoading(false);
                     fetchInvestigationsLogger.error(err, Severity.HIGH);
-                })
+                });
         }
     };
 

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -354,14 +354,14 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
                                 const blue = getFlooredRandomNumber(minColorValue, maxColorValue);
                                 investigationColor.current.set(row.groupId, `rgb(${red}, ${green}, ${blue})`);
                             });
-                            setIsLoading(false);
+                        setIsLoading(false);
                     } else {
                         fetchInvestigationsLogger.warn('user investigation group is invalid', Severity.MEDIUM);
                     }
                 })
                 .catch((err: any) => {
                     alertError('אופס... לא הצלחנו לשלוף');
-                    setIsLoading(false)
+                    setIsLoading(false);
                     fetchInvestigationsLogger.error(err, Severity.HIGH);
                 })
         }

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -354,15 +354,16 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
                                 const blue = getFlooredRandomNumber(minColorValue, maxColorValue);
                                 investigationColor.current.set(row.groupId, `rgb(${red}, ${green}, ${blue})`);
                             });
-                        setIsLoading(false);
+                            setIsLoading(false);
                     } else {
                         fetchInvestigationsLogger.warn('user investigation group is invalid', Severity.MEDIUM);
                     }
                 })
                 .catch((err: any) => {
                     alertError('אופס... לא הצלחנו לשלוף');
+                    setIsLoading(false)
                     fetchInvestigationsLogger.error(err, Severity.HIGH);
-                });
+                })
         }
     };
 


### PR DESCRIPTION
# What this MR does you ask?
* Make the investigation comment input border go red in case that the user enters more than the 500 characters in the comment
* hide the loading spinner in case that the fetching investigation process has been failed due to some reason


PS: hid the loading spinner not in finally block because it has been hidden before the investigations have been displayed