### PR TITLE
Feat/no desk filter

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/DeskFilter/DeskFilter.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/DeskFilter/DeskFilter.tsx
@@ -17,11 +17,12 @@ const DeskFilter = ({ desks, filteredDesks, onDeskChange }: Props) => {
 
     return (
         <Card className={classes.card}>
-            <Typography variant='h6'>הדסקים בהם הנך צופה כעת:</Typography>
+            <Typography variant='subtitle1'>הדסקים בהם הנך צופה כעת:</Typography>
             <Autocomplete
                 className={classes.autocomplete}
                 disableCloseOnSelect
                 multiple
+                size='small'
                 options={desks}
                 value={desks.filter(desk => filteredDesks.includes(desk.id))}
                 getOptionLabel={(option) => option.deskName}
@@ -31,11 +32,7 @@ const DeskFilter = ({ desks, filteredDesks, onDeskChange }: Props) => {
                         {...params}
                     />
                 }
-                renderTags={(tags: Desk[]) => {
-                    const additionalTagsAmount = tags.length - 1;
-                    const additionalDisplay = additionalTagsAmount > 0 ? ` (+${additionalTagsAmount})` : '';
-                    return tags[0].deskName + additionalDisplay;
-                }}
+                limitTags={2}
             />
         </Card>
     )

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/DeskFilter/DeskFilter.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/DeskFilter/DeskFilter.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { Card, TextField, Typography } from '@material-ui/core';
+import { Autocomplete } from '@material-ui/lab';
+
+import Desk from 'models/Desk';
+
+import useStyles from './DeskFilterStyles';
+
+interface Props {
+    desks: Desk[];
+    filteredDesks: number[];
+    onDeskChange: (event: React.ChangeEvent<{}>, selectedDesks: Desk[]) => void;
+}
+
+const DeskFilter = ({ desks, filteredDesks, onDeskChange }: Props) => {
+    const classes = useStyles();
+
+    return (
+        <Card className={classes.card}>
+            <Typography variant='h6'>הדסקים בהם הנך צופה כעת:</Typography>
+            <Autocomplete
+                className={classes.autocomplete}
+                disableCloseOnSelect
+                multiple
+                options={desks}
+                value={desks.filter(desk => filteredDesks.includes(desk.id))}
+                getOptionLabel={(option) => option.deskName}
+                onChange={onDeskChange}
+                renderInput={(params) =>
+                    <TextField
+                        {...params}
+                    />
+                }
+                renderTags={(tags: Desk[]) => {
+                    const additionalTagsAmount = tags.length - 1;
+                    const additionalDisplay = additionalTagsAmount > 0 ? ` (+${additionalTagsAmount})` : '';
+                    return tags[0].deskName + additionalDisplay;
+                }}
+            />
+        </Card>
+    )
+}
+
+export default DeskFilter

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/DeskFilter/DeskFilterStyles.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/DeskFilter/DeskFilterStyles.ts
@@ -10,7 +10,7 @@ const useStyles = makeStyles((theme: Theme) => ({
         alignItems: 'center'
     },
     autocomplete: {
-        width: '80%',
+        width: '100%',
     },
 }));
 

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/DeskFilter/DeskFilterStyles.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/DeskFilter/DeskFilterStyles.ts
@@ -1,0 +1,17 @@
+import { Theme } from '@material-ui/core';
+import { makeStyles } from '@material-ui/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+    card: {
+        padding: theme.spacing(1.5),
+        borderRadius: 16,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center'
+    },
+    autocomplete: {
+        width: '80%',
+    },
+}));
+
+export default useStyles;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/FilterCreators.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/FilterCreators.ts
@@ -5,43 +5,29 @@ const filterCreators: { [T in InvestigationsFilterByFields]: ((values: any) => E
         return values.length > 0 ?
             { investigationStatus: { in: values } }
             :
-            { investigationStatus: null };
+            {};
     },
     [InvestigationsFilterByFields.DESK_ID]: (values: number[]) => {
         return values.length > 0 ?
             { deskId: { in: values } }
             :
-            { deskId: null };
+            {};
     },
     [InvestigationsFilterByFields.FULL_NAME]: (values: string) => {
         return Boolean(values) ?
-            {
-                investigatedPatientByInvestigatedPatientId: { covidPatientByCovidPatient: { fullName: { includes: values } } },
-                or: [
-                    { investigatedPatientByInvestigatedPatientId: { covidPatientByCovidPatient: { primaryPhone: { includes: "" } } } },
-                    { investigatedPatientByInvestigatedPatientId: { covidPatientByCovidPatient: { identityNumber: { includes: "" } } } }]
-            } :
-            {
-                investigatedPatientByInvestigatedPatientId: { covidPatientByCovidPatient: { fullName: { includes: "" } } },
-                or: [
-                    { investigatedPatientByInvestigatedPatientId: { covidPatientByCovidPatient: { primaryPhone: { includes: "" } } } },
-                    { investigatedPatientByInvestigatedPatientId: { covidPatientByCovidPatient: { identityNumber: { includes: "" } } } }]
-            };
+            { investigatedPatientByInvestigatedPatientId: { covidPatientByCovidPatient: { fullName: { includes: values } } } } :
+            {};
     },
     [InvestigationsFilterByFields.NUMERIC_PROPERTIES]: (values: string) => {
         return Boolean(values) ?
             {
-                investigatedPatientByInvestigatedPatientId: { covidPatientByCovidPatient: { fullName: { includes: "" } } },
-                or: [{ epidemiologyNumber: { equalTo: Number(values) } },
-                { investigatedPatientByInvestigatedPatientId: { covidPatientByCovidPatient: { primaryPhone: { includes: values } } } },
-                { investigatedPatientByInvestigatedPatientId: { covidPatientByCovidPatient: { identityNumber: { includes: values } } } }]
-            } :
-            {
-                investigatedPatientByInvestigatedPatientId: { covidPatientByCovidPatient: { fullName: { includes: "" } } },
                 or: [
-                    { investigatedPatientByInvestigatedPatientId: { covidPatientByCovidPatient: { primaryPhone: { includes: "" } } } },
-                    { investigatedPatientByInvestigatedPatientId: { covidPatientByCovidPatient: { identityNumber: { includes: "" } } } }]
-            }
+                    { epidemiologyNumber: { equalTo: Number(values) } },
+                    { investigatedPatientByInvestigatedPatientId: { covidPatientByCovidPatient: { primaryPhone: { includes: values } } } },
+                    { investigatedPatientByInvestigatedPatientId: { covidPatientByCovidPatient: { identityNumber: { includes: values } } } }
+                ]
+            } :
+            {}
     }
 };
 

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/FilterCreators.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/FilterCreators.ts
@@ -7,9 +7,18 @@ const filterCreators: { [T in InvestigationsFilterByFields]: ((values: any) => E
             :
             {};
     },
-    [InvestigationsFilterByFields.DESK_ID]: (values: number[]) => {
-        return values.length > 0 ?
-            { deskId: { in: values } }
+    [InvestigationsFilterByFields.DESK_ID]: (deskIds: number[]) => {
+        if (deskIds.includes(-1)) {
+            return {
+                or: [
+                    { deskId: { in: deskIds.filter(deskId => deskId !== -1) } },
+                    { deskId: { isNull: true } }
+                ]
+            }
+        }
+
+        return deskIds.length > 0 ?
+            { deskId: { in: deskIds } }
             :
             {};
     },

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -1,6 +1,5 @@
 import { useSelector } from 'react-redux';
 import React, { useMemo, useState, useRef } from 'react';
-import { useHistory } from 'react-router-dom';
 import { Autocomplete, Pagination } from '@material-ui/lab';
 import {
     Paper, Table, TableRow, TableBody, TableCell, Typography,
@@ -24,21 +23,17 @@ import InvestigationTableRow from 'models/InvestigationTableRow';
 import InvestigationMainStatus from 'models/InvestigationMainStatus';
 import RefreshSnackbar from 'commons/RefreshSnackbar/RefreshSnackbar';
 import InvestigationMainStatusCodes from 'models/enums/InvestigationMainStatusCodes';
-import InvestigationsFilterByFields from 'models/enums/InvestigationsFilterByFields';
-import { stringAlphanum } from 'commons/AlphanumericTextField/AlphanumericTextField';
 import ComplexityIcon from 'commons/InvestigationComplexity/ComplexityIcon/ComplexityIcon';
 import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
 
-import filterCreators from './FilterCreators';
 import useStyles from './InvestigationTableStyles';
 import CommentDisplay from './commentDisplay/commentDisplay';
 import SettingsActions from './SettingsActions/SettingsActions';
 import InvestigationTableFooter from './InvestigationTableFooter/InvestigationTableFooter';
 import InvestigationStatusColumn from './InvestigationStatusColumn/InvestigationStatusColumn';
 import InvestigationNumberColumn from './InvestigationNumberColumn/InvestigationNumberColumn';
-import useInvestigationTable, { UNDEFINED_ROW, allStatusesOption } from './useInvestigationTable';
+import useInvestigationTable, { UNDEFINED_ROW } from './useInvestigationTable';
 import { TableHeadersNames, TableHeaders, adminCols, userCols, Order, sortableCols, IndexedInvestigation } from './InvestigationTablesHeaders';
-import { phoneAndIdentityNumberRegex } from '../../InvestigationForm/TabManagement/ExposuresAndFlights/ExposureForm/ExposureForm'
 import DeskFilter from './DeskFilter/DeskFilter';
 
 export const defaultOrderBy = 'defaultOrder';
@@ -75,25 +70,11 @@ const showInvestigationGroupText = 'הצג חקירות קשורות';
 const hideInvestigationGroupText = 'הסתר חקירות קשורות';
 const emptyGroupText = 'שים לב, בסבירות גבוהה לחקירה זו קובצו חקירות ישנות שכבר לא קיימות במערכת'
 
-type StatusFilter = number[];
-type DeskFilter = number[];
-
-export interface HistoryState {
-    filterRules?: any;
-    statusFilter?: StatusFilter;
-    deskFilter?: DeskFilter;
-}
-
 const InvestigationTable: React.FC = (): JSX.Element => {
     const isScreenWide = useMediaQuery('(min-width: 1680px)');
     const classes = useStyles(isScreenWide);
     const { alertWarning } = useCustomSwal();
     const theme = useTheme();
-    const history = useHistory<HistoryState>();
-    const { statusFilter: historyStatusFilter = [], deskFilter: historyDeskFilter = [] } = useMemo(() => {
-        const { location: { state } } = history;
-        return state || {};
-    }, []);
 
     const [checkedIndexedRows, setCheckedIndexedRows] = useState<IndexedInvestigation[]>([]);
     const [selectedRow, setSelectedRow] = useState<number>(UNDEFINED_ROW);
@@ -110,10 +91,6 @@ const InvestigationTable: React.FC = (): JSX.Element => {
     const [showFilterRow, setShowFilterRow] = useState<boolean>(false);
     const [allDesks, setAllDesks] = useState<Desk[]>([]);
     const [currentPage, setCurrentPage] = useState<number>(defaultPage);
-    const [filterByStatuses, setFilterByStatuses] = useState<StatusFilter>(historyStatusFilter);
-    const [filterByDesks, setFilterByDesks] = useState<DeskFilter>(historyDeskFilter);
-    const [searchBarQuery, setSearchBarQuery] = useState<string>('');
-    const [isSearchBarValid, setIsSearchBarValid] = useState<boolean>(true);
     const [checkGroupedInvestigationOpen, setCheckGroupedInvestigationOpen] = React.useState<number[]>([])
     const [allGroupedInvestigations, setAllGroupedInvestigations] = useState<Map<string, InvestigationTableRow[]>>(new Map());
     const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
@@ -139,8 +116,9 @@ const InvestigationTable: React.FC = (): JSX.Element => {
     const {
         onCancel, onOk, snackbarOpen, tableRows, onInvestigationRowClick, convertToIndexedRow, getCountyMapKeyByValue,
         sortInvestigationTable, getUserMapKeyByValue, changeCounty, changeGroupsDesk, changeInvestigationsDesk, getTableCellStyles,
-        moveToTheInvestigationForm, totalCount, handleFilterChange, unassignedInvestigationsCount,
-        fetchInvestigationsByGroupId, fetchTableData, changeGroupsInvestigator, changeInvestigationsInvestigator
+        moveToTheInvestigationForm, totalCount, unassignedInvestigationsCount,
+        fetchInvestigationsByGroupId, fetchTableData, changeGroupsInvestigator, changeInvestigationsInvestigator,
+        statusFilter, changeStatusFilter, deskFilter, changeDeskFilter, searchQuery, changeSearchQuery, isSearchQueryValid,
     } = useInvestigationTable({
         selectedInvestigator, setSelectedRow, setAllUsersOfCurrCounty, allGroupedInvestigations,
         setAllCounties, setAllStatuses, setAllDesks, currentPage, setCurrentPage, setAllGroupedInvestigations,
@@ -193,13 +171,13 @@ const InvestigationTable: React.FC = (): JSX.Element => {
 
     const getFilteredUsersOfCurrentCounty = (): InvestigatorOption[] => {
         const allUsersOfCountyArray = Array.from(allUsersOfCurrCounty, ([id, value]) => ({ id, value }));
-        return filterByDesks.length === 0 ?
+        return deskFilter.length === 0 ?
             allUsersOfCountyArray :
             allUsersOfCountyArray.filter(({ id, value }) => {
                 if (!value.deskByDeskId) {
                     return false;
                 }
-                return filterByDesks.includes(value.deskByDeskId.id);
+                return deskFilter.includes(value.deskByDeskId.id);
             });
     }
 
@@ -491,18 +469,11 @@ const InvestigationTable: React.FC = (): JSX.Element => {
     const toggleFilterRow = () => setShowFilterRow(!showFilterRow);
 
     const clearSearchBarQuery = () => {
-        handleFilterChange(filterCreators[InvestigationsFilterByFields.NUMERIC_PROPERTIES](''));
-        setSearchBarQuery('');
+        changeSearchQuery('');
     }
 
-    const onSearchBarType = (typedInQuery: string) => {
-        if (stringAlphanum.isValidSync(typedInQuery)) {
-            setSearchBarQuery(typedInQuery)
-            !isSearchBarValid &&
-                setIsSearchBarValid(true);
-        } else {
-            setIsSearchBarValid(false);
-        }
+    const onSearchBarType = (newSearchQuery: string) => {
+        changeSearchQuery(newSearchQuery);
     }
 
     const markRow = async (indexedRow: IndexedInvestigation) => {
@@ -540,44 +511,19 @@ const InvestigationTable: React.FC = (): JSX.Element => {
             setCheckGroupedInvestigationOpen([...checkGroupedInvestigationOpen, epidemiologyNumber])
     }
 
-    const generateStatusFilterBySelectedStatues = (selectedStatuses: InvestigationMainStatus[]) => {
-        return selectedStatuses.includes(allStatusesOption)
-            ? [] : selectedStatuses;
-    };
-
     const onSelectedStatusesChange = (event: React.ChangeEvent<{}>, selectedStatuses: InvestigationMainStatus[]) => {
-        const nextFilterByStatuses = generateStatusFilterBySelectedStatues(selectedStatuses).map(filter => filter.id);
-        const { location: { state } } = history;
-        history.replace({
-            state: {
-                ...state,
-                statusFilter: nextFilterByStatuses
-            }
-        });
-        setFilterByStatuses(nextFilterByStatuses);
-        handleFilterChange(filterCreators[InvestigationsFilterByFields.STATUS](nextFilterByStatuses));
+        changeStatusFilter(selectedStatuses);
     }
 
     const onSelectedDesksChange = (event: React.ChangeEvent<{}>, selectedDesks: Desk[]) => {
-        const selectedDesksIds = selectedDesks.map(desk => desk.id);
-        const { location: { state } } = history;
-        history.replace({
-            state: {
-                ...state,
-                deskFilter: selectedDesksIds
-            }
-        });
-        setFilterByDesks(selectedDesksIds);
-        handleFilterChange(filterCreators[InvestigationsFilterByFields.DESK_ID](selectedDesksIds));
+        changeDeskFilter(selectedDesks);
     };
 
     const onSearchClick = () => {
-        if (searchBarQuery === '') {
-            clearSearchBarQuery();
+        if(currentPage !== defaultPage) {
+            setCurrentPage(defaultPage);
         } else {
-            phoneAndIdentityNumberRegex.test(searchBarQuery) ?
-                handleFilterChange(filterCreators[InvestigationsFilterByFields.NUMERIC_PROPERTIES](searchBarQuery)) :
-                handleFilterChange(filterCreators[InvestigationsFilterByFields.FULL_NAME](searchBarQuery));
+            fetchTableData();
         }
     }
 
@@ -612,7 +558,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                     </Typography>
                 </Grid>
                 <Grid item xs={2} >
-                    <DeskFilter desks={allDesks} filteredDesks={filterByDesks} onDeskChange={onSelectedDesksChange} />
+                    <DeskFilter desks={allDesks} filteredDesks={deskFilter} onDeskChange={onSelectedDesksChange} />
                 </Grid>
             </Grid>
             <Grid className={classes.content}>
@@ -623,18 +569,18 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                     <Box justifyContent='flex-end'>
                         <TextField
                             className={classes.searchBar}
-                            value={searchBarQuery}
+                            value={searchQuery}
                             onChange={event => onSearchBarType(event.target.value)}
                             onKeyPress={event => {
                                 event.key === 'Enter' &&
                                     onSearchClick();
                             }}
-                            label={isSearchBarValid ? searchBarLabel : searchBarError}
+                            label={isSearchQueryValid ? searchBarLabel : searchBarError}
                             InputProps={{
                                 endAdornment: (
                                     <InputAdornment position='end'>
                                         {
-                                            Boolean(searchBarQuery) &&
+                                            searchQuery.length > 0 &&
                                             <IconButton className={classes.searchBarIcons} onClick={clearSearchBarQuery}>
                                                 <Close />
                                             </IconButton>
@@ -646,7 +592,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
 
                                 ),
                             }}
-                            error={!isSearchBarValid}
+                            error={!isSearchQueryValid}
                         />
                         <Button
                             color='primary'
@@ -674,7 +620,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                 disableCloseOnSelect
                                 multiple
                                 options={allStatuses}
-                                value={allStatuses.filter(status => filterByStatuses.includes(status.id))}
+                                value={allStatuses.filter(status => statusFilter.includes(status.id))}
                                 getOptionLabel={(option) => option.displayName}
                                 onChange={onSelectedStatusesChange}
                                 renderInput={(params) =>

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -551,13 +551,13 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                 event.key === 'Escape' && closeDropdowns()}
         >
             <Grid className={classes.title} container alignItems='center' justify='space-between'>
-                <Grid item xs={2}></Grid>
-                <Grid item xs={8}>
+                <Grid item xs={2}/>
+                <Grid item xs={7}>
                     <Typography color='textPrimary' className={classes.welcomeMessage}>
                         {tableRows.length === 0 ? noInvestigationsMessage : welcomeMessage}
                     </Typography>
                 </Grid>
-                <Grid item xs={2} >
+                <Grid item xs={3} >
                     <DeskFilter desks={allDesks} filteredDesks={deskFilter} onDeskChange={onSelectedDesksChange} />
                 </Grid>
             </Grid>

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -39,6 +39,7 @@ import InvestigationNumberColumn from './InvestigationNumberColumn/Investigation
 import useInvestigationTable, { UNDEFINED_ROW, allStatusesOption } from './useInvestigationTable';
 import { TableHeadersNames, TableHeaders, adminCols, userCols, Order, sortableCols, IndexedInvestigation } from './InvestigationTablesHeaders';
 import { phoneAndIdentityNumberRegex } from '../../InvestigationForm/TabManagement/ExposuresAndFlights/ExposureForm/ExposureForm'
+import DeskFilter from './DeskFilter/DeskFilter';
 
 export const defaultOrderBy = 'defaultOrder';
 export const defaultPage = 1;
@@ -611,28 +612,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                     </Typography>
                 </Grid>
                 <Grid item xs={2} >
-                    <Card className={classes.filterByDeskCard}>
-                        <Typography className={classes.deskFilterTitle}>הדסקים בהם הנך צופה כעת:</Typography>
-                        <Autocomplete
-                            disableCloseOnSelect
-                            multiple
-                            options={allDesks}
-                            value={allDesks.filter(desk => filterByDesks.includes(desk.id))}
-                            getOptionLabel={(option) => option.deskName}
-                            onChange={onSelectedDesksChange}
-                            renderInput={(params) =>
-                                <TextField
-                                    {...params}
-                                />
-                            }
-                            renderTags={(tags: Desk[]) => {
-                                const additionalTagsAmount = tags.length - 1;
-                                const additionalDisplay = additionalTagsAmount > 0 ? ` (+${additionalTagsAmount})` : '';
-                                return tags[0].deskName + additionalDisplay;
-                            }}
-                            classes={{ inputRoot: classes.autocompleteInput }}
-                        />
-                    </Card>
+                    <DeskFilter desks={allDesks} filteredDesks={filterByDesks} onDeskChange={onSelectedDesksChange} />
                 </Grid>
             </Grid>
             <Grid className={classes.content}>

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -85,7 +85,7 @@ export interface HistoryState {
 
 const InvestigationTable: React.FC = (): JSX.Element => {
     const isScreenWide = useMediaQuery('(min-width: 1680px)');
-    const classes = useStyles(isScreenWide)();
+    const classes = useStyles(isScreenWide);
     const { alertWarning } = useCustomSwal();
     const theme = useTheme();
     const history = useHistory<HistoryState>();

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
@@ -10,6 +10,15 @@ import InvestigatorOption from 'models/InvestigatorOption';
 
 import { IndexedInvestigation, IndexedInvestigationData } from './InvestigationTablesHeaders';
 
+export type StatusFilter = number[];
+export type DeskFilter = number[];
+
+export interface HistoryState {
+    filterRules?: any;
+    statusFilter?: StatusFilter;
+    deskFilter?: DeskFilter;
+}
+
 export interface useInvestigationTableParameters {
     selectedInvestigator: Investigator;
     currentPage: number;
@@ -39,11 +48,17 @@ export interface useInvestigationTableOutcome {
     snackbarOpen: boolean;
     moveToTheInvestigationForm: (epidemiologyNumber: number) => void;
     totalCount: number;
-    handleFilterChange: (filterBy: any) => void;
     unassignedInvestigationsCount: number;
     fetchInvestigationsByGroupId: (groupId: string) => Promise<InvestigationTableRow[]>;
     changeGroupsInvestigator: (groupIds: string[], investigator: InvestigatorOption | null, transferReason?: string) => Promise<void>;
     changeInvestigationsInvestigator: (epidemiologyNumbers: number[], investigator: InvestigatorOption | null, transferReason?: string) => Promise<void>;
     changeGroupsDesk: (groupIds: string[], newSelectedDesk: Desk | null, transferReason?: string) => Promise<void>;
     changeInvestigationsDesk: (epidemiologyNumbers: number[], newSelectedDesk: Desk | null, transferReason?: string) => Promise<void>;
+    statusFilter: StatusFilter;
+    changeStatusFilter: (statuses: InvestigationMainStatus[]) => void;
+    deskFilter: DeskFilter;
+    changeDeskFilter: (desks: Desk[]) => void;
+    searchQuery: string;
+    changeSearchQuery: (searchQuery: string) => void;
+    isSearchQueryValid: boolean;
 };

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableStyles.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableStyles.ts
@@ -186,6 +186,6 @@ const useStyles = (isWide: boolean) => makeStyles((theme: Theme) => ({
         width: 250,
         padding: theme.spacing(1)
     }
-}));
+}))();
 
 export default useStyles;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableStyles.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableStyles.ts
@@ -24,7 +24,8 @@ const useStyles = (isWide: boolean) => makeStyles((theme: Theme) => ({
     },
     title: {
         margin: 'auto',
-        height: '14vh',
+        paddingTop: theme.spacing(1),
+        paddingBottom: theme.spacing(1),
         width: tableWidth,
     },
     tableContainer: {

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableStyles.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableStyles.ts
@@ -57,15 +57,6 @@ const useStyles = (isWide: boolean) => makeStyles((theme: Theme) => ({
         whiteSpace: 'nowrap',
         fontSize: '0.9rem'
     },
-    filterByDeskCard: {
-        padding: '1vh 1vw',
-        width: '13vw',
-        borderRadius: 15,
-        left: 0
-    },
-    deskFilterTitle: {
-        fontSize: '1.2vw',
-    },
     tableHeaderRow: {
         width: tableWidth,
         alignItems: 'center',

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -105,7 +105,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         setAllStatuses, setAllDesks, currentPage, setCurrentPage, setAllGroupedInvestigations, allGroupedInvestigations,
         investigationColor } = parameters;
 
-    const classes = useStyle(false)();
+    const classes = useStyle(false);
     const { alertError, alertWarning } = useCustomSwal();
     const history = useHistory<HistoryState>();
 

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -3,7 +3,9 @@ import { useSelector } from 'react-redux';
 import axios from 'axios';
 import { format } from 'date-fns';
 import { SweetAlertResult } from 'sweetalert2';
+import { useHistory } from 'react-router-dom';
 
+import Desk from 'models/Desk';
 import User from 'models/User';
 import theme from 'styles/theme';
 import County from 'models/County';
@@ -20,23 +22,24 @@ import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
 import InvestigationTableRow from 'models/InvestigationTableRow';
 import InvestigationMainStatus from 'models/InvestigationMainStatus';
 import { setIsLoading } from 'redux/IsLoading/isLoadingActionCreators';
+import { stringAlphanum } from 'commons/AlphanumericTextField/AlphanumericTextField';
 import InvestigationMainStatusCodes from 'models/enums/InvestigationMainStatusCodes';
 import { setLastOpenedEpidemiologyNum } from 'redux/Investigation/investigationActionCreators';
 import { setInvestigationStatus, setCreator } from 'redux/Investigation/investigationActionCreators';
 import { setAxiosInterceptorId } from 'redux/Investigation/investigationActionCreators';
 import InvestigatorOption from 'models/InvestigatorOption';
-import Desk from 'models/Desk';
 
 import useStyle from './InvestigationTableStyles';
-import { defaultOrderBy, rowsPerPage, defaultPage, HistoryState } from './InvestigationTable';
+import { defaultOrderBy, rowsPerPage, defaultPage } from './InvestigationTable';
 import {
     TableHeadersNames,
     IndexedInvestigation,
     IndexedInvestigationData,
     investigatorIdPropertyName
 } from './InvestigationTablesHeaders';
-import { useInvestigationTableOutcome, useInvestigationTableParameters } from './InvestigationTableInterfaces';
-import { useHistory } from 'react-router-dom';
+import { DeskFilter, HistoryState, StatusFilter, useInvestigationTableOutcome, useInvestigationTableParameters } from './InvestigationTableInterfaces';
+import { phoneAndIdentityNumberRegex } from '../../InvestigationForm/TabManagement/ExposuresAndFlights/ExposureForm/ExposureForm';
+import filterCreators from './FilterCreators';
 
 const investigationURL = '/investigation';
 const getFlooredRandomNumber = (min: number, max: number): number => (
@@ -108,12 +111,20 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
     const classes = useStyle(false);
     const { alertError, alertWarning } = useCustomSwal();
     const history = useHistory<HistoryState>();
+    const { statusFilter: historyStatusFilter = [], deskFilter: historyDeskFilter = [] } = useMemo(() => {
+        const { location: { state } } = history;
+        return state || {};
+    }, []);
 
     const [rows, setRows] = useState<InvestigationTableRow[]>([]);
     const [isDefaultOrder, setIsDefaultOrder] = useState<boolean>(true);
     const [orderBy, setOrderBy] = useState<string>(defaultOrderBy);
     const [totalCount, setTotalCount] = useState<number>(0);
     const [unassignedInvestigationsCount, setUnassignedInvestigationsCount] = useState<number>(0);
+    const [statusFilter, setStatusFilter] = useState<StatusFilter>(historyStatusFilter);
+    const [deskFilter, setDeskFilter] = useState<DeskFilter>(historyDeskFilter);
+    const [searchQuery, setSearchQuery] = useState<string>('');
+    const [isSearchQueryValid, setIsSearchQueryValid] = useState<boolean>(true);
 
     const user = useSelector<StoreStateType, User>(state => state.user.data);
     const isLoggedIn = useSelector<StoreStateType, boolean>(state => state.user.isLoggedIn);
@@ -121,6 +132,48 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
     const axiosInterceptorId = useSelector<StoreStateType, number>(state => state.investigation.axiosInterceptorId);
     const windowTabsBroadcastChannel = useRef(new BroadcastChannel(BC_TABS_NAME));
+
+    const generateStatusFilterBySelectedStatues = (statuses: InvestigationMainStatus[]) => {
+        return statuses.includes(allStatusesOption)
+            ? [] : statuses;
+    };
+
+    const changeStatusFilter = (statuses: InvestigationMainStatus[]) => {
+        const statusesIds = generateStatusFilterBySelectedStatues(statuses).map(status => status.id);
+        updateFilterHistory('statusFilter', statusesIds);
+        setStatusFilter(statusesIds);
+        setCurrentPage(defaultPage);
+    };
+
+
+    const changeDeskFilter = (desks: Desk[]) => {
+        const desksIds = desks.map(desk => desk.id);
+        updateFilterHistory('desksFilter', desksIds);
+        setDeskFilter(desksIds);
+        setCurrentPage(defaultPage);
+    };
+
+    const changeSearchQuery = (newSearchQuery: string) => {
+        if (stringAlphanum.isValidSync(newSearchQuery)) {
+            setSearchQuery(newSearchQuery);
+
+            if(!isSearchQueryValid) {
+                setIsSearchQueryValid(true);
+            }
+        } else {
+            setIsSearchQueryValid(false);
+        }
+    };
+
+    const updateFilterHistory = (key: string, value: any) => {
+        const { location: { state } } = history;
+        history.replace({
+            state: {
+                ...state,
+                [key]: value
+            }
+        });
+    };
 
     const fetchAllDesksByCountyId = () => {
         const desksByCountyIdLogger = logger.setup('Getting Desks by county id');
@@ -184,12 +237,20 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
 
     const getInvestigationsAxiosRequest = (orderBy: string): any => {
         const getInvestigationsLogger = logger.setup('Getting Investigations');
+        
+        const searchQueryFilter = phoneAndIdentityNumberRegex.test(searchQuery)? filterCreators.NUMERIC_PROPERTIES(searchQuery) : filterCreators.FULL_NAME(searchQuery);
+
+        const filterRules = {
+            ...filterCreators.DESK_ID(deskFilter),
+            ...filterCreators.STATUS(statusFilter),
+            ...searchQueryFilter,
+        };
 
         const requestData = {
             orderBy,
             size: rowsPerPage,
             currentPage: currentPage,
-            filterRules: history.location.state?.filterRules,
+            filterRules,
         };
 
         if (user.userType === userType.ADMIN || user.userType === userType.SUPER_ADMIN) {
@@ -359,40 +420,11 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
 
     const { startWaiting, onCancel, onOk, snackbarOpen } = usePageRefresh(fetchTableData, TABLE_REFRESH_INTERVAL);
 
-    const getGraphQLConditionsFromFilters = (conditions: any, aggFilters: any) => {
-        return Object.entries(conditions).reduce((previousValue, [filterKey, filterValue]) => {
-            if (filterValue) {
-                return {
-                    ...previousValue,
-                    [filterKey]: filterValue
-                }
-            }
-
-            delete previousValue[filterKey as any];
-            return previousValue;
-        }, aggFilters);
-    };
-
-    const handleFilterChange = (filterBy: any) => {
-        const { location: { state = {}} } = history;
-        const {filterRules= {}} = state;
-        const nextFilterRules = getGraphQLConditionsFromFilters(filterBy, { ...filterRules });
-
-        history.replace({
-            state: {
-                ...state,
-                filterRules: nextFilterRules,
-            }
-        });
-
-        setCurrentPage(defaultPage);
-    };
-
     useEffect(() => {
         if (isLoggedIn) {
             fetchTableData();
         }
-    }, [isLoggedIn, currentPage, orderBy, history.location.state?.filterRules]);
+    }, [isLoggedIn, currentPage, orderBy, statusFilter, deskFilter]);
 
     const onInvestigationRowClick = (investigationRow: { [T in keyof IndexedInvestigationData]: any }) => {
         const investigationClickLogger = logger.setupVerbose({
@@ -741,11 +773,17 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         changeGroupsDesk,
         changeInvestigationsDesk,
         totalCount,
-        handleFilterChange,
         unassignedInvestigationsCount,
         fetchInvestigationsByGroupId,
         changeGroupsInvestigator,
         changeInvestigationsInvestigator,
+        statusFilter,
+        changeStatusFilter,
+        deskFilter,
+        changeDeskFilter,
+        searchQuery,
+        changeSearchQuery,
+        isSearchQueryValid
     };
 };
 

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -156,7 +156,6 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
     const changeSearchQuery = (newSearchQuery: string) => {
         if (stringAlphanum.isValidSync(newSearchQuery)) {
             setSearchQuery(newSearchQuery);
-
             if(!isSearchQueryValid) {
                 setIsSearchQueryValid(true);
             }

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -148,7 +148,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
 
     const changeDeskFilter = (desks: Desk[]) => {
         const desksIds = desks.map(desk => desk.id);
-        updateFilterHistory('desksFilter', desksIds);
+        updateFilterHistory('deskFilter', desksIds);
         setDeskFilter(desksIds);
         setCurrentPage(defaultPage);
     };
@@ -181,7 +181,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             .then((result) => {
                 if (result?.data && result.headers['content-type'].includes('application/json')) {
                     desksByCountyIdLogger.info('The desks were fetched successfully', Severity.LOW);
-                    setAllDesks(result.data);
+                    setAllDesks([{ id: -1, deskName: 'לא שוייך לדסק' }, ...result.data]);
                 } else {
                     desksByCountyIdLogger.error('Got 200 status code but results structure isnt as expected', Severity.HIGH);
                 }
@@ -568,7 +568,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         }
     };
 
-    const changeCounty = async (indexedRow: IndexedInvestigation, newSelectedCounty: {id: number, value: County} | null) => {
+    const changeCounty = async (indexedRow: IndexedInvestigation, newSelectedCounty: { id: number, value: County } | null) => {
         const changeCountyLogger = logger.setupVerbose({
             workflow: 'Change Investigation County',
             user: user.id,
@@ -620,7 +620,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
     }
 
     const changeGroupsDesk = async (groupIds: string[], newSelectedDesk: Desk | null, transferReason?: string) => {
-        const changeDeskLogger= logger.setup('Change Investigation Desk');
+        const changeDeskLogger = logger.setup('Change Investigation Desk');
         const joinedGroupIds = groupIds.join(', ');
         changeDeskLogger.info(`performing desk change request for group ${joinedGroupIds}`, Severity.LOW);
         try {

--- a/client/src/styles/theme.ts
+++ b/client/src/styles/theme.ts
@@ -60,15 +60,6 @@ const theme = createMuiTheme({
                 fontSize: 16
             }
         },
-        //@ts-ignore
-        MuiAutocomplete: {
-            inputRoot: {
-                '&&[class*="MuiOutlinedInput-root"][class*="MuiOutlinedInput-marginDense"] $input': {
-                    flip: false,
-                    padding: '1px 10px 1px 10px'
-                }
-            }
-        },
         MuiSelect: {
             select: {
                 '&:focus': {


### PR DESCRIPTION
This PR adds the option to filter by investigations which are unassigned to a desk.
## The Problem
While this feature sounds simple enough, the implementation of the filtering logic was very unorganized and convoluted which caused issues with implementing this pretty small feature.
## How the Filtering Worked
Up until now we had the `filterCreator` which applied the graphql filtering logic to the query which is sent to the server. The thing is, that on each filter change we would call a function called `getGraphQLConditionsFromFilters` which would override old filter rules with the new ones.

The problem was that the new filter rules for unassigned desks is different than the filter rules of normal desks, causing the `getGraphQLConditionsFromFilters` function not to override the old filterRules.
## The Solution
The filterRules needs to be created from scratch each time a table fetch is requested, instead of overriding the old filterRules object.

## Changes
* Seperated DeskFilter to component.
* Improved styling of DeskFilter.
* Refactored filterRules creation so it would be created from scratch instead of overriding old filter rules.
* Added unassigned desk filter option.