### PR TITLE
centered statuses

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationStatusColumn/InvestigationStatusColumn.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationStatusColumn/InvestigationStatusColumn.tsx
@@ -19,7 +19,7 @@ const InvestigationStatusColumn = (props: Props) => {
     const classes = useStyles();
 
     return (
-        <div className={shouldMarginNonIcon ? classes.marginStatusWithoutIcon : classes.columnWrapper}>
+        <div className={!shouldMarginNonIcon ?  classes.columnWrapper : ""}>
             {
                 investigationStatus.id === InvestigationMainStatusCodes.CANT_COMPLETE && investigationSubStatus &&
                 <Tooltip title={investigationSubStatus} placement='top' arrow>

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationStatusColumn/InvestigationStatusColumn.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationStatusColumn/InvestigationStatusColumn.tsx
@@ -19,7 +19,7 @@ const InvestigationStatusColumn = (props: Props) => {
     const classes = useStyles();
 
     return (
-        <div className={!shouldMarginNonIcon ?  classes.columnWrapper : ""}>
+        <div className={!shouldMarginNonIcon ?  classes.columnWrapper : ''}>
             {
                 investigationStatus.id === InvestigationMainStatusCodes.CANT_COMPLETE && investigationSubStatus &&
                 <Tooltip title={investigationSubStatus} placement='top' arrow>

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationStatusColumn/InvestigationStatusColumnStyles.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationStatusColumn/InvestigationStatusColumnStyles.ts
@@ -4,7 +4,8 @@ import { makeStyles } from '@material-ui/styles';
 const useStyles = makeStyles((theme: Theme) => ({
     columnWrapper: {
         display: 'flex',
-        alignItems: 'center'
+        alignItems: 'center',
+        justifyContent: 'center'
     },
     investigatonIcon: {
         marginLeft: theme.spacing(0.75),

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationStatusColumn/InvestigationStatusColumnStyles.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationStatusColumn/InvestigationStatusColumnStyles.ts
@@ -11,12 +11,6 @@ const useStyles = makeStyles((theme: Theme) => ({
         cursor: 'pointer',
         flip: false
     },
-    marginStatusWithoutIcon: {
-        display: 'flex',
-        alignItems: 'center',
-        flip: false,
-        marginRight: '1.4vw'
-    }
 }));
 
 export default useStyles;


### PR DESCRIPTION
fixes bug [1060](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1060/)

removed class `marginStatusWithoutIcon`
I'm still not sure as to why this class existed in the first place (as the flex and align-items proprety were being used horizontally)
centered all of the status's cells so they would appear like all of the other cells