### PR TITLE
Feat/disable table row

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -443,6 +443,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                                         isGroupShown={isGroupShown}
                                                         checked={isRowSelected(indexedRow.epidemiologyNumber)}
                                                         clickable={isGroupedRowClickable}
+                                                        disabled={user.countyByInvestigationGroup.districtId !== row.county.id}
                                                         tableContainerRef={tableContainerRef}
                                                         allGroupedInvestigations={allGroupedInvestigations}
                                                         checkGroupedInvestigationOpen={checkGroupedInvestigationOpen}

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -398,7 +398,6 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                             isGroupShown={isGroupShown}
                                             checked={isRowSelected(indexedRow.epidemiologyNumber)}
                                             clickable={isRowClickable}
-                                            index={index}
                                             tableContainerRef={tableContainerRef}
                                             allGroupedInvestigations={allGroupedInvestigations}
                                             checkGroupedInvestigationOpen={checkGroupedInvestigationOpen}
@@ -444,7 +443,6 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                                         isGroupShown={isGroupShown}
                                                         checked={isRowSelected(indexedRow.epidemiologyNumber)}
                                                         clickable={isGroupedRowClickable}
-                                                        index={index}
                                                         tableContainerRef={tableContainerRef}
                                                         allGroupedInvestigations={allGroupedInvestigations}
                                                         checkGroupedInvestigationOpen={checkGroupedInvestigationOpen}

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -443,7 +443,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                                         isGroupShown={isGroupShown}
                                                         checked={isRowSelected(indexedRow.epidemiologyNumber)}
                                                         clickable={isGroupedRowClickable}
-                                                        disabled={user.countyByInvestigationGroup.districtId !== row.county.id}
+                                                        disabled={user.investigationGroup !== row.county.id}
                                                         tableContainerRef={tableContainerRef}
                                                         allGroupedInvestigations={allGroupedInvestigations}
                                                         checkGroupedInvestigationOpen={checkGroupedInvestigationOpen}

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableRow/InvestigationTableRow.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableRow/InvestigationTableRow.tsx
@@ -22,6 +22,7 @@ import InvestigationStatusColumn from '../InvestigationStatusColumn/Investigatio
 import InvestigationIndicatorsColumn from '../InvestigationIndicatorsColumn/InvestigationIndicatorsColumn';
 
 interface RowTooltipProps {
+    titleOverride?: string;
     creationDate: InvestigationTableRowType['creationDate'];
     startTime: InvestigationTableRowType['startTime'];
     children: React.ReactElement;
@@ -30,7 +31,7 @@ interface RowTooltipProps {
 const noDataMessage = 'אין מידע אודות תאריכים לחקירה זו';
 const tooltipEnterDelay = 800;
 const RowTooltip = (props: RowTooltipProps) => {
-    const { creationDate, startTime } = props;
+    const { creationDate, startTime, titleOverride } = props;
     const tooltipClasses = useTooltipStyles();
 
     const formatDate = (date: Date): string => date ? format(new Date(date), 'dd/MM/yyyy') : 'אין מידע';
@@ -44,7 +45,7 @@ const RowTooltip = (props: RowTooltipProps) => {
         </>
         : noDataMessage;
 
-    return <Tooltip title={title} enterDelay={tooltipEnterDelay} enterNextDelay={tooltipEnterDelay}
+    return <Tooltip title={titleOverride ? titleOverride : title} enterDelay={tooltipEnterDelay} enterNextDelay={tooltipEnterDelay}
         classes={{ tooltip: tooltipClasses.content }}
         PopperProps={{
             placement: 'right',
@@ -63,6 +64,7 @@ interface Props {
     deskAutoCompleteClicked: boolean;
     checked: boolean;
     clickable: boolean;
+    disabled?: boolean;
     desks: Desk[];
     indexedRow: { [T in keyof typeof TableHeadersNames]: any };
     row: InvestigationTableRowType;
@@ -96,6 +98,7 @@ const InvestigationTableRow = ({
     isGroupShown,
     checked,
     clickable,
+    disabled = false,
     tableContainerRef,
     allGroupedInvestigations,
     checkGroupedInvestigationOpen,
@@ -165,7 +168,7 @@ const InvestigationTableRow = ({
                     return deskValue ? deskValue : unassignedToDesk
                 }
             case TableHeadersNames.subOccupation:
-                const subOccupation =  row.isInInstitute && indexedRow[cellName as keyof typeof TableHeadersNames];
+                const subOccupation = row.isInInstitute && indexedRow[cellName as keyof typeof TableHeadersNames];
                 const parentOccupation = Boolean(subOccupation) ? row.parentOccupation : '';
                 return <Tooltip title={parentOccupation} placement='top'>
                     <div>{subOccupation || '-'}</div>
@@ -202,16 +205,18 @@ const InvestigationTableRow = ({
                     </>
                 )
             case TableHeadersNames.settings:
-                return <SettingsActions
-                    epidemiologyNumber={indexedRow.epidemiologyNumber}
-                    investigationStatus={indexedRow.investigationStatus}
-                    groupId={indexedRow.groupId}
-                    allGroupedInvestigations={allGroupedInvestigations}
-                    checkGroupedInvestigationOpen={checkGroupedInvestigationOpen}
-                    fetchTableData={fetchTableData}
-                    fetchInvestigationsByGroupId={fetchInvestigationsByGroupId}
-                    moveToTheInvestigationForm={moveToTheInvestigationForm}
-                />
+                return (
+                    <SettingsActions
+                        epidemiologyNumber={indexedRow.epidemiologyNumber}
+                        investigationStatus={indexedRow.investigationStatus}
+                        groupId={indexedRow.groupId}
+                        allGroupedInvestigations={allGroupedInvestigations}
+                        checkGroupedInvestigationOpen={checkGroupedInvestigationOpen}
+                        fetchTableData={fetchTableData}
+                        fetchInvestigationsByGroupId={fetchInvestigationsByGroupId}
+                        moveToTheInvestigationForm={moveToTheInvestigationForm}
+                    />
+                );
             default:
                 return indexedRow[cellName as keyof typeof TableHeadersNames]
         }
@@ -220,13 +225,15 @@ const InvestigationTableRow = ({
     return (
         <RowTooltip
             creationDate={row.creationDate}
-            startTime={row.startTime}>
+            startTime={row.startTime}
+            titleOverride={disabled ? 'בלה בלה' : ''}
+        >
             <TableRow
                 selected={checked}
                 key={indexedRow.epidemiologyNumber}
                 classes={{ selected: classes.checkedRow }}
-                className={[classes.investigationRow, clickable && classes.clickableInvestigationRow].join(' ')}
-                onClick={() => clickable && onInvestigationRowClick(indexedRow as { [T in keyof IndexedInvestigationData]: any })}
+                className={`${classes.investigationRow} ${clickable && classes.clickableInvestigationRow} ${disabled && classes.disabled}`}
+                onClick={() => clickable && !disabled && onInvestigationRowClick(indexedRow as { [T in keyof IndexedInvestigationData]: any })}
             >
                 {
                     Object.values(columns).map((key: string) => (

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableRow/InvestigationTableRow.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableRow/InvestigationTableRow.tsx
@@ -228,7 +228,7 @@ const InvestigationTableRow = ({
         <RowTooltip
             creationDate={row.creationDate}
             startTime={row.startTime}
-            titleOverride={disabled ? 'בלה בלה' : ''}
+            titleOverride={disabled ? `חקירה של נפת ${row.county.displayName}` : ''}
         >
             <TableRow
                 selected={checked}

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableRow/InvestigationTableRow.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableRow/InvestigationTableRow.tsx
@@ -139,10 +139,11 @@ const InvestigationTableRow = ({
                     <InvestigatorAllocationCell
                         investigatorName={indexedRow[cellName as keyof typeof TableHeadersNames]}
                         isInvestigatorActive={row.investigator?.isActive}
+                        disabled={disabled}
                     />
                 )
             case TableHeadersNames.investigationDesk:
-                if (selected && deskAutoCompleteClicked &&
+                if (selected && deskAutoCompleteClicked && !disabled &&
                     (user.userType === UserType.ADMIN || user.userType === UserType.SUPER_ADMIN) && !wasInvestigationFetchedByGroup) {
                     return (
                         <Autocomplete
@@ -174,11 +175,11 @@ const InvestigationTableRow = ({
                     <div>{subOccupation || '-'}</div>
                 </Tooltip>
             case TableHeadersNames.comment:
-                return <ClickableTooltip value={indexedRow[cellName as keyof typeof TableHeadersNames]}
+                return <ClickableTooltip disabled={disabled} value={indexedRow[cellName as keyof typeof TableHeadersNames]}
                     defaultValue='אין הערה' scrollableRef={tableContainerRef.current} InputIcon={Comment} />
 
             case TableHeadersNames.phoneNumber:
-                return <ClickableTooltip value={indexedRow[cellName as keyof typeof TableHeadersNames]}
+                return <ClickableTooltip disabled={disabled} value={indexedRow[cellName as keyof typeof TableHeadersNames]}
                     defaultValue='' scrollableRef={tableContainerRef.current} InputIcon={Call} />
             case TableHeadersNames.investigationStatus:
                 const investigationStatus = indexedRow[cellName as keyof typeof TableHeadersNames];
@@ -206,6 +207,7 @@ const InvestigationTableRow = ({
                 )
             case TableHeadersNames.settings:
                 return (
+                    !disabled &&
                     <SettingsActions
                         epidemiologyNumber={indexedRow.epidemiologyNumber}
                         investigationStatus={indexedRow.investigationStatus}
@@ -240,7 +242,7 @@ const InvestigationTableRow = ({
                         <TableCell
                             classes={{ root: classes.tableCellRoot }}
                             className={tableCellStyleFunction(key).join(' ')}
-                            onClick={(event: any) => onCellClick(event, key, indexedRow.epidemiologyNumber, indexedRow.groupId)}
+                            onClick={(event: any) => !disabled && onCellClick(event, key, indexedRow.epidemiologyNumber, indexedRow.groupId)}
                         >
                             {
                                 getTableCell(key)

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableRow/InvestigationTableRow.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableRow/InvestigationTableRow.tsx
@@ -67,7 +67,6 @@ interface Props {
     indexedRow: { [T in keyof typeof TableHeadersNames]: any };
     row: InvestigationTableRowType;
     isGroupShown: boolean;
-    index: number;
     tableContainerRef: MutableRefObject<HTMLElement | undefined>;
     allGroupedInvestigations: Map<string, InvestigationTableRowType[]>;
     checkGroupedInvestigationOpen: number[];
@@ -97,7 +96,6 @@ const InvestigationTableRow = ({
     isGroupShown,
     checked,
     clickable,
-    index,
     tableContainerRef,
     allGroupedInvestigations,
     checkGroupedInvestigationOpen,

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableRow/InvestigationTableRowStyles.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableRow/InvestigationTableRowStyles.ts
@@ -22,7 +22,8 @@ const useStyles = makeStyles((theme: Theme) => ({
         cursor: 'pointer'
     },
     disabled: {
-        opacity: theme.palette.action.disabledOpacity
+        opacity: theme.palette.action.disabledOpacity,
+        cursor: 'not-allowed'
     }
 }));
 

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableRow/InvestigationTableRowStyles.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableRow/InvestigationTableRowStyles.ts
@@ -21,6 +21,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     clickableInvestigationRow: {
         cursor: 'pointer'
     },
+    disabled: {
+        opacity: theme.palette.action.disabledOpacity
+    }
 }));
 
 export default useStyles;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigatorAllocation/InvestigatorAllocationCell.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigatorAllocation/InvestigatorAllocationCell.tsx
@@ -6,7 +6,7 @@ import useStyles from './InvestigatorAllocationCellStyles';
 
 const InvestigatorAllocationCell: React.FC<Props> = (props: Props) => {
 
-    const { investigatorName ,isInvestigatorActive} = props;
+    const { investigatorName, isInvestigatorActive, disabled } = props;
 
     const [isCellHovered, setIsCellHovered] = useState<boolean>(false);
 
@@ -20,15 +20,15 @@ const InvestigatorAllocationCell: React.FC<Props> = (props: Props) => {
     )
 
     return (
-        <div 
-            className={`${classes.selectedInvestigator} ${ !isInvestigatorActive && !isUnassigned ? classes.inActiveInvestigator : ''}`}
-            onMouseOver={() => setIsCellHovered(true)}
-            onMouseLeave={() => setIsCellHovered(false)}
+        <div
+            className={`${classes.selectedInvestigator} ${!isInvestigatorActive && !isUnassigned ? classes.inActiveInvestigator : ''}`}
+            onMouseOver={() => !disabled && setIsCellHovered(true)}
+            onMouseLeave={() => !disabled && setIsCellHovered(false)}
         >
             {isUnassigned && !isCellHovered && <UnassignedWarning />}
             {investigatorName}
             {isCellHovered && <Edit fontSize='small' className={classes.editIcon} />}
-            
+
         </div>
     )
 };
@@ -36,6 +36,7 @@ const InvestigatorAllocationCell: React.FC<Props> = (props: Props) => {
 interface Props {
     investigatorName: string;
     isInvestigatorActive: Boolean;
+    disabled: boolean;
 }
 
 export default InvestigatorAllocationCell;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigatorAllocation/InvestigatorAllocationCell.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigatorAllocation/InvestigatorAllocationCell.tsx
@@ -28,7 +28,6 @@ const InvestigatorAllocationCell: React.FC<Props> = (props: Props) => {
             {isUnassigned && !isCellHovered && <UnassignedWarning />}
             {investigatorName}
             {isCellHovered && <Edit fontSize='small' className={classes.editIcon} />}
-
         </div>
     )
 };

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/clickableTooltip/clickableTooltip.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/clickableTooltip/clickableTooltip.tsx
@@ -4,7 +4,7 @@ import { SvgIconComponent } from '@material-ui/icons';
 
 import useStyles from './clickableTooltipStyles';
 
-const ClickableTooltip = ({value, defaultValue, scrollableRef, InputIcon}: Props) => {
+const ClickableTooltip = ({value, defaultValue, scrollableRef, InputIcon, disabled = false}: Props) => {
     const [isTooltipOpen, setIsTooltipOpen] = React.useState<boolean>(false);
 
     const handleTooltipClose = () => setIsTooltipOpen(false);
@@ -37,7 +37,7 @@ const ClickableTooltip = ({value, defaultValue, scrollableRef, InputIcon}: Props
             open={isTooltipOpen}
                    disableHoverListener
             title={value || defaultValue || ''}>
-                  <IconButton onClick={handleTooltipToggle}>
+                  <IconButton disabled={disabled} onClick={handleTooltipToggle}>
                       <InputIcon color={value ? 'primary' : 'disabled'}/>
                   </IconButton>
           </Tooltip>
@@ -50,6 +50,7 @@ interface Props {
     defaultValue?: string;
     scrollableRef?: HTMLElement;
     InputIcon: SvgIconComponent;
+    disabled?: boolean;
 }
 
 export default ClickableTooltip;


### PR DESCRIPTION
This PR implements the disabling of investigation rows when they are from a different county.

## Changes
* Add visual disable indicator with opacity and cursor type.
* Change tooltip when row is disabled to display the row's county.
* Disable/Remove all cell and row functionalities while row is disabled.