### PR TITLE
fix(users): fix multiple request call for investigator list

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -59,7 +59,6 @@ const InvestigationTable: React.FC = (): JSX.Element => {
     const [checkedIndexedRows, setCheckedIndexedRows] = useState<IndexedInvestigation[]>([]);
     const [selectedRow, setSelectedRow] = useState<SelectedRow>(DEFAULT_SELECTED_ROW);
     const [deskAutoCompleteClicked, setDeskAutoCompleteClicked] = useState<boolean>(false);
-    const [allUsersOfCurrCounty, setAllUsersOfCurrCounty] = useState<Map<string, User>>(new Map());
     const [allCounties, setAllCounties] = useState<County[]>([]);
     const [order, setOrder] = useState<Order>(SortOrder.asc);
     const [orderBy, setOrderBy] = useState<string>(defaultOrderBy);
@@ -98,8 +97,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
         changeUnassginedUserFilter, unassignedUserFilter, changeInactiveUserFilter, inactiveUserFilter, fetchAllCountyUsers,
         tableTitle
     } = useInvestigationTable({
-        setSelectedRow, setAllUsersOfCurrCounty, allGroupedInvestigations,
-        setAllCounties, setAllStatuses, setAllDesks, currentPage, setCurrentPage, setAllGroupedInvestigations,
+        setSelectedRow, allGroupedInvestigations, setAllCounties, setAllStatuses, setAllDesks, currentPage, setCurrentPage, setAllGroupedInvestigations,
         investigationColor
     });
 
@@ -471,7 +469,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
             <InvestigatorAllocationDialog
                 isOpen={isInvestigatorAllocationDialogOpen}
                 handleCloseDialog={() => setIsInvestigatorAllocationDialogOpen(false)}
-                fetchInvestigators={getFilteredUsersOfCurrentCounty()}
+                fetchInvestigators={getFilteredUsersOfCurrentCounty}
                 allocateInvestigationToInvestigator={allocateInvestigationToInvestigator}
                 groupIds={[selectedRow.groupId]}
                 epidemiologyNumbers={[selectedRow.epidemiologyNumber]}
@@ -493,7 +491,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                     fetchInvestigationsByGroupId={fetchInvestigationsByGroupId}
                     isInvestigatorAllocationDialogOpen={isInvestigatorAllocationDialogOpen}
                     setIsInvestigatorAllocationDialogOpen={setIsInvestigatorAllocationDialogOpen}
-                    fetchInvestigators={getFilteredUsersOfCurrentCounty()}
+                    fetchInvestigators={getFilteredUsersOfCurrentCounty}
                     allocateInvestigationToInvestigator={allocateInvestigationToInvestigator}
                 />
             </Slide>

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableFooter/InvestigationTableFooter.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableFooter/InvestigationTableFooter.tsx
@@ -194,7 +194,7 @@ interface Props {
     checkedIndexedRows: IndexedInvestigation[];
     allDesks: Desk[];
     allCounties: County[];
-    fetchInvestigators: Promise<InvestigatorOption[]>;
+    fetchInvestigators: () => Promise<InvestigatorOption[]>;
     tableRows: InvestigationTableRow[];
     allGroupedInvestigations: Map<string, InvestigationTableRow[]>;
     isInvestigatorAllocationDialogOpen: boolean;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
@@ -28,7 +28,6 @@ export interface useInvestigationTableParameters {
     currentPage: number;
     allGroupedInvestigations: Map<string, InvestigationTableRow[]>;
     setSelectedRow: React.Dispatch<React.SetStateAction<SelectedRow>>;
-    setAllUsersOfCurrCounty: React.Dispatch<React.SetStateAction<Map<string, User>>>;
     setAllCounties: React.Dispatch<React.SetStateAction<County[]>>;
     setAllStatuses: React.Dispatch<React.SetStateAction<InvestigationMainStatus[]>>;
     setAllDesks: React.Dispatch<React.SetStateAction<Desk[]>>;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -124,8 +124,7 @@ const welcomeMessage = 'היי, אלו הן החקירות שהוקצו לך ה�
 const noInvestigationsMessage = 'היי,אין חקירות לביצוע!';
 
 const useInvestigationTable = (parameters: useInvestigationTableParameters): useInvestigationTableOutcome => {
-    const { setSelectedRow, setAllCounties, setAllUsersOfCurrCounty,
-        setAllStatuses, setAllDesks, currentPage, setCurrentPage, setAllGroupedInvestigations, allGroupedInvestigations,
+    const { setSelectedRow, setAllCounties, setAllStatuses, setAllDesks, currentPage, setCurrentPage, setAllGroupedInvestigations, allGroupedInvestigations,
         investigationColor } = parameters;
 
     const classes = useStyle(false);
@@ -349,8 +348,6 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         if (isLoggedIn) {
             setIsLoading(true);
             if (user.userType === userType.ADMIN || user.userType === userType.SUPER_ADMIN) {
-                const allCountyUsers = await fetchAllCountyUsers();
-                setAllUsersOfCurrCounty(allCountyUsers);
                 fetchAllCounties();
             }
             fetchInvestigationsLogger.info(`launching the selected request to the DB ordering by ${orderBy}`, Severity.LOW);


### PR DESCRIPTION
Fix for bug #1273:

Seems each render of InvestigationTable fired fetchAllCountyUsers() function. now this function is fired when 
nvestigatorAllocationDialog is open. Also, I removed the call for this function when fetching investigation - it seems not in need anymore.
Now app runs a bit faster :)


 
