### PR TITLE
Fixed empty value issue in contact questioning

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningInfo/ReachContact.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningInfo/ReachContact.tsx
@@ -73,9 +73,9 @@ const ReachContact = (props: Props) => {
                                         <TextField
                                             {...params}
                                             placeholder='סטטוס'
-                                            onClick={(event) => {
+                                            onClick={(event) => 
                                                 event.stopPropagation()
-                                            }}
+                                            }
                                             InputProps={{
                                                 ...params.InputProps,
                                                 value: currentValue?.displayName,

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningInfo/ReachContact.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningInfo/ReachContact.tsx
@@ -60,7 +60,6 @@ const ReachContact = (props: Props) => {
                                     getOptionLabel={(option) =>
                                         option.displayName
                                     }
-                                    inputValue={currentValue?.displayName}
                                     value={currentValue}
                                     onChange={(e, data) =>
                                         changeContactStatus(
@@ -74,10 +73,14 @@ const ReachContact = (props: Props) => {
                                         <TextField
                                             {...params}
                                             placeholder='סטטוס'
-                                            onClick={(event) =>
+                                            onClick={(event) => {
                                                 event.stopPropagation()
-                                            }
-                                            InputProps={{...params.InputProps, className: classes.statusAutocompleteRoot}}
+                                            }}
+                                            InputProps={{
+                                                ...params.InputProps,
+                                                value: currentValue?.displayName,
+                                                className: classes.statusAutocompleteRoot
+                                            }}
                                         />
                                     )}
                                 />


### PR DESCRIPTION
issue was that the `{...params.InputProps}`  overrides the default value of the field

fixes [1355](https://dev.azure.com/spectrumFactory/CoronaI/_sprints/backlog/CoronaI%20Team/CoronaI/Sprint%2013?workitem=1355)