### PR TITLE
Fixed error on empty fields on /saveClinicalDetails

### DIFF
--- a/server/src/ClientToDBAPI/ClinicalDetailsRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/ClinicalDetailsRoute/mainRoute.ts
@@ -229,7 +229,6 @@ clinicalDetailsRoute.post('/saveClinicalDetails', (request: Request, response: R
         
         const parameters = {id: isolationAddressId, addressPatch: isolationAddress};
         updateAddressLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
-        console.log(parameters);
         graphqlRequest(UPDATE_ADDRESS, response.locals, parameters)
         .then(result => {
             updateAddressLogger.info(validDBResponseLog, Severity.LOW);

--- a/server/src/ClientToDBAPI/ClinicalDetailsRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/ClinicalDetailsRoute/mainRoute.ts
@@ -6,7 +6,7 @@ import Investigation from '../../Models/ClinicalDetails/Investigation';
 import CreateAddressResponse from '../../Models/Address/CreateAddress';
 import { errorStatusCode, graphqlRequest } from '../../GraphqlHTTPRequest';
 import ClinicalDetails from '../../Models/ClinicalDetails/ClinicalDetails';
-import { formatToInsertAndGetAddressIdInput } from '../../Utils/addressUtils';
+import { formatToInsertAndGetAddressIdInput, formatToNullable} from '../../Utils/addressUtils';
 import InsertAndGetAddressIdInput from '../../Models/Address/InsertAndGetAddressIdInput';
 import logger, { invalidDBResponseLog, launchingDBRequestLog, validDBResponseLog } from '../../Logger/Logger';
 import { calculateInvestigationComplexity } from '../../Utils/InvestigationComplexity/InvestigationComplexity';
@@ -203,15 +203,14 @@ const saveClinicalDetails = (request: Request, response: Response, baseLog: Init
 
 clinicalDetailsRoute.post('/saveClinicalDetails', (request: Request, response: Response) => {
     const isolationAddressId = request.body.clinicalDetails?.isolationAddressId;
-    const isolationAddress = request.body.clinicalDetails?.isolationAddress;
     const logData = {
         workflow: `saving clinical details tab`,
         investigation: response.locals.epidemiologynumber,
         user: response.locals.user.id
     };
-
-    const requestAddress: InsertAndGetAddressIdInput = formatToInsertAndGetAddressIdInput(isolationAddress);
+    const isolationAddress = formatToNullable(request.body.clinicalDetails?.isolationAddress);
     if (!isolationAddressId) {
+        const requestAddress: InsertAndGetAddressIdInput = formatToInsertAndGetAddressIdInput(isolationAddress);
         const createAddressLogger = logger.setup({...logData, workflow: `${logData.workflow}: create isolation address`})
 
         const parameters = {input: requestAddress};
@@ -227,10 +226,10 @@ clinicalDetailsRoute.post('/saveClinicalDetails', (request: Request, response: R
         });
     } else {
         const updateAddressLogger = logger.setup({...logData, workflow: `${logData.workflow}: update isolation address`})
-
+        
         const parameters = {id: isolationAddressId, addressPatch: isolationAddress};
         updateAddressLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
-
+        console.log(parameters);
         graphqlRequest(UPDATE_ADDRESS, response.locals, parameters)
         .then(result => {
             updateAddressLogger.info(validDBResponseLog, Severity.LOW);

--- a/server/src/Utils/addressUtils.ts
+++ b/server/src/Utils/addressUtils.ts
@@ -10,9 +10,9 @@ export const formatToInsertAndGetAddressIdInput = (address: Address) :  InsertAn
 
 export const formatToNullable = (address : Address): Address => {
     return {
-        city : address.city !== '' ? address.city : null,
-        street : address.street !== '' ? address.street : null, 
-        houseNum : address.houseNum !== '' ? address.houseNum : null, 
-        floor : address.floor !== '' ? address.floor : null, 
+        city : address.city || null,
+        street : address.street || null, 
+        houseNum : address.houseNum || null, 
+        floor : address.floor || null, 
     }
 } 

--- a/server/src/Utils/addressUtils.ts
+++ b/server/src/Utils/addressUtils.ts
@@ -7,3 +7,12 @@ export const formatToInsertAndGetAddressIdInput = (address: Address) :  InsertAn
     floorValue: address.floor || null,
     houseNumValue: address.houseNum || null,
 });
+
+export const formatToNullable = (address : Address): Address => {
+    return {
+        city : address.city !== '' ? address.city : null,
+        street : address.street !== '' ? address.street : null, 
+        houseNum : address.houseNum !== '' ? address.houseNum : null, 
+        floor : address.floor !== '' ? address.floor : null, 
+    }
+} 


### PR DESCRIPTION
# the issue
With the addition of #1115 the state of an empty isolationAddress  was { city : '', street : '' , floor : '' , housenum : ''}
the problem was that in the Address table the fields city and street were nullable and had FK constraint to their respective table.
# the solution
added a new formatting function `formatToNullable` that takes those fields and formats empty fields to nulls
reasoning is that now the form is a generic components and this is the only exception where those fields need to be either nullable or FK.

fixes [1372](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1372/)