### PR TITLE
removed unnecessary function from useInvestigationTableOutcome 

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
@@ -39,8 +39,6 @@ export interface useInvestigationTableOutcome {
     onInvestigationRowClick: (investigationRow: { [T in keyof IndexedInvestigationData]: any }) => void;
     convertToIndexedRow: (row: InvestigationTableRow) => { [T in keyof IndexedInvestigationData]: any };
     getUserMapKeyByValue: (map: Map<string, User>, value: string) => string;
-    getCountyMapKeyByValue: (map: Map<number, County>, value: string) => number;
-    changeCounty: (indexedRow: IndexedInvestigation, newSelectedCountyId: { id: number, value: County } | null) => Promise<void>;
     getNestedCellStyle: (cellKey: string , isLast : boolean) => string[];
     getRegularCellStyle: (rowIndex: number, cellKey: string , isGroupShown : boolean) => string[];
     sortInvestigationTable: (orderByValue: string) => void;


### PR DESCRIPTION
Currently the dev doesn't work because the functions getCountyMapKeyByValue and changeCounty were removed in #971 but not removed from the useInvestigationTableOutcome  interface.
