### PR TITLE
Fix/grouped rows borders

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -644,10 +644,8 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                         {checkGroupedInvestigationOpen.includes(indexedRow.epidemiologyNumber) &&
                                             allGroupedInvestigations.get(indexedRow.groupId)?.filter((row: InvestigationTableRow) => row.epidemiologyNumber !== indexedRow.epidemiologyNumber).map((row: InvestigationTableRow, index: number) => {
                                                 const currentGroupedInvestigationsLength = allGroupedInvestigations.get(indexedRow.groupId)?.filter((row: InvestigationTableRow) => row.epidemiologyNumber !== indexedRow.epidemiologyNumber).length!;
-                                                console.log(index === currentGroupedInvestigationsLength - 1);
                                                 const indexedGroupedInvestigationRow = convertToIndexedRow(row);
                                                 const isGroupedRowClickable = isInvestigationRowClickable(row.mainStatus);
-                                                console.log(indexedGroupedInvestigationRow.epidemiologyNumber);
                                                 return (
                                                     <TableRow selected={isRowSelected(indexedGroupedInvestigationRow.epidemiologyNumber)}
                                                         key={indexedGroupedInvestigationRow.epidemiologyNumber} classes={{ selected: classes.checkedRow }}

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -115,7 +115,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
 
     const {
         onCancel, onOk, snackbarOpen, tableRows, onInvestigationRowClick, convertToIndexedRow,
-        sortInvestigationTable, getUserMapKeyByValue, changeGroupsDesk, changeInvestigationsDesk, getTableCellStyles,
+        sortInvestigationTable, getUserMapKeyByValue, changeGroupsDesk, changeInvestigationsDesk, getNestedCellStyle, getRegularCellStyle,
         moveToTheInvestigationForm, totalCount, unassignedInvestigationsCount,
         fetchInvestigationsByGroupId, fetchTableData, changeGroupsInvestigator, changeInvestigationsInvestigator,
         statusFilter, changeStatusFilter, deskFilter, changeDeskFilter, searchQuery, changeSearchQuery, isSearchQueryValid,
@@ -631,7 +631,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                                     <TableCell
                                                         classes={{ root: classes.tableCellRoot }}
                                                         padding='none'
-                                                        className={getTableCellStyles(index, key , undefined , isGroupShown).join(' ')}
+                                                        className={getRegularCellStyle(index, key , isGroupShown).join(' ')}
                                                         onClick={(event: any) => handleCellClick(event, key, indexedRow.epidemiologyNumber)}
                                                     >
                                                         {
@@ -643,7 +643,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                         </TableRow>
                                         {checkGroupedInvestigationOpen.includes(indexedRow.epidemiologyNumber) &&
                                             allGroupedInvestigations.get(indexedRow.groupId)?.filter((row: InvestigationTableRow) => row.epidemiologyNumber !== indexedRow.epidemiologyNumber).map((row: InvestigationTableRow, index: number) => {
-                                                const currentGroupedInvestigationsLength = allGroupedInvestigations.get(indexedRow.groupId)?.length! - 2;
+                                                const currentGroupedInvestigationsLength = allGroupedInvestigations.get(indexedRow.groupId)?.length! - 1; // not including row head
                                                 const indexedGroupedInvestigationRow = convertToIndexedRow(row);
                                                 const isGroupedRowClickable = isInvestigationRowClickable(row.mainStatus);
                                                 return (
@@ -656,7 +656,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                                             Object.values((user.userType === userType.ADMIN || user.userType === userType.SUPER_ADMIN) ? adminCols : userCols).map((key: string) => (
                                                                 <TableCell
                                                                     classes={{ root: classes.tableCellRoot }}
-                                                                    className={getTableCellStyles(index, key , index === currentGroupedInvestigationsLength).join(' ')}
+                                                                    className={getNestedCellStyle(key , index + 1 === currentGroupedInvestigationsLength).join(' ')}
                                                                     onClick={(event: any) => handleCellClick(event, key, indexedGroupedInvestigationRow.epidemiologyNumber)}
                                                                 >
                                                                     {

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -613,11 +613,12 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                 }
                             </TableRow>
                         </TableHead>
-                        {console.log(`--------`)}
                         <TableBody>
                             {tableRows.map((row: InvestigationTableRow, index: number) => {
                                 const indexedRow = convertToIndexedRow(row);
                                 const isRowClickable = isInvestigationRowClickable(row.mainStatus);
+                                const isGroupShown = checkGroupedInvestigationOpen.includes(indexedRow.epidemiologyNumber);
+
                                 return (
                                     <>
                                         <TableRow selected={isRowSelected(indexedRow.epidemiologyNumber)}
@@ -630,7 +631,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                                     <TableCell
                                                         classes={{ root: classes.tableCellRoot }}
                                                         padding='none'
-                                                        className={getTableCellStyles(index, key , false).join(' ')}
+                                                        className={getTableCellStyles(index, key , undefined , isGroupShown).join(' ')}
                                                         onClick={(event: any) => handleCellClick(event, key, indexedRow.epidemiologyNumber)}
                                                     >
                                                         {
@@ -643,7 +644,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                         {checkGroupedInvestigationOpen.includes(indexedRow.epidemiologyNumber) &&
                                             allGroupedInvestigations.get(indexedRow.groupId)?.filter((row: InvestigationTableRow) => row.epidemiologyNumber !== indexedRow.epidemiologyNumber).map((row: InvestigationTableRow, index: number) => {
                                                 const currentGroupedInvestigationsLength = allGroupedInvestigations.get(indexedRow.groupId)?.filter((row: InvestigationTableRow) => row.epidemiologyNumber !== indexedRow.epidemiologyNumber).length!;
-                                                
+                                                console.log(index === currentGroupedInvestigationsLength - 1);
                                                 const indexedGroupedInvestigationRow = convertToIndexedRow(row);
                                                 const isGroupedRowClickable = isInvestigationRowClickable(row.mainStatus);
                                                 console.log(indexedGroupedInvestigationRow.epidemiologyNumber);

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -643,7 +643,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                         </TableRow>
                                         {checkGroupedInvestigationOpen.includes(indexedRow.epidemiologyNumber) &&
                                             allGroupedInvestigations.get(indexedRow.groupId)?.filter((row: InvestigationTableRow) => row.epidemiologyNumber !== indexedRow.epidemiologyNumber).map((row: InvestigationTableRow, index: number) => {
-                                                const currentGroupedInvestigationsLength = allGroupedInvestigations.get(indexedRow.groupId)?.filter((row: InvestigationTableRow) => row.epidemiologyNumber !== indexedRow.epidemiologyNumber).length! - 1;
+                                                const currentGroupedInvestigationsLength = allGroupedInvestigations.get(indexedRow.groupId)?.length! - 2;
                                                 const indexedGroupedInvestigationRow = convertToIndexedRow(row);
                                                 const isGroupedRowClickable = isInvestigationRowClickable(row.mainStatus);
                                                 return (

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -175,7 +175,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
     }
 
     const getTableCell = (cellName: string, indexedRow: { [T in keyof typeof TableHeadersNames]: any }, index:number) => {
-        const wasInvestigationFetchedByGroup = indexedRow.groupId && !indexedRow.canFetchGroup;
+        const wasInvestigationFetchedByGroup = Boolean(indexedRow.groupId) && !indexedRow.canFetchGroup;
         switch (cellName) {
             case TableHeadersNames.color:
                 return (
@@ -613,6 +613,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                 }
                             </TableRow>
                         </TableHead>
+                        {console.log(`--------`)}
                         <TableBody>
                             {tableRows.map((row: InvestigationTableRow, index: number) => {
                                 const indexedRow = convertToIndexedRow(row);
@@ -629,7 +630,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                                     <TableCell
                                                         classes={{ root: classes.tableCellRoot }}
                                                         padding='none'
-                                                        className={getTableCellStyles(index, key).join(' ')}
+                                                        className={getTableCellStyles(index, key , false).join(' ')}
                                                         onClick={(event: any) => handleCellClick(event, key, indexedRow.epidemiologyNumber)}
                                                     >
                                                         {
@@ -641,8 +642,11 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                         </TableRow>
                                         {checkGroupedInvestigationOpen.includes(indexedRow.epidemiologyNumber) &&
                                             allGroupedInvestigations.get(indexedRow.groupId)?.filter((row: InvestigationTableRow) => row.epidemiologyNumber !== indexedRow.epidemiologyNumber).map((row: InvestigationTableRow, index: number) => {
+                                                const currentGroupedInvestigationsLength = allGroupedInvestigations.get(indexedRow.groupId)?.filter((row: InvestigationTableRow) => row.epidemiologyNumber !== indexedRow.epidemiologyNumber).length!;
+                                                
                                                 const indexedGroupedInvestigationRow = convertToIndexedRow(row);
                                                 const isGroupedRowClickable = isInvestigationRowClickable(row.mainStatus);
+                                                console.log(indexedGroupedInvestigationRow.epidemiologyNumber);
                                                 return (
                                                     <TableRow selected={isRowSelected(indexedGroupedInvestigationRow.epidemiologyNumber)}
                                                         key={indexedGroupedInvestigationRow.epidemiologyNumber} classes={{ selected: classes.checkedRow }}
@@ -653,7 +657,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                                             Object.values((user.userType === userType.ADMIN || user.userType === userType.SUPER_ADMIN) ? adminCols : userCols).map((key: string) => (
                                                                 <TableCell
                                                                     classes={{ root: classes.tableCellRoot }}
-                                                                    className={getTableCellStyles(index, key).join(' ')}
+                                                                    className={getTableCellStyles(index, key , index === currentGroupedInvestigationsLength - 1).join(' ')}
                                                                     onClick={(event: any) => handleCellClick(event, key, indexedGroupedInvestigationRow.epidemiologyNumber)}
                                                                 >
                                                                     {

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -643,7 +643,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                         </TableRow>
                                         {checkGroupedInvestigationOpen.includes(indexedRow.epidemiologyNumber) &&
                                             allGroupedInvestigations.get(indexedRow.groupId)?.filter((row: InvestigationTableRow) => row.epidemiologyNumber !== indexedRow.epidemiologyNumber).map((row: InvestigationTableRow, index: number) => {
-                                                const currentGroupedInvestigationsLength = allGroupedInvestigations.get(indexedRow.groupId)?.filter((row: InvestigationTableRow) => row.epidemiologyNumber !== indexedRow.epidemiologyNumber).length!;
+                                                const currentGroupedInvestigationsLength = allGroupedInvestigations.get(indexedRow.groupId)?.filter((row: InvestigationTableRow) => row.epidemiologyNumber !== indexedRow.epidemiologyNumber).length! - 1;
                                                 const indexedGroupedInvestigationRow = convertToIndexedRow(row);
                                                 const isGroupedRowClickable = isInvestigationRowClickable(row.mainStatus);
                                                 return (
@@ -656,7 +656,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                                             Object.values((user.userType === userType.ADMIN || user.userType === userType.SUPER_ADMIN) ? adminCols : userCols).map((key: string) => (
                                                                 <TableCell
                                                                     classes={{ root: classes.tableCellRoot }}
-                                                                    className={getTableCellStyles(index, key , index === currentGroupedInvestigationsLength - 1).join(' ')}
+                                                                    className={getTableCellStyles(index, key , index === currentGroupedInvestigationsLength).join(' ')}
                                                                     onClick={(event: any) => handleCellClick(event, key, indexedGroupedInvestigationRow.epidemiologyNumber)}
                                                                 >
                                                                     {

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
@@ -39,7 +39,9 @@ export interface useInvestigationTableOutcome {
     onInvestigationRowClick: (investigationRow: { [T in keyof IndexedInvestigationData]: any }) => void;
     convertToIndexedRow: (row: InvestigationTableRow) => { [T in keyof IndexedInvestigationData]: any };
     getUserMapKeyByValue: (map: Map<string, User>, value: string) => string;
-    getTableCellStyles: (rowIndex: number, cellKey: string) => string[];
+    getCountyMapKeyByValue: (map: Map<number, County>, value: string) => number;
+    changeCounty: (indexedRow: IndexedInvestigation, newSelectedCountyId: { id: number, value: County } | null) => Promise<void>;
+    getTableCellStyles: (rowIndex: number, cellKey: string , nested : boolean) => string[];
     sortInvestigationTable: (orderByValue: string) => void;
     onOk: () => void;
     onCancel: () => void;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
@@ -41,7 +41,8 @@ export interface useInvestigationTableOutcome {
     getUserMapKeyByValue: (map: Map<string, User>, value: string) => string;
     getCountyMapKeyByValue: (map: Map<number, County>, value: string) => number;
     changeCounty: (indexedRow: IndexedInvestigation, newSelectedCountyId: { id: number, value: County } | null) => Promise<void>;
-    getTableCellStyles: (rowIndex: number, cellKey: string , lastNested? : boolean , isGroupShown? : boolean) => string[];
+    getNestedCellStyle: (cellKey: string , isLast : boolean) => string[];
+    getRegularCellStyle: (rowIndex: number, cellKey: string , isGroupShown : boolean) => string[];
     sortInvestigationTable: (orderByValue: string) => void;
     onOk: () => void;
     onCancel: () => void;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
@@ -41,7 +41,7 @@ export interface useInvestigationTableOutcome {
     getUserMapKeyByValue: (map: Map<string, User>, value: string) => string;
     getCountyMapKeyByValue: (map: Map<number, County>, value: string) => number;
     changeCounty: (indexedRow: IndexedInvestigation, newSelectedCountyId: { id: number, value: County } | null) => Promise<void>;
-    getTableCellStyles: (rowIndex: number, cellKey: string , nested : boolean) => string[];
+    getTableCellStyles: (rowIndex: number, cellKey: string , lastNested? : boolean , isGroupShown? : boolean) => string[];
     sortInvestigationTable: (orderByValue: string) => void;
     onOk: () => void;
     onCancel: () => void;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableStyles.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableStyles.ts
@@ -53,6 +53,12 @@ const useStyles = (isWide: boolean) => makeStyles((theme: Theme) => ({
     rowBorder: {
         borderBottom: '3px solid rgb(222, 218, 218)'
     },
+    openedTableCell: {
+        borderTop: '3px solid rgb(222, 218, 218)'
+    },
+    nestedTableCell: {
+        borderBottom: 'none'
+    },
     font: {
         color: '#424242',
         whiteSpace: 'nowrap',

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -610,10 +610,8 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         }
     }
 
-    const getTableCellStyles = (rowIndex: number, cellKey: string , isLastNestedCell? : boolean , isGroupShown? :boolean) => {
-        const isNestedCell = isLastNestedCell !== undefined;
-        let classNames = [];
-
+    const getDefaultCellStyles = (cellKey : string) => {
+        const classNames: string[] = [];
         classNames.push(classes.font);
         if (cellKey !== TableHeadersNames.color) {
             classNames.push(classes.tableCell);
@@ -626,22 +624,32 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             classNames.push(classes.priorityTableCell);
         }
 
-        if(!isNestedCell) {
-            if(cellNeedsABorder(rowIndex)) {
-                classNames.push(classes.rowBorder);
-            }
-            if(isGroupShown) {
-                classNames.push(classes.nestedTableCell);
-                if(rowIndex !== 0 && !cellNeedsABorder(rowIndex - 1)) {
-                    classNames.push(classes.openedTableCell);
-                }
-            }
-        } else if(isLastNestedCell) {
-            console.log(isLastNestedCell);
+        return classNames;
+    }
+
+    const getNestedCellStyle = (cellKey: string , isLast : boolean ) => {
+        let classNames = getDefaultCellStyles(cellKey);
+
+        if(isLast) {
             classNames.push(classes.rowBorder);
         } else {
-            console.log(isLastNestedCell);
             classNames.push(classes.nestedTableCell);
+        }
+
+        return classNames;
+    }
+
+    const getRegularCellStyle = (rowIndex: number, cellKey: string , isGroupShown :boolean) => {
+        let classNames = getDefaultCellStyles(cellKey);
+
+        if(cellNeedsABorder(rowIndex)) {
+            classNames.push(classes.rowBorder);
+        }
+        if(isGroupShown) {
+            classNames.push(classes.nestedTableCell);
+            if(rowIndex !== 0 && !cellNeedsABorder(rowIndex - 1)) {
+                classNames.push(classes.openedTableCell);
+            }
         }
 
         return classNames;
@@ -750,7 +758,8 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         fetchTableData,
         onInvestigationRowClick,
         convertToIndexedRow,
-        getTableCellStyles,
+        getNestedCellStyle,
+        getRegularCellStyle,
         sortInvestigationTable,
         getUserMapKeyByValue,
         onCancel,

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -610,7 +610,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         }
     }
 
-    const getTableCellStyles = (rowIndex: number, cellKey: string , isLastNested : boolean) => {
+    const getTableCellStyles = (rowIndex: number, cellKey: string , isLastNested? : boolean , isGroupShown? :boolean) => {
         let classNames = [];
 
         classNames.push(classes.font);
@@ -624,28 +624,31 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         if (cellKey === TableHeadersNames.priority) {
             classNames.push(classes.priorityTableCell);
         }
+        if (isGroupShown) {
+            classNames.push(classes.openedTableCell);
+            classNames.push(classes.nestedTableCell);
+        }
 
-        if(!isLastNested) {
+        if(isLastNested === undefined) {
             const currentRow = rows[rowIndex];
             const nextRow = rows[rowIndex + 1];
 
             const isNotLastRow = (rows.length - 1 !== rowIndex);
             const hasATestDate = Boolean(currentRow?.coronaTestDate);
-            const isLastOfDate = (getFormattedDate(currentRow?.coronaTestDate) !== getFormattedDate(Boolean(nextRow) ? nextRow.coronaTestDate : "9999/12/31" ));
-            const isLastOfGroup = Boolean(nextRow) && currentRow.groupId !== null ? 
-                                    currentRow?.groupId !== nextRow?.groupId :
-                                    false ;
-
-            console.log(currentRow.epidemiologyNumber , currentRow.groupId)
+            const isLastOfDate = (getFormattedDate(currentRow?.coronaTestDate) !== getFormattedDate(Boolean(nextRow) ?
+                                 nextRow.coronaTestDate :
+                                 "9999/12/31" ));
 
             if ((isDefaultOrder && !isLoading) &&
                 isNotLastRow &&
                 hasATestDate &&
-                (isLastOfGroup || isLastOfDate)) {
+                isLastOfDate && !isGroupShown) {
                 classNames.push(classes.rowBorder)
             }
-        } else {
+        } else if(isLastNested) {
             classNames.push(classes.rowBorder)
+        } else {
+            classNames.push(classes.nestedTableCell);
         }
 
         return classNames;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -610,7 +610,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         }
     }
 
-    const getTableCellStyles = (rowIndex: number, cellKey: string) => {
+    const getTableCellStyles = (rowIndex: number, cellKey: string , isLastNested : boolean) => {
         let classNames = [];
 
         classNames.push(classes.font);
@@ -625,22 +625,26 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             classNames.push(classes.priorityTableCell);
         }
 
-        const currentRow = rows[rowIndex];
-        const nextRow = rows[rowIndex + 1];
+        if(!isLastNested) {
+            const currentRow = rows[rowIndex];
+            const nextRow = rows[rowIndex + 1];
 
-        const isNotLastRow = (rows.length - 1 !== rowIndex);
-        const hasATestDate = Boolean(currentRow?.coronaTestDate);
-        const isLastOfDate = (getFormattedDate(currentRow?.coronaTestDate) !== getFormattedDate(Boolean(nextRow) ? nextRow.coronaTestDate : "9999/12/31" ));
-        const isLastOfGroup = Boolean(nextRow) ? 
-                                currentRow?.groupId !== nextRow?.groupId :
-                                false ;
+            const isNotLastRow = (rows.length - 1 !== rowIndex);
+            const hasATestDate = Boolean(currentRow?.coronaTestDate);
+            const isLastOfDate = (getFormattedDate(currentRow?.coronaTestDate) !== getFormattedDate(Boolean(nextRow) ? nextRow.coronaTestDate : "9999/12/31" ));
+            const isLastOfGroup = Boolean(nextRow) && currentRow.groupId !== null ? 
+                                    currentRow?.groupId !== nextRow?.groupId :
+                                    false ;
 
-        console.log(currentRow.epidemiologyNumber);
+            console.log(currentRow.epidemiologyNumber , currentRow.groupId)
 
-        if ((isDefaultOrder && !isLoading) &&
-            isNotLastRow &&
-            hasATestDate &&
-            isLastOfDate) {
+            if ((isDefaultOrder && !isLoading) &&
+                isNotLastRow &&
+                hasATestDate &&
+                (isLastOfGroup || isLastOfDate)) {
+                classNames.push(classes.rowBorder)
+            }
+        } else {
             classNames.push(classes.rowBorder)
         }
 

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -611,6 +611,8 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
     }
 
     const getTableCellStyles = (rowIndex: number, cellKey: string , isLastNestedCell? : boolean , isGroupShown? :boolean) => {
+        const isNestedCell = isLastNestedCell === undefined;
+
         let classNames = [];
 
         classNames.push(classes.font);
@@ -625,9 +627,9 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             classNames.push(classes.priorityTableCell);
         }
 
-        if(isLastNestedCell === undefined) {
+        if(!isNestedCell) {
             if(cellNeedsABorder(rowIndex)) {
-                classNames.push(classes.rowBorder)
+                classNames.push(classes.rowBorder);
             }
             if(isGroupShown){
                     classNames.push(classes.nestedTableCell);
@@ -636,7 +638,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
                     }
             }
         } else if(isLastNestedCell) {
-            classNames.push(classes.rowBorder)
+            classNames.push(classes.rowBorder);
         } else {
             classNames.push(classes.nestedTableCell);
         }

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -611,7 +611,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
     }
 
     const getDefaultCellStyles = (cellKey : string) => {
-        const classNames: string[] = [];
+        let classNames: string[] = [];
         classNames.push(classes.font);
         if (cellKey !== TableHeadersNames.color) {
             classNames.push(classes.tableCell);

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -611,8 +611,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
     }
 
     const getTableCellStyles = (rowIndex: number, cellKey: string , isLastNestedCell? : boolean , isGroupShown? :boolean) => {
-        const isNestedCell = isLastNestedCell === undefined;
-
+        const isNestedCell = isLastNestedCell !== undefined;
         let classNames = [];
 
         classNames.push(classes.font);
@@ -631,15 +630,17 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             if(cellNeedsABorder(rowIndex)) {
                 classNames.push(classes.rowBorder);
             }
-            if(isGroupShown){
-                    classNames.push(classes.nestedTableCell);
-                    if(rowIndex !== 0 && !cellNeedsABorder(rowIndex - 1)) {
-                        classNames.push(classes.openedTableCell);
-                    }
+            if(isGroupShown) {
+                classNames.push(classes.nestedTableCell);
+                if(rowIndex !== 0 && !cellNeedsABorder(rowIndex - 1)) {
+                    classNames.push(classes.openedTableCell);
+                }
             }
         } else if(isLastNestedCell) {
+            console.log(isLastNestedCell);
             classNames.push(classes.rowBorder);
         } else {
+            console.log(isLastNestedCell);
             classNames.push(classes.nestedTableCell);
         }
 

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -610,7 +610,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         }
     }
 
-    const getTableCellStyles = (rowIndex: number, cellKey: string , isLastNested? : boolean , isGroupShown? :boolean) => {
+    const getTableCellStyles = (rowIndex: number, cellKey: string , isLastNestedCell? : boolean , isGroupShown? :boolean) => {
         let classNames = [];
 
         classNames.push(classes.font);
@@ -624,12 +624,27 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         if (cellKey === TableHeadersNames.priority) {
             classNames.push(classes.priorityTableCell);
         }
-        if (isGroupShown) {
-            classNames.push(classes.openedTableCell);
+
+        if(isLastNestedCell === undefined) {
+            if(cellNeedsABorder(rowIndex)) {
+                classNames.push(classes.rowBorder)
+            }
+            if(isGroupShown){
+                    classNames.push(classes.nestedTableCell);
+                    if(rowIndex !== 0 && !cellNeedsABorder(rowIndex - 1)) {
+                        classNames.push(classes.openedTableCell);
+                    }
+            }
+        } else if(isLastNestedCell) {
+            classNames.push(classes.rowBorder)
+        } else {
             classNames.push(classes.nestedTableCell);
         }
 
-        if(isLastNested === undefined) {
+        return classNames;
+    }
+
+    const cellNeedsABorder = (rowIndex : number) => {
             const currentRow = rows[rowIndex];
             const nextRow = rows[rowIndex + 1];
 
@@ -639,19 +654,10 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
                                  nextRow.coronaTestDate :
                                  "9999/12/31" ));
 
-            if ((isDefaultOrder && !isLoading) &&
+            return ((isDefaultOrder && !isLoading) &&
                 isNotLastRow &&
                 hasATestDate &&
-                isLastOfDate && !isGroupShown) {
-                classNames.push(classes.rowBorder)
-            }
-        } else if(isLastNested) {
-            classNames.push(classes.rowBorder)
-        } else {
-            classNames.push(classes.nestedTableCell);
-        }
-
-        return classNames;
+                isLastOfDate)
     }
 
     const sortInvestigationTable = (orderByValue: string) => {

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -329,7 +329,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             fetchInvestigationsLogger.info(`launching the selected request to the DB ordering by ${orderBy}`, Severity.LOW);
             getInvestigationsAxiosRequest(orderBy)
                 .then((response: any) => {
-                    fetchInvestigationsLogger.info('got respond from the server', Severity.LOW);
+                    fetchInvestigationsLogger.info('got response from the server', Severity.LOW);
 
                     const { data } = response;
                     let allInvestigationsRawData: any = [];
@@ -624,10 +624,23 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         if (cellKey === TableHeadersNames.priority) {
             classNames.push(classes.priorityTableCell);
         }
+
+        const currentRow = rows[rowIndex];
+        const nextRow = rows[rowIndex + 1];
+
+        const isNotLastRow = (rows.length - 1 !== rowIndex);
+        const hasATestDate = Boolean(currentRow?.coronaTestDate);
+        const isLastOfDate = (getFormattedDate(currentRow?.coronaTestDate) !== getFormattedDate(Boolean(nextRow) ? nextRow.coronaTestDate : "9999/12/31" ));
+        const isLastOfGroup = Boolean(nextRow) ? 
+                                currentRow?.groupId !== nextRow?.groupId :
+                                false ;
+
+        console.log(currentRow.epidemiologyNumber);
+
         if ((isDefaultOrder && !isLoading) &&
-            (rows.length - 1 !== rowIndex) &&
-            rows[rowIndex]?.coronaTestDate &&
-            (getFormattedDate(rows[rowIndex]?.coronaTestDate) !== getFormattedDate(rows[rowIndex + 1]?.coronaTestDate))) {
+            isNotLastRow &&
+            hasATestDate &&
+            isLastOfDate) {
             classNames.push(classes.rowBorder)
         }
 


### PR DESCRIPTION
fixed the issue where grouped investigation's border were not properly blocked together

changed ```getTableCellStyles``` to address whether the cell is nested and whether It's the "head" of a group

