### PR TITLE
fixed save-all function

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/useContactQuestioning.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/useContactQuestioning.ts
@@ -79,13 +79,13 @@ const useContactQuestioning = (parameters: useContactQuestioningParameters): use
     const saveContactQuestioning = (formState: InteractedContact[]) => {
         if (
             !checkDuplicateIds(
-                allContactedInteractions.map(
+                formState.map(
                     (contact: InteractedContact) => contact.identificationNumber
                 )
             )
         ) {
             const contactsSavingVariable = {
-                unSavedContacts: {contacts: allContactedInteractions}
+                unSavedContacts: {contacts: formState}
             }
             const contactLogger = logger.setup('Saving all contacts');
             contactLogger.info(`launching server request with parameter: ${JSON.stringify(contactsSavingVariable)}`, Severity.LOW);


### PR DESCRIPTION
the save all function accidently sent the state (that it received) instead of the form's state causing the form's values to reset
connected the form state (instead of the general state) to the sending function