### PR TITLE
fix(exposures): fixed validations and display

### DIFF
--- a/client/src/commons/AirportTextField/AirportTextField.tsx
+++ b/client/src/commons/AirportTextField/AirportTextField.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import * as yup from 'yup';
+
+import useStyles from './AirportTextFieldStyles';
+import AirportTextFieldType from './AirportTextFieldTypes';
+import TypePreventiveTextField from '../TypingPreventionTextField/TypingPreventionTextField';
+
+const errorMessage = 'השדה יכול להכיל אותיות, רווחים ומקפים';
+const maxLengthErrorMessage = 'השדה יכול להכיל 50 אותיות בלבד';
+
+const airport = yup
+  .string()
+  .matches(/^[a-zA-Z\u0590-\u05fe-\s]*$/, errorMessage)
+  .max(50, maxLengthErrorMessage);
+
+const AirportTextField: AirportTextFieldType = (props) => {
+
+  const classes = useStyles();
+
+  return (
+    <TypePreventiveTextField
+        {...props}
+        value={props.value || ''}
+        validationSchema={airport}
+        InputLabelProps={{
+          className: classes.label,
+        }}
+    />
+  );
+};
+
+export default AirportTextField;

--- a/client/src/commons/AirportTextField/AirportTextField.tsx
+++ b/client/src/commons/AirportTextField/AirportTextField.tsx
@@ -1,27 +1,18 @@
 import React from 'react';
-import * as yup from 'yup';
+
+import AlphabetWithDashTextField from 'commons/AlphabetWithDashTextField/AlphabetWithDashTextField';
 
 import useStyles from './AirportTextFieldStyles';
 import AirportTextFieldType from './AirportTextFieldTypes';
-import TypePreventiveTextField from '../TypingPreventionTextField/TypingPreventionTextField';
-
-const errorMessage = 'השדה יכול להכיל אותיות, רווחים ומקפים';
-const maxLengthErrorMessage = 'השדה יכול להכיל 50 אותיות בלבד';
-
-const airport = yup
-  .string()
-  .matches(/^[a-zA-Z\u0590-\u05fe-\s]*$/, errorMessage)
-  .max(50, maxLengthErrorMessage);
 
 const AirportTextField: AirportTextFieldType = (props) => {
 
   const classes = useStyles();
 
   return (
-    <TypePreventiveTextField
+    <AlphabetWithDashTextField
         {...props}
         value={props.value || ''}
-        validationSchema={airport}
         InputLabelProps={{
           className: classes.label,
         }}

--- a/client/src/commons/AirportTextField/AirportTextFieldStyles.ts
+++ b/client/src/commons/AirportTextField/AirportTextFieldStyles.ts
@@ -1,9 +1,9 @@
 import { makeStyles } from '@material-ui/styles';
 
 const useStyles = makeStyles({
-    flightInputDate: {
-        marginRight: '6vw',
-    },
+    label: {
+        width: '30vw',
+    }
 });
 
 export default useStyles;

--- a/client/src/commons/AirportTextField/AirportTextFieldTypes.ts
+++ b/client/src/commons/AirportTextField/AirportTextFieldTypes.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export interface AirportTextFieldProps<T> {
+    disabled?: boolean,
+    testId?: string,
+    name: string,
+    value: T | null,
+    onChange: (value: string) => void,
+    onBlur?: (event: React.ChangeEvent<{}>) => void,
+    placeholder?: string,
+    label?: string,
+    className?: string,
+}
+
+type AirportTextFieldType = <T>(props: AirportTextFieldProps<T>) => JSX.Element;
+export default AirportTextFieldType;

--- a/client/src/commons/AlphabetWithDashTextField/AlphabetWithDashTextField.tsx
+++ b/client/src/commons/AlphabetWithDashTextField/AlphabetWithDashTextField.tsx
@@ -4,7 +4,7 @@ import * as yup from 'yup';
 import AlphbetWithDashTextFieldType from './AlphabetWithDashTextFieldTypes';
 import TypePreventiveTextField from '../TypingPreventionTextField/TypingPreventionTextField';
 
-const errorMessage = 'השדה יכול להכיל רק אותיות ואת התו -';
+const errorMessage = 'השדה יכול להכיל אותיות, רווחים ומקפים';
 const maxLengthErrorMessage = 'השדה יכול להכיל 50 תווים בלבד';
 
 const stringAlphabetWithDash = yup

--- a/client/src/commons/AlphabetWithDashTextField/AlphabetWithDashTextFieldTypes.ts
+++ b/client/src/commons/AlphabetWithDashTextField/AlphabetWithDashTextFieldTypes.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TextFieldProps } from '@material-ui/core';
 
 export interface AlphabetWithDashTextFieldProps<T> {
     disabled?: boolean,
@@ -10,6 +11,7 @@ export interface AlphabetWithDashTextFieldProps<T> {
     placeholder?: string,
     label?: string,
     className?: string,
+    InputLabelProps?: TextFieldProps['InputLabelProps'];
 }
 
 type AlphabetWithDashTextFieldType = <T>(props: AlphabetWithDashTextFieldProps<T>) => JSX.Element;

--- a/client/src/commons/FlightNumberTextField/FlightNumberTextField.tsx
+++ b/client/src/commons/FlightNumberTextField/FlightNumberTextField.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import * as yup from 'yup';
+
+import FlightNumberTextFieldTypes from './FlightNumberTextFieldTypes';
+import TypePreventiveTextField from '../TypingPreventionTextField/TypingPreventionTextField';
+
+const errorMessage = 'הזנת תו לא תקין';
+const maxLengthErrorMessage = 'השדה יכול להכיל 50 תוים בלבד';
+
+const flightNumberRegex = /^[a-zA-Z0-9-\s//\\]*$/;
+
+export const flightNumber = yup
+  .string()
+  .matches(flightNumberRegex, errorMessage)
+  .max(50, maxLengthErrorMessage);
+
+const FlightNumberTextField: FlightNumberTextFieldTypes = (props) => {
+
+  return (
+    <TypePreventiveTextField
+        {...props}
+        value={props.value || ''}
+        validationSchema={flightNumber}
+    />
+  );
+};
+
+export default FlightNumberTextField;

--- a/client/src/commons/FlightNumberTextField/FlightNumberTextFieldTypes.ts
+++ b/client/src/commons/FlightNumberTextField/FlightNumberTextFieldTypes.ts
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export interface FlightNumberTextFieldProps<T> {
+    testId?: string,
+    name: string,
+    value: T | null,
+    onChange: (value: string) => void,
+    onBlur?: (event: React.ChangeEvent<{}>) => void,
+    placeholder?: string,
+    label?: string,
+    error? : boolean,
+    className?: string,
+    disabled?: boolean,
+}
+
+type FlightNumberTextFieldType = <T>(props: FlightNumberTextFieldProps<T>) => JSX.Element;
+
+export default FlightNumberTextFieldType;

--- a/client/src/commons/InternationalCityTextField/InternationalCityTextField.tsx
+++ b/client/src/commons/InternationalCityTextField/InternationalCityTextField.tsx
@@ -1,23 +1,14 @@
 import React from 'react';
-import * as yup from 'yup';
+
+import AlphabetWithDashTextField from 'commons/AlphabetWithDashTextField/AlphabetWithDashTextField';
 
 import InternationalCityTextFieldType from './InternationalCityTextFieldTypes';
-import TypePreventiveTextField from '../TypingPreventionTextField/TypingPreventionTextField';
-
-const errorMessage = 'השדה יכול להכיל אותיות, רווחים ומקפים';
-const maxLengthErrorMessage = 'השדה יכול להכיל 50 אותיות בלבד';
-
-const internationalCity = yup
-  .string()
-  .matches(/^[a-zA-Z\u0590-\u05fe-\s]*$/, errorMessage)
-  .max(50, maxLengthErrorMessage);
 
 const InternationalCityTextField: InternationalCityTextFieldType = (props) => {
   return (
-    <TypePreventiveTextField
+    <AlphabetWithDashTextField
         {...props}
         value={props.value || ''}
-        validationSchema={internationalCity}
     />
   );
 };

--- a/client/src/commons/InternationalCityTextField/InternationalCityTextField.tsx
+++ b/client/src/commons/InternationalCityTextField/InternationalCityTextField.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import * as yup from 'yup';
+
+import InternationalCityTextFieldType from './InternationalCityTextFieldTypes';
+import TypePreventiveTextField from '../TypingPreventionTextField/TypingPreventionTextField';
+
+const errorMessage = 'השדה יכול להכיל אותיות, רווחים ומקפים';
+const maxLengthErrorMessage = 'השדה יכול להכיל 50 אותיות בלבד';
+
+const internationalCity = yup
+  .string()
+  .matches(/^[a-zA-Z\u0590-\u05fe-\s]*$/, errorMessage)
+  .max(50, maxLengthErrorMessage);
+
+const InternationalCityTextField: InternationalCityTextFieldType = (props) => {
+  return (
+    <TypePreventiveTextField
+        {...props}
+        value={props.value || ''}
+        validationSchema={internationalCity}
+    />
+  );
+};
+
+export default InternationalCityTextField;

--- a/client/src/commons/InternationalCityTextField/InternationalCityTextFieldTypes.ts
+++ b/client/src/commons/InternationalCityTextField/InternationalCityTextFieldTypes.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export interface InternationalCityTextFieldProps<T> {
+    disabled?: boolean,
+    testId?: string,
+    name: string,
+    value: T | null,
+    onChange: (value: string) => void,
+    onBlur?: (event: React.ChangeEvent<{}>) => void,
+    placeholder?: string,
+    label?: string,
+    className?: string,
+}
+
+type InternationalCityTextFieldType = <T>(props: InternationalCityTextFieldProps<T>) => JSX.Element;
+export default InternationalCityTextFieldType;

--- a/client/src/commons/TypingPreventionTextField/TypingPreventionTextFieldTypes.ts
+++ b/client/src/commons/TypingPreventionTextField/TypingPreventionTextFieldTypes.ts
@@ -18,6 +18,7 @@ export interface TypePreventiveTextFieldProps<T> {
     inputProps?: TextFieldProps['inputProps'];
     InputProps?: TextFieldProps['InputProps'];
     onKeyDown? : (e : React.KeyboardEvent) => void;
+    InputLabelProps?: TextFieldProps['InputLabelProps'];
 }
 
 type TypePreventiveTextFieldType = <T>(props: TypePreventiveTextFieldProps<T>) => JSX.Element;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/Forms/FlightsForm/AirportInput/AirportInput.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/Forms/FlightsForm/AirportInput/AirportInput.tsx
@@ -7,8 +7,9 @@ import { Controller, useFormContext } from 'react-hook-form';
 
 import Country from 'models/Country';
 import useFormStyles from 'styles/formStyles';
+import AirportTextField from 'commons/AirportTextField/AirportTextField';
 import AutocompletedField from 'commons/AutoCompletedField/AutocompletedField';
-import AlphanumericTextField from 'commons/AlphanumericTextField/AlphanumericTextField';
+import InternationalCityTextField from 'commons/InternationalCityTextField/InternationalCityTextField';
 
 import useStyles from './AirportInputStyles';
 
@@ -94,7 +95,7 @@ const AirportInput = (props: any) => {
                     defaultValue={city}
                     render={(props) => {
                         return (
-                            <AlphanumericTextField
+                            <InternationalCityTextField
                                 {...props}
                                 onChange={(value) => {
                                     props.onChange(value);
@@ -114,7 +115,7 @@ const AirportInput = (props: any) => {
                     defaultValue={airport}
                     render={(props) => {
                         return (
-                            <AlphanumericTextField
+                            <AirportTextField
                                 {...props}
                                 onChange={(value) => {
                                     props.onChange(value);

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/Forms/FlightsForm/FlightsForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/Forms/FlightsForm/FlightsForm.tsx
@@ -6,20 +6,22 @@ import useFormStyles from 'styles/formStyles';
 import DatePick from 'commons/DatePick/DatePick';
 import FormRowWithInput from 'commons/FormRowWithInput/FormRowWithInput';
 import AlphanumericTextField from 'commons/AlphanumericTextField/AlphanumericTextField';
+import FlightNumberTextField from 'commons/FlightNumberTextField/FlightNumberTextField';
 
+import useStyles from './FlightFormStyles';
 import AirportInput from './AirportInput/AirportInput';
-
 
 const FlightsForm = (props: any) => {
   const { exposureAndFlightsData, fieldsNames, handleChangeExposureDataAndFlightsField, index } = props;
 
   const {control , errors} = useFormContext();
 
-  const classes = useFormStyles();
+  const classes = useStyles();
+  const formClasses = useFormStyles();
 
   const getDateLabel = (dateError : {message? : string , type? : string}) => {
 		if(dateError) {
-			if(dateError.type === "typeError") {
+			if(dateError.type === 'typeError') {
 				return 'תאריך לא ולידי'
 			}
 			return dateError.message;
@@ -32,7 +34,7 @@ const FlightsForm = (props: any) => {
   const endDateError = currentErrors ? currentErrors.flightEndDate : undefined;
 
   return (
-		<Grid className={classes.form} container justify='flex-start'>
+		<Grid className={formClasses.form} container justify='flex-start'>
 			<FormRowWithInput testId='flightStartingPoint' fieldName='מוצא:'>
 				<AirportInput
 					country={exposureAndFlightsData[fieldsNames.originCountry]}
@@ -60,8 +62,8 @@ const FlightsForm = (props: any) => {
 			</FormRowWithInput>
 
 			<FormRowWithInput fieldName='תאריך טיסה:'>
-				<Grid className={classes.inputRow} item container xs={9}  justify='flex-start' alignItems="center" spacing={1}>
-					<Grid item xs={5} lg={3}>
+				<Grid className={formClasses.inputRow} item container xs={9} justify='flex-start' alignItems='center' spacing={1}>
+					<Grid item xs={5} lg={3} className={classes.flightInputDate}>
 						<Typography variant='caption'>מתאריך</Typography>
 						<Controller
 							control={control}
@@ -85,7 +87,7 @@ const FlightsForm = (props: any) => {
 							}}
 						/>
 					</Grid>
-					<Grid item xs={5} lg={3}>
+					<Grid item xs={5} lg={3} className={classes.flightInputDate}>
 					<Typography variant='caption'>עד תאריך</Typography>
 						<Controller
 							control={control}
@@ -139,7 +141,7 @@ const FlightsForm = (props: any) => {
 					defaultValue={exposureAndFlightsData[fieldsNames.flightNumber]}
 					render={(props) => {
 						return (
-							<AlphanumericTextField
+							<FlightNumberTextField
 								{...props}
 								testId='airlineNumber'
 								onChange={(value) => {

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/Schema/flightsValidation.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/Schema/flightsValidation.ts
@@ -3,9 +3,9 @@ import * as yup from 'yup';
 import { subDays } from 'date-fns';
 import { fieldsNames } from 'commons/Contexts/ExposuresAndFlights';
 
-const hebrewAndEnglish = /^[a-zA-Z\u0590-\u05fe\s]*$/;
 const endDateBeforeValidationDateText = 'תאריך לא יכול להיות יותר גדול מתאריך תחילת מחלה';
 const twoWeeksBeforeValidationDateText = 'תאריך לא יכול להיות יותר קטן משבועיים מתאריך תחילת מחלה';
+const requiredErrorMessage = 'שדה חובה';
 
 const flightValidation = (validationDate: Date): yup.Schema<any, object> => {
     return yup.object().shape({
@@ -13,24 +13,23 @@ const flightValidation = (validationDate: Date): yup.Schema<any, object> => {
         [fieldsNames.destinationAirport]: yup
             .string()
             .nullable()
-            .matches(hebrewAndEnglish, 'תווים בעברית ובאנגלית בלבד')
-            .required('שדה חובה'),
-        [fieldsNames.destinationCity]: yup.string().nullable().matches(hebrewAndEnglish, 'תווים בעברית ובאנגלית בלבד').required('שדה חובה'),
-        [fieldsNames.destinationCountry]: yup.string().nullable().required('שדה חובה'),
-        [fieldsNames.flightNumber]: yup.string().nullable(),
-        [fieldsNames.originAirport]: yup.string().nullable().matches(hebrewAndEnglish, 'תווים בעברית ובאנגלית בלבד').required('שדה חובה'),
-        [fieldsNames.originCity]: yup.string().nullable().matches(hebrewAndEnglish, 'תווים בעברית ובאנגלית בלבד').required('שדה חובה'),
-        [fieldsNames.originCountry]: yup.string().nullable().required('שדה חובה'),
+            .required(requiredErrorMessage),
+        [fieldsNames.destinationCity]: yup.string().nullable(),
+        [fieldsNames.destinationCountry]: yup.string().nullable().required(requiredErrorMessage),
+        [fieldsNames.flightNumber]: yup.string().nullable().required(requiredErrorMessage),
+        [fieldsNames.originAirport]: yup.string().nullable().required(requiredErrorMessage),
+        [fieldsNames.originCity]: yup.string().nullable(),
+        [fieldsNames.originCountry]: yup.string().nullable().required(requiredErrorMessage),
         [fieldsNames.flightEndDate]: yup
             .date()
             .nullable()
-            .required('שדה חובה')
+            .required(requiredErrorMessage)
             .max(validationDate, endDateBeforeValidationDateText)
             .min(subDays(new Date(validationDate), 14), twoWeeksBeforeValidationDateText),
         [fieldsNames.flightStartDate]: yup
             .date()
             .nullable()
-            .required('שדה חובה')
+            .required(requiredErrorMessage)
             .max(validationDate, endDateBeforeValidationDateText)
             .min(subDays(new Date(validationDate), 14), twoWeeksBeforeValidationDateText),
     });

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/InteractionSection/TransportationForms/FlightEventForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/InteractionSection/TransportationForms/FlightEventForm.tsx
@@ -9,8 +9,11 @@ import Country from 'models/Country';
 import useFormStyles from 'styles/formStyles';
 import StoreStateType from 'redux/storeStateType';
 import FormInput from 'commons/FormInput/FormInput';
+import AirportTextField from 'commons/AirportTextField/AirportTextField';
 import AlphanumericTextField from 'commons/AlphanumericTextField/AlphanumericTextField';
+import FlightNumberTextField from 'commons/FlightNumberTextField/FlightNumberTextField';
 import TypePreventiveTextField from 'commons/TypingPreventionTextField/TypingPreventionTextField';
+import InternationalCityTextField from 'commons/InternationalCityTextField/InternationalCityTextField';
 import InteractionEventDialogFields from 'models/enums/InteractionsEventDialogContext/InteractionEventDialogFields';
 
 import useStyles from './TransportationFormsStyles';
@@ -39,7 +42,7 @@ const FlightEventForm: React.FC = (): JSX.Element => {
                         name={InteractionEventDialogFields.FLIGHT_NUM}
                         control={control}
                         render={(props) => (
-                            <AlphanumericTextField
+                            <FlightNumberTextField
                                 name={props.name}
                                 value={props.value}
                                 onChange={(newValue: string) => props.onChange(newValue as string)}
@@ -94,7 +97,7 @@ const FlightEventForm: React.FC = (): JSX.Element => {
                             name={InteractionEventDialogFields.FLIGHT_ORIGIN_CITY}
                             control={control}
                             render={(props) => (
-                                <AlphanumericTextField
+                                <InternationalCityTextField
                                     name={props.name}
                                     value={props.value}
                                     onChange={(newValue: string) => props.onChange(newValue as string)}
@@ -108,7 +111,7 @@ const FlightEventForm: React.FC = (): JSX.Element => {
                             name={InteractionEventDialogFields.FLIGHT_ORIGIN_AIRPORT}
                             control={control}
                             render={(props) => (
-                                <AlphanumericTextField
+                                <AirportTextField
                                     name={props.name}
                                     value={props.value}
                                     onChange={(newValue: string) => props.onChange(newValue as string)}
@@ -150,7 +153,7 @@ const FlightEventForm: React.FC = (): JSX.Element => {
                             name={InteractionEventDialogFields.FLIGHT_DESTINATION_CITY}
                             control={control}
                             render={(props) => (
-                                <AlphanumericTextField
+                                <InternationalCityTextField
                                     name={props.name}
                                     value={props.value}
                                     onChange={(newValue: string) => props.onChange(newValue as string)}
@@ -164,7 +167,7 @@ const FlightEventForm: React.FC = (): JSX.Element => {
                             name={InteractionEventDialogFields.FLIGHT_DESTINATION_AIRPORT}
                             control={control}
                             render={(props) => (
-                                <AlphanumericTextField
+                                <AirportTextField
                                     name={props.name}
                                     value={props.value}
                                     onChange={(newValue: string) => props.onChange(newValue as string)}


### PR DESCRIPTION
### This PR contains:
1. the display of the flight dates (for bug [1302](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1302/))
2. fixed the required fields on exposures to be as supposed to be (for bug [1301](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1301/))
3. fixed the validations regexed as supposed to be (for bug [1303](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1303/)). I did it by creating new preventing text fields to airport, international city and flight number. I used that text field in both export and interaction event form