### PR TITLE
fix/blank isolationAddress Fields 

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningClinical.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningClinical.tsx
@@ -67,15 +67,15 @@ const ContactQuestioningClinical: React.FC<Props> = (props: Props): JSX.Element 
 
     useEffect(() => {
         if (isFieldDisabled) {
-            setValue(`form[${index}].${InteractedContactFields.ISOLATION_ADDRESS}.${InteractedContactFields.CONTACTED_PERSON_CITY}`, interactedContact.isolationAddress?.city?.id);
-            setValue(`form[${index}].${InteractedContactFields.ISOLATION_ADDRESS}.${InteractedContactFields.CONTACTED_PERSON_STREET}`, interactedContact.isolationAddress?.street?.id);
-            setValue(`form[${index}].${InteractedContactFields.ISOLATION_ADDRESS}.${InteractedContactFields.CONTACTED_PERSON_HOUSE_NUMBER}`, interactedContact.isolationAddress?.houseNum);
-            setValue(`form[${index}].${InteractedContactFields.ISOLATION_ADDRESS}.${InteractedContactFields.CONTACTED_PERSON_APARTMENT_NUMBER}`, interactedContact.isolationAddress?.apartment);
-        } else {
-            setValue(`form[${index}].${InteractedContactFields.ISOLATION_ADDRESS}.${InteractedContactFields.CONTACTED_PERSON_CITY}`, null);
-            setValue(`form[${index}].${InteractedContactFields.ISOLATION_ADDRESS}.${InteractedContactFields.CONTACTED_PERSON_STREET}`, null);
-            setValue(`form[${index}].${InteractedContactFields.ISOLATION_ADDRESS}.${InteractedContactFields.CONTACTED_PERSON_HOUSE_NUMBER}`, null);
-            setValue(`form[${index}].${InteractedContactFields.ISOLATION_ADDRESS}.${InteractedContactFields.CONTACTED_PERSON_APARTMENT_NUMBER}`, null);
+            setValue(
+                `form[${index}].${InteractedContactFields.ISOLATION_ADDRESS}`, 
+                {
+                    [InteractedContactFields.CONTACTED_PERSON_CITY] : interactedContact.isolationAddress?.city?.id,
+                    [InteractedContactFields.CONTACTED_PERSON_STREET] : interactedContact.isolationAddress?.street?.id,
+                    [InteractedContactFields.CONTACTED_PERSON_HOUSE_NUMBER] : interactedContact.isolationAddress?.houseNum,
+                    [InteractedContactFields.CONTACTED_PERSON_APARTMENT_NUMBER] : interactedContact.isolationAddress?.apartment,
+                }
+            )
         }
     }, [isFieldDisabled])
 


### PR DESCRIPTION
fixes [1385](https://dev.azure.com/spectrumFactory/CoronaI/_sprints/backlog/CoronaI%20Team/CoronaI/Sprint%2013?workitem=1385)

the issue was that because of  #1115  all of the fields were set to null if they weren't disabled
removed the exception and re-formatted it to run only once.