### PR TITLE
fixed null contact statuses

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningInfo/ReachContact.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningInfo/ReachContact.tsx
@@ -29,11 +29,11 @@ const ReachContact = (props: Props) => {
 
     const watchContactStatus = watch(`form[${index}].contactStatus`)
     const currentContactStatus = watchContactStatus ? watchContactStatus : formValues.contactStatus;
-
-    const currentValue = contactStatuses.find(
+    const foundValue = contactStatuses.find(
         (contactStatus: ContactStatus) =>
             contactStatus.id === currentContactStatus
     );
+    const currentValue = foundValue || { id : -1 , displayName : "..."}
     const { isFieldDisabled } = useContactFields(formValues.contactStatus);
 
     const { changeContactStatus } = useReachContact({


### PR DESCRIPTION
continuing #1113 it appears that _sometimes_ the contactStatus state is empty when the object is initialized - leading to an `undefined` value that is moved on to the form value and messes up the form's state.

added an exception to catch the undefined value and added a temporary "loading" value