### PR TITLE
Fix(self-investigation-icon-toolTip):make icon toolTip not clickable

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationIndicatorsColumn/SelfInvestigationIcon/SelfInvestigationIcon.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationIndicatorsColumn/SelfInvestigationIcon/SelfInvestigationIcon.tsx
@@ -18,7 +18,7 @@ const SelfInvestigationIcon = (props: Props) => {
 	const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
 
 	const classes = useStyles();
-	const handleTooltipClose = (e : React.MouseEvent<Document, MouseEvent>) => {
+	const handleTooltipClose = (e: any) => {
 		e.stopPropagation();
 		setIsTooltipOpen(false);
 		setAnchorEl(null);
@@ -41,6 +41,7 @@ const SelfInvestigationIcon = (props: Props) => {
                 anchorEl={anchorEl}
                 open={isTooltipOpen}
                 onClose={handleTooltipClose}
+                onClick={handleTooltipClose}
                 anchorOrigin={{
                     vertical: 'bottom',
                     horizontal: 'right',


### PR DESCRIPTION
Fix to: [1368](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1368/)

Now when toolTip opens when you click on it you get transferred to the investigation page, after fix when you click the toolTip get closed.