### PR TITLE
accurate coronaTestDates

### DIFF
--- a/client/src/Utils/DateUtils/formatDate.ts
+++ b/client/src/Utils/DateUtils/formatDate.ts
@@ -16,8 +16,9 @@ export const formatDateTime = (date: Date): string => {
     ) 
 }
 
+const ISOformatDateIndicator = 'T';
 export const truncateDate = (dateInISO : string): Date => {
-    return new Date(dateInISO.split('T')[0])
+    return new Date(dateInISO.split(ISOformatDateIndicator)[0])
 }
 
 export default formatDate;

--- a/client/src/Utils/DateUtils/formatDate.ts
+++ b/client/src/Utils/DateUtils/formatDate.ts
@@ -16,4 +16,8 @@ export const formatDateTime = (date: Date): string => {
     ) 
 }
 
+export const truncateDate = (dateInISO : string): Date => {
+    return new Date(dateInISO.split('T')[0])
+}
+
 export default formatDate;

--- a/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigatedPersonInfo/InvestigatedPersonInfo.tsx
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigatedPersonInfo/InvestigatedPersonInfo.tsx
@@ -276,7 +276,7 @@ const InvestigatedPersonInfo = (props: Props) => {
                     <Divider />
                     <InfoItemWithIcon testId='examinationDate' name='תאריך תחילת מחלה' value=
                         {
-                            format(new Date(props.coronaTestDate), displayDateFormat)
+                            format(props.coronaTestDate, displayDateFormat)
                         }
                         icon={EventOutlined}
                     />

--- a/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigationInfoBar.tsx
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigationInfoBar.tsx
@@ -8,12 +8,13 @@ import { Severity } from 'models/Logger';
 import UserType from 'models/enums/UserType';
 import { timeout } from 'Utils/Timeout/Timeout';
 import StoreStateType from 'redux/storeStateType';
-import InvestigationInfo , { InvestigationInfoData } from 'models/InvestigationInfo';
 import { defaultEpidemiologyNumber } from 'Utils/consts';
+import { truncateDate } from 'Utils/DateUtils/formatDate';
 import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
 import { setGender } from 'redux/Gender/GenderActionCreators';
 import { CommentContextProvider } from './Context/CommentContext';
 import { landingPageRoute, adminLandingPageRoute } from 'Utils/Routes/Routes';
+import InvestigationInfo , { InvestigationInfoData } from 'models/InvestigationInfo';
 import { setEpidemiologyNum, setLastOpenedEpidemiologyNum, setDatesToInvestigateParams } from 'redux/Investigation/investigationActionCreators';
 import { setInvestigatedPatientId , setIsCurrentlyHospitialized, setIsDeceased, setEndTime } from 'redux/Investigation/investigationActionCreators';
 
@@ -93,8 +94,7 @@ const InvestigationInfoBar: React.FC<Props> = ({ currentTab }: Props) => {
                     setIsCurrentlyHospitialized(investigationInfo.investigatedPatient.isCurrentlyHospitalized);
                     const gender = investigationInfo.investigatedPatient.gender;
                     setGender(gender ? gender : '');
-                    const { coronaTestDate } = investigationInfo;
-                    const formattedTestDate = new Date(coronaTestDate.split('T')[0])
+                    const formattedTestDate = truncateDate(investigationInfo.coronaTestDate)
                     const formattedInvestigationInfo = {
                         ...investigationInfo,
                         coronaTestDate : formattedTestDate

--- a/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigationInfoBar.tsx
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigationInfoBar.tsx
@@ -8,7 +8,7 @@ import { Severity } from 'models/Logger';
 import UserType from 'models/enums/UserType';
 import { timeout } from 'Utils/Timeout/Timeout';
 import StoreStateType from 'redux/storeStateType';
-import InvestigationInfo from 'models/InvestigationInfo';
+import InvestigationInfo , { InvestigationInfoData } from 'models/InvestigationInfo';
 import { defaultEpidemiologyNumber } from 'Utils/consts';
 import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
 import { setGender } from 'redux/Gender/GenderActionCreators';
@@ -87,19 +87,24 @@ const InvestigationInfoBar: React.FC<Props> = ({ currentTab }: Props) => {
             .then((result: any) => {
                 if (result && result.data) {
                     investigationInfoLogger.info('investigation info request was successful', Severity.LOW);
-                    const investigationInfo : InvestigationInfo = result.data;
+                    const investigationInfo : InvestigationInfoData = result.data;
                     setInvestigatedPatientId(investigationInfo.investigatedPatientId);
                     setIsDeceased(investigationInfo.investigatedPatient.isDeceased);
                     setIsCurrentlyHospitialized(investigationInfo.investigatedPatient.isCurrentlyHospitalized);
                     const gender = investigationInfo.investigatedPatient.gender;
                     setGender(gender ? gender : '');
+                    const { coronaTestDate } = investigationInfo;
+                    const formattedTestDate = new Date(coronaTestDate.split('T')[0])
+                    const formattedInvestigationInfo = {
+                        ...investigationInfo,
+                        coronaTestDate : formattedTestDate
+                    }
                     setDatesToInvestigateParams({
                         symptomsStartDate: investigationInfo.symptomsStartDate, 
                         doesHaveSymptoms: investigationInfo.doesHaveSymptoms,
-                        }, investigationInfo.coronaTestDate
-                    )
+                        }, formattedTestDate);
                     setEndTime(investigationInfo.endTime);
-                    setInvestigationStaticInfo(investigationInfo);
+                    setInvestigationStaticInfo(formattedInvestigationInfo);
                 }
                 else {
                     investigationInfoLogger.warn('got status 200 but wrong data', Severity.HIGH);

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/Forms/ExposureForm/useExposureForm.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/Forms/ExposureForm/useExposureForm.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import axios  from 'axios';
+import { addDays } from 'date-fns';
 import { useSelector } from 'react-redux';
 
 import logger from 'logger/logger';
@@ -20,7 +21,7 @@ const useExposureForm = (props: Props) => {
     const { alertError } = useCustomSwal();
 
     const validationDate = useSelector<StoreStateType, Date>((state) => state.investigation.validationDate);
-
+    const formattedValidationDate = addDays(validationDate , 1).toISOString() // the date is rounded down so we need to ceil it 
     const { exposureAndFlightsData, exposureSourceSearchString , setOptionalPatientsLoading} = props;
 
     const minSourceSearchLengthToSearch: number = 2;
@@ -32,11 +33,11 @@ const useExposureForm = (props: Props) => {
             const confirmedExposuresLogger = logger.setup('Fetching list of confirmed exposures');
             setOptionalPatientsLoading(true);
             confirmedExposuresLogger.info(
-                `launching request with parameters ${exposureSourceSearchString} and ${validationDate}`,
+                `launching request with parameters ${exposureSourceSearchString} and ${formattedValidationDate}`,
                 Severity.LOW
             );
             const optionalCovidPatients = await axios
-                .get(`/exposure/optionalExposureSources/${exposureSourceSearchString}/${validationDate}`)
+                .get(`/exposure/optionalExposureSources/${exposureSourceSearchString}/${formattedValidationDate}`)
                 .then((result) => {
                     if (result?.data && result.headers['content-type'].includes('application/json')) {
                         confirmedExposuresLogger.info('got results back from the server', Severity.LOW);

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -395,7 +395,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
     }
 
     const getFormattedDate = (date: string) => {
-        return format(new Date(date), 'dd/MM')
+        return format(new Date(date.split('T')[0]), 'dd/MM')
     };
 
     const fetchTableData = async () => {

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -16,6 +16,7 @@ import Investigator from 'models/Investigator';
 import StoreStateType from 'redux/storeStateType';
 import { BC_TABS_NAME } from 'models/BroadcastMessage';
 import usePageRefresh from 'Utils/vendor/usePageRefresh';
+import { truncateDate } from 'Utils/DateUtils/formatDate';
 import InvestigatorOption from 'models/InvestigatorOption';
 import { defaultTimeRange } from 'models/enums/timeRanges';
 import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
@@ -395,7 +396,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
     }
 
     const getFormattedDate = (date: string) => {
-        return format(new Date(date.split('T')[0]), 'dd/MM')
+        return format(truncateDate(date), 'dd/MM')
     };
 
     const fetchTableData = async () => {

--- a/client/src/models/InvestigationInfo.ts
+++ b/client/src/models/InvestigationInfo.ts
@@ -15,4 +15,8 @@ interface InvestigationInfo extends SymptomsExistenceInfo {
     endTime: Date | null;
 }
 
+export interface InvestigationInfoData extends Omit<InvestigationInfo , "coronaTestDate">{
+    coronaTestDate: string;
+}
+
 export default InvestigationInfo;


### PR DESCRIPTION
## The issue
dates are being sent from the API in ISO format (e.g. "2020-11-19T20:00:00.000Z"), those dates are later being formatted to a Date object by JS's new Date() function,
JS's Date() constructor **rounds** those datetimes to dates so "2020-11-19T20:00:00.000Z" now becomes "2020-11-20T00:00:00.000Z" which is displayed in the entirety of the project ( 😱 )
## The solution
instead of rounding , I've added a pre-emptive floor to the date (by using .split('T')[0]) and then formatting the date, and added a ceil to the search (so in this example searching from  2020-11-20T00:00:00.000Z instead of  2020-11-19T00:00:00.000Z)

fixes [1340](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1340/)