### PR TITLE
feat(transfer reason): remove required reason

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableFooter/TransferInvestigationsDialogs/TransferInvestigationInvestigatorSchema.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableFooter/TransferInvestigationsDialogs/TransferInvestigationInvestigatorSchema.ts
@@ -4,7 +4,6 @@ import TransferInvestigationInvestigatorInputNames from './TransferInvestigation
 
 const errorMessage = 'סיבה לא תקנית';
 const investigatorRequiredMessage = 'יש לבחור חוקר';
-const reasonRequiredMessage = 'יש לכתוב סיבה';
 const maxLengthErrorMessage = 'הסיבה חייבת להיות עד 200 תווים';
 
 const schema = yup.object().shape<{[T in TransferInvestigationInvestigatorInputNames]: any}>({
@@ -13,7 +12,6 @@ const schema = yup.object().shape<{[T in TransferInvestigationInvestigatorInputN
         value: yup.object()
     }).nullable().required(investigatorRequiredMessage),
     [TransferInvestigationInvestigatorInputNames.REASON]: yup.string()
-                                                             .required(reasonRequiredMessage)
                                                              .matches( /^[a-zA-Z\u0590-\u05fe\s0-9-+*!?'"():_,.\/\\]*$/, errorMessage)
                                                              .max(200, maxLengthErrorMessage)
 });


### PR DESCRIPTION
# Transfer Reason is not required anymore

* The text for transfer reason is not required for all the investigations' transfer

* It makes admin investigators to write some garbage text for no reason just to be able to make it.

# Solution

* Remove the 'required' enforcement to be able to transfer an investigation without reason when you don't have one.