### PR TITLE
removed 'tabindex' and added eventListener insead

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { Pagination } from '@material-ui/lab';
-import React, { useMemo, useState, useRef } from 'react';
+import React, { useMemo, useState, useRef, useEffect } from 'react';
 import {
     Paper, Table, TableRow, TableBody, TableCell, Typography,
     TableHead, TableContainer, TextField, TableSortLabel, Button,
@@ -253,12 +253,19 @@ const InvestigationTable: React.FC = (): JSX.Element => {
             }
         }
 
+    useEffect(() => {
+        window.addEventListener("keydown", handleEscKey);
+        return () => {
+            window.removeEventListener("keydown", handleEscKey);
+        };
+    }, []);
+
+    const handleEscKey = (e: KeyboardEvent) => {
+        e.key === 'Escape' && closeDropdowns()
+    }
+
     return (
-        <div tabIndex={0}
-            onClick={closeDropdowns}
-            onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) =>
-                event.key === 'Escape' && closeDropdowns()}
-        >
+        <div onClick={closeDropdowns} >
             <Grid className={classes.title} container alignItems='center' justify='space-between'>
                 {
                     (user.userType === userType.ADMIN || user.userType === userType.SUPER_ADMIN) &&


### PR DESCRIPTION
fixes the 'black box' issue at the investigation table ([1334](https://dev.azure.com/spectrumFactory/CoronaI/_sprints/backlog/CoronaI%20Team/CoronaI/Sprint%2013?workitem=1334)

issue was the Tabindex={0} part - it used the user agent stylesheets for tabindex:focus (which is a black border)

moved the 'escape' key listener to the window instead of the div