### PR TITLE
fix/blank addresses on contact questioning

### DIFF
--- a/client/src/commons/Forms/AddressForm/AddressForm.tsx
+++ b/client/src/commons/Forms/AddressForm/AddressForm.tsx
@@ -70,7 +70,7 @@ const AddressForm: React.FC<Props> = ({
                                 options={Array.from(cities, ([id, value]) => ({ id, value }))}
                                 getOptionLabel={(option) => option ? option.value.displayName : option}
                                 value={props.value && {id: props.value as string, value: cities.get(props.value) as City}}
-                                onChange={(event, selectedCity) => props.onChange(selectedCity ? selectedCity.id : '')}
+                                onChange={(event, selectedCity) => props.onChange(selectedCity ? selectedCity.id : null)}
                                 renderInput={(params) =>
                                     <TextField
                                         test-id={cityField.testId || ''}

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningClinical.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningClinical.tsx
@@ -47,12 +47,12 @@ const ContactQuestioningClinical: React.FC<Props> = (props: Props): JSX.Element 
             name: `form[${index}].${InteractedContactFields.ISOLATION_ADDRESS}.${InteractedContactFields.CONTACTED_PERSON_CITY}`, 
             className: classes.addressTextField, 
             testId: 'contactedPersonCity',
-            defaultValue: interactedContact.isolationAddress?.city?.id
+            defaultValue: interactedContact.isolationAddress?.city?.id || null
         },
         streetField: {
             name: `form[${index}].${InteractedContactFields.ISOLATION_ADDRESS}.${InteractedContactFields.CONTACTED_PERSON_STREET}`, 
             className: classes.addressTextField,
-            defaultValue: interactedContact.isolationAddress?.street?.id
+            defaultValue: interactedContact.isolationAddress?.street?.id  || null
         },
         houseNumberField: {
             name: `form[${index}].${InteractedContactFields.ISOLATION_ADDRESS}.${InteractedContactFields.CONTACTED_PERSON_HOUSE_NUMBER}`,


### PR DESCRIPTION
## the issue 
the issue was that if the address is empty the server would send the isolationAddress object like this : { isolationAddress { city : {} , street : null ...} and the client expects city/street's ID.
also if you've erased the existing city the server would be sent { city : ""} instead of {city : null}

## the solution 
added a null exception if the city/street's ID was undefined
changed '' to null in the city field in the form itself