### PR TITLE
Fix/group actions for county

### DIFF
--- a/server/src/ClientToDBAPI/LandingPageRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/LandingPageRoute/mainRoute.ts
@@ -160,8 +160,9 @@ landingPageRoute.post('/changeGroupDesk', adminMiddleWare, (request: Request, re
     const desk = request.body.desk;
     const selectedGroups = request.body.groupIds;
     const reason = request.body.reason ? request.body.reason : ''; 
+    const userCounty = response.locals.user.investigationGroup;
     changeGroupDeskLogger.info(`querying the graphql API with parameters ${JSON.stringify(request.body)}`, Severity.LOW);
-    graphqlRequest(UPDATE_DESK_BY_GROUP_ID, response.locals, {desk, selectedGroups, reason})
+    graphqlRequest(UPDATE_DESK_BY_GROUP_ID, response.locals, {desk, selectedGroups, userCounty, reason})
     .then((result: any) => {
         if (result?.data && !result.errors) {
             changeGroupDeskLogger.info(`investigator have been changed in the DB for group: ${selectedGroups}`, Severity.LOW);

--- a/server/src/ClientToDBAPI/UsersRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/UsersRoute/mainRoute.ts
@@ -132,9 +132,10 @@ usersRoute.post('/changeGroupInvestigator', adminMiddleWare, (request: Request, 
     });
     const newInvestigator = request.body.user;
     const selectedGroups = request.body.groupIds;
+    const userCounty = response.locals.user.investigationGroup;
     const reason = request.body.reason ? request.body.reason : ''; 
     changeGroupInvestigatorLogger.info(`querying the graphql API with parameters ${JSON.stringify(request.body)}`, Severity.LOW);
-    graphqlRequest(UPDATE_INVESTIGATOR_BY_GROUP_ID, response.locals, {newInvestigator, selectedGroups, reason})
+    graphqlRequest(UPDATE_INVESTIGATOR_BY_GROUP_ID, response.locals, {newInvestigator, selectedGroups, userCounty, reason})
     .then((result: any) => {
         if (result?.data && !result.errors) {
             changeGroupInvestigatorLogger.info(`investigator have been changed in the DB for group: ${selectedGroups}`, Severity.LOW);
@@ -157,8 +158,9 @@ usersRoute.post('/changeGroupCounty', adminMiddleWare, (request: Request, respon
     });
     let newInvestigator = 'admin.group' + request.body.county;
     const selectedGroups = request.body.groupIds;
+    const userCounty = response.locals.user.investigationGroup;
     changeGroupCountyLogger.info(`querying the graphql API with parameters ${JSON.stringify(request.body)}`, Severity.LOW);
-    graphqlRequest(UPDATE_INVESTIGATOR_BY_GROUP_ID, response.locals, {newInvestigator, selectedGroups, wasInvestigationTransferred: true})
+    graphqlRequest(UPDATE_INVESTIGATOR_BY_GROUP_ID, response.locals, {newInvestigator, selectedGroups, userCounty, wasInvestigationTransferred: true})
     .then((result: any) => {
         if (result?.data && !result.errors) {
             changeGroupCountyLogger.info(`investigator have been changed in the DB for group: ${selectedGroups}`, Severity.LOW);

--- a/server/src/DBService/LandingPage/Mutation.ts
+++ b/server/src/DBService/LandingPage/Mutation.ts
@@ -9,8 +9,8 @@ export const CHANGE_DESK_ID = gql`
 `;
 
 export const UPDATE_DESK_BY_GROUP_ID = gql`
-mutation updateInvestigatorByGroupId($desk: Int!, $selectedGroups: [UUID!]!, $reason: String) {
-  updateDeskByGroupId(input: {desk: $desk, selectedGroups: $selectedGroups, reason: $reason}) {
+mutation updateInvestigatorByGroupId($desk: Int!, $selectedGroups: [UUID!]!, $userCounty: Int!, $reason: String) {
+  updateDeskByGroupId(input: {desk: $desk, selectedGroups: $selectedGroups, userCounty: $userCounty, reason: $reason}) {
     clientMutationId
   }
 }

--- a/server/src/DBService/Users/Mutation.ts
+++ b/server/src/DBService/Users/Mutation.ts
@@ -22,8 +22,8 @@ mutation ChangeInvestigator($epidemiologyNumber: Int!, $newUser: String!, $trans
 `;
 
 export const UPDATE_INVESTIGATOR_BY_GROUP_ID = gql`
-mutation updateInvestigatorByGroupId($newInvestigator: String!, $selectedGroups: [UUID!]!, $reason: String, $wasInvestigationTransferred: Boolean) {
-  updateInvestigatorByGroupId(input: {newInvestigator: $newInvestigator, selectedGroups: $selectedGroups, reason: $reason, investigationTransferred: $wasInvestigationTransferred}) {
+mutation updateInvestigatorByGroupId($newInvestigator: String!, $selectedGroups: [UUID!]!, $userCounty: Int!, $reason: String, $wasInvestigationTransferred: Boolean) {
+  updateInvestigatorByGroupId(input: {newInvestigator: $newInvestigator, selectedGroups: $selectedGroups, userCounty: $userCounty, reason: $reason, investigationTransferred: $wasInvestigationTransferred}) {
     clientMutationId
   }
 }


### PR DESCRIPTION
# prevent actions on investigation that not belong to the investigator county.
group from mabar combine investigation from different counties 

* prevent changing investigator for investigation in group that not belong to the investigator county.
* prevent changing county for investigation in group that not belong to the investigator county.
* prevent changing desk for investigation in group that not belong to the investigator county.

us 1211
the change include db functions changes