### PR TITLE
Fix/admin landing page css refactor

### DIFF
--- a/client/src/commons/DatePick/DatePickStyles.ts
+++ b/client/src/commons/DatePick/DatePickStyles.ts
@@ -9,9 +9,6 @@ export const useStyles = makeStyles({
         '& .MuiSvgIcon-root': {
             fontSize: 'small'
         },
-        '& .MuiInputBase-input': {
-            fontSize: '1vw'
-        },
     },
     label: {
         width: '40vw',

--- a/client/src/commons/DatePick/DateRangePick.tsx
+++ b/client/src/commons/DatePick/DateRangePick.tsx
@@ -10,7 +10,7 @@ const DateRangePick: React.FC<Props> = (props: Props): JSX.Element => {
     const classes = useStyles();
 
     return (
-        <Grid container alignItems='center' xs={12} justify='space-between'>
+        <Grid container alignItems='center' xs={12} spacing={1}>
             <Grid item xs={5} className={classes.dateItem}>
                 <DatePick
                     minDate={minDate}
@@ -19,8 +19,8 @@ const DateRangePick: React.FC<Props> = (props: Props): JSX.Element => {
                     onChange={onStartDateChange}
                 />
             </Grid>
-            <Grid item xs={1}>
-                <Typography className={classes.text}>עד</Typography>
+            <Grid item xs={2}>
+                <Typography align='center'>עד</Typography>
             </Grid>
             <Grid item xs={5} className={classes.dateItem}>
                 <DatePick

--- a/client/src/commons/DatePick/DateRangePickStyles.ts
+++ b/client/src/commons/DatePick/DateRangePickStyles.ts
@@ -7,9 +7,6 @@ export const useStyles = makeStyles({
             margin: '0 0.2vw',
         }
     },
-    text: {
-        fontSize: '1vw'
-    }
 });
 
 export default useStyles;

--- a/client/src/commons/Select/SelectDropdown.tsx
+++ b/client/src/commons/Select/SelectDropdown.tsx
@@ -10,7 +10,6 @@ const SelectDropdown: React.FC<Props> = (props: Props): JSX.Element => {
 
     return (
         <Select
-            classes={{ select: classes.muiSelect}}
             MenuProps={{
                 anchorOrigin: {
                     vertical: "bottom",

--- a/client/src/commons/Select/SelectDropdownStyles.ts
+++ b/client/src/commons/Select/SelectDropdownStyles.ts
@@ -4,9 +4,6 @@ const useStyles = makeStyles({
     menuItem: {
         height: '2vw'
     },
-    muiSelect: {
-        fontSize: '1vw'
-    },
 });
 
 export default useStyles;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableStyles.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableStyles.ts
@@ -14,7 +14,6 @@ export const useTooltipStyles = makeStyles(({
 
 const useStyles = (isWide: boolean) => makeStyles((theme: Theme) => ({
     content: {
-        height: '80vh',
         backgroundColor: '#F3F6FB',
         display: 'flex',
         justifyContent: 'flex-start',
@@ -37,7 +36,7 @@ const useStyles = (isWide: boolean) => makeStyles((theme: Theme) => ({
         marginBottom: '2vh'
     },
     welcomeMessage: {
-        fontSize: '4vh',
+        fontSize: '2vw',
     },
     errorAlertTitle: {
         fontFamily: 'Assistant'

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/TimeRangeFilterCard/TimeRangeFilterCardStyles.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/TimeRangeFilterCard/TimeRangeFilterCardStyles.ts
@@ -4,20 +4,17 @@ import theme from 'styles/theme';
 
 const useStyles = makeStyles({
     timeRangeCard: {
-        width: '20vw',
         borderRadius: '1vw',
     },
     cardTitle: {
-        fontSize: '0.9vw',
         marginBottom: theme.spacing(1)
     },
     timeRangeCardContent: {
         height: '36%',
     },
     dateRangeCardContent: {
-        paddingTop: 0,
+        paddingTop: theme.spacing(1),
         paddingBottom: 0,
-        width: '18vw'
     },
     collapse: {
         height: '36%',

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/UnallocatedCard/UnallocatedCard.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/UnallocatedCard/UnallocatedCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Tooltip, Typography } from '@material-ui/core';
+import { Tooltip, Typography, Box } from '@material-ui/core';
 import NavigateBeforeIcon from '@material-ui/icons/NavigateBefore';
 
 import FilterRulesVariables from 'models/FilterRulesVariables';
@@ -8,7 +8,7 @@ import FilterRulesDescription from 'models/enums/FilterRulesDescription';
 
 import useHoverStyles from '../useHoverStyles';
 import LoadingCard from '../LoadingCard/LoadingCard';
-import useStyles, { cardHeight, cardWidth } from './UnallocatedCardStyles';
+import useStyles, { cardHeight } from './UnallocatedCardStyles';
 
 const unallocatedInvestigationsText = 'חקירות לא משויכות/ משויכות לחוקרים לא פעילים';
 
@@ -19,17 +19,17 @@ const UnallocatedCard: React.FC<Props> = (props: Props): JSX.Element => {
     const { onClick, isLoading, unallocatedInvestigationsCount } = props;
 
     return (
-        <LoadingCard isLoading={isLoading} width={cardWidth} height={cardHeight} className={[classes.unallocatedCard, hoverClasses.whiteButtons].join(' ')}>
+        <LoadingCard isLoading={isLoading} height={cardHeight} className={[classes.unallocatedCard, hoverClasses.whiteButtons].join(' ')}>
             <Tooltip title={unallocatedInvestigationsText}>
                 <div onClick={() => onClick(statusToFilterConvertor[FilterRulesDescription.UNALLOCATED])}>
                     <div className={classes.investigationAmount}>
                         <Typography className={classes.investigationNumberText}><b>{unallocatedInvestigationsCount}</b></Typography>
                         <Typography className={classes.investigationAmountText}><b>חקירות</b></Typography>
                     </div>
-                    <div className={classes.unallocatedInvestigations}>
-                        <Typography className={classes.unallocatedInvestigationsText}><b>{FilterRulesDescription.UNALLOCATED}</b></Typography>
+                    <Box display='flex'>
+                        <Typography><b>{FilterRulesDescription.UNALLOCATED}</b></Typography>
                         <NavigateBeforeIcon className={classes.navigateIcon} />
-                    </div>
+                    </Box>
                 </div>
             </Tooltip>
         </LoadingCard>

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/UnallocatedCard/UnallocatedCardStyles.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/UnallocatedCard/UnallocatedCardStyles.ts
@@ -1,35 +1,23 @@
 import { makeStyles } from '@material-ui/styles';
 
-export const cardWidth = '14vw';
 export const cardHeight = '8vh';
 
 const useStyles = makeStyles({
     unallocatedCard: {
-        width: cardWidth,
         height: cardHeight,
         borderRadius: '1vw',
-        padding: '1vw',
+        padding: '1vh 1vw',
         cursor: 'pointer',
     },
     investigationAmount: {
+        fontSize: '1.2vw',
         display: 'flex',
     },
     investigationNumberText: {
-        fontSize: '1.2vw',
         color: '#F95959',
         marginRight: '0.8vw',
     },
     investigationAmountText: {
-        fontSize: '1.2vw',
-    },
-    unallocatedInvestigations: {
-        display: 'flex',
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        width: '13vw',
-    },
-    unallocatedInvestigationsText: {
-        fontSize: '1.2vw',
     },
     navigateIcon: {
         backgroundColor: 'WhiteSmoke',

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/adminLandingPage.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/adminLandingPage.tsx
@@ -38,32 +38,32 @@ const AdminLandingPage: React.FC = (): JSX.Element => {
     return (
         <div className={classes.content}>
             <Grid container spacing={5} className={classes.gridContainer}>
-                <Grid item xs={3}>
-                    <Typography color='textPrimary' className={classes.countyDisplayName}>
+                <Grid item xs={6} md={3}>
+                    <Typography color='textPrimary'>
                         <b>{'נפת ' + countyDisplayName}</b>
                     </Typography>
                 </Grid>
-                <Grid item xs={9}>
+                <Grid item xs={6} md={9}>
                     <LastUpdateMessage lastUpdated={lastUpdated} fetchInvestigationStatistics={fetchInvestigationStatistics}/>
                 </Grid>
-                <Grid item xs={3}>
+                <Grid item xs={12} md={3}>
                     <DesksFilterCard
                         onUpdateButtonClicked={updateInvestigationFilterByDesks}
                     />
                 </Grid>
-                <Grid item xs={9}>
+                <Grid item xs={12} md={9}>
                     <InvestigationsInfo
                         isLoading={isLoading}
                         allInvestigationsCount={investigationsStatistics.allInvestigations}
                         investigationsStatistics={investigationsStatistics as InvesitgationInfoStatistics}
                         onInfoButtonClick={(infoFilter, filterType) => redirectToInvestigationTable(infoFilter, filterType)} />
                 </Grid>
-                <Grid item xs={3}>
+                <Grid item xs={6} md={3}>
                     <TimeRangeFilterCard 
                         onUpdateButtonClicked={updateInvestigationFilterByTime}
                     />
                 </Grid>
-                <Grid item xs={3}>
+                <Grid item xs={6} md={3}>
                     <UnallocatedCard
                         isLoading={isLoading}
                         onClick={(infoFilter) => redirectToInvestigationTable(infoFilter, FilterRulesDescription.UNALLOCATED)} 

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/adminLandingPageStyles.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/adminLandingPageStyles.ts
@@ -6,8 +6,6 @@ const useStyles = makeStyles({
         flexDirection: 'column',
         padding: '0 3vw',
     },
-    countyDisplayName: {
-    },
     gridContainer: {
         paddingTop: '3vh',
     }

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/adminLandingPageStyles.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/adminLandingPageStyles.ts
@@ -1,17 +1,12 @@
 import { makeStyles } from '@material-ui/styles';
 
-import { primaryBackgroundColor } from 'styles/theme';
-
 const useStyles = makeStyles({
     content: {
         display: 'flex',
         flexDirection: 'column',
-        padding: '5vh 3vw',
-        height: '93.5vh',
-        backgroundColor: primaryBackgroundColor,
+        padding: '0 3vw',
     },
     countyDisplayName: {
-        fontSize: '1.5vw',
     },
     gridContainer: {
         paddingTop: '3vh',

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCard.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCard.tsx
@@ -23,7 +23,7 @@ const DesksFilterCard = (props : Props): JSX.Element => {
         <LoadingCard isLoading={isLoading} width={cardWidth} height={cardHeight} className={classes.desksCard}>
             <CardContent>
                 <Box display='flex' flexDirection='column' className={classes.desksCardContent}>
-                <Typography variant='h6' className={classes.cardTitle}>
+                <Typography variant='h6'>
                     <b>הדסקים בהם הינך צופה</b>
                 </Typography>
                     <CustomCheckbox

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCardStyles.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCardStyles.ts
@@ -11,9 +11,6 @@ const useStyles = makeStyles({
     desksCardContent: {
         height: '30vh',
     },
-    cardTitle: {
-
-    },
     desksCardActions: {
         direction: 'ltr', 
         paddingLeft: '1vw',

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCardStyles.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCardStyles.ts
@@ -5,7 +5,6 @@ export const cardHeight = '35vh';
 
 const useStyles = makeStyles({
     desksCard: {
-        width: '20vw',
         height: '35vh',
         borderRadius: '1vw',
     },
@@ -13,7 +12,7 @@ const useStyles = makeStyles({
         height: '30vh',
     },
     cardTitle: {
-        fontSize: '0.9vw',
+
     },
     desksCardActions: {
         direction: 'ltr', 

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/investigationsInfo/investigationInfoButton/investigationInfoButton.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/investigationsInfo/investigationInfoButton/investigationInfoButton.tsx
@@ -19,8 +19,8 @@ const InvestigationInfoButton: React.FC<Props> = (props: Props): JSX.Element => 
                 size='large'
             >
                 <div>
-                    <Typography className={classes.amountOfInvestigations}><b>{amountOfInvestigations}</b></Typography>
-                    <Typography className={classes.text}><b>{text}</b></Typography>
+                    <Typography><b>{amountOfInvestigations}</b></Typography>
+                    <Typography><b>{text}</b></Typography>
                 </div>
             </Button>
         </>

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/investigationsInfo/investigationInfoButton/investigationInfoButtonStyles.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/investigationsInfo/investigationInfoButton/investigationInfoButtonStyles.ts
@@ -6,7 +6,7 @@ const useStyles = makeStyles({
         borderRadius: '0.8vw',
         padding: '1vw 1vh',
         margin: '0 1vw',
-        flexBasis: '0',
+        flexBasis: 0,
         flexGrow: 1,
         height: '10vh'
     },

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/investigationsInfo/investigationInfoButton/investigationInfoButtonStyles.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/investigationsInfo/investigationInfoButton/investigationInfoButtonStyles.ts
@@ -3,15 +3,12 @@ import { makeStyles } from '@material-ui/styles';
 const useStyles = makeStyles({
     button: {
         color: 'white',
-        height: '11vh',
-        width: '9.6vw',
         borderRadius: '0.8vw',
-    },
-    amountOfInvestigations: {
-        fontSize: '1.5vw',
-    },
-    text: {
-        fontSize: '0.95vw',
+        padding: '1vw 1vh',
+        margin: '0 1vw',
+        flexBasis: '0',
+        flexGrow: 1,
+        height: '10vh'
     },
 });
 

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/investigationsInfo/investigationsInfo.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/investigationsInfo/investigationsInfo.tsx
@@ -50,10 +50,11 @@ const InvestigationsInfo: React.FC<Props> = (props: Props): JSX.Element => {
         <LoadingCard isLoading={isLoading} height={cardHeight} className={classes.filtersCard}>
             <CardContent>
                 <Grid container>
-                    <Grid item xs={12} className={classes.investigationInfoButtonWrapper}>
-                        <div className={classes.investigationsGraphContainer}>
+                    <Grid item container xs={12} alignItems='flex-end' justify='space-around'>
+                        <Grid item xs={3} className={classes.investigationsGraphContainer}>
                             <InvestigationBarChart investigationsGraphData={investigationsGraphData} />
-                        </div>
+                        </Grid>
+                        <Grid item container alignItems='flex-end' justify='space-around' spacing={1} xs={9}>
                         {
                             investigationsGraphData.map((InvestigationData: InvestigationChart) => (
                                 <InvestigationInfoButton
@@ -64,10 +65,11 @@ const InvestigationsInfo: React.FC<Props> = (props: Props): JSX.Element => {
                                 />
                             ))
                         }
+                        </Grid>
                     </Grid>
                     <Grid item xs={12} className={[classes.investigationAmountContainer, hoverClasses.whiteButtons].join(' ')}>
                         <Typography className={classes.investigationAmountText}><b>{allInvestigationsCount}</b></Typography>
-                        <Typography className={classes.allInvestigationsText}><b>חקירות בסך הכל</b></Typography>
+                        <Typography><b>חקירות בסך הכל</b></Typography>
                         <IconButton onClick={() => onInfoButtonClick({})}>
                             <NavigateBeforeIcon className={classes.navigateIcon} />
                         </IconButton>

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/investigationsInfo/investigationsInfoStyles.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/investigationsInfo/investigationsInfoStyles.ts
@@ -26,12 +26,8 @@ const useStyles = makeStyles({
         flip: false,
     },
     investigationAmountText: {
-        fontSize: '1.5vw',
         marginLeft: '0.3vw',
         flip: false
-    },
-    allInvestigationsText: {
-        fontSize: '1.3vw',
     },
     navigateIcon: {
         backgroundColor: 'WhiteSmoke',

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -6,4 +6,5 @@ body {
 html, body, #root {
     height: 100%;
     width: 100%;
+    background-color: #F3F6FB;
 }


### PR DESCRIPTION
Fixes a couple of issues :
## scaling
- removed dynamic font size - talked with laly about this - when its big it looks too big and when it's small it looks to small, otherwise there's really no reason to do this in anything other than headlines*
- added a new xs-sm grid sizes so that things like desk filter and county headline would look more reasonable with small screens 
before : ![image](https://user-images.githubusercontent.com/68457306/104433566-eaee3d00-5592-11eb-8c6a-d06aed2728cb.png)
after : ![image](https://user-images.githubusercontent.com/68457306/104433833-33a5f600-5593-11eb-80b1-dd7ccc38533b.png)
- removed 'vh' values from contents - the 'vh' values for content size would at best proved a tiny overflow that created a scrollbar even though there shouldn't be one or at worst created a white space underneath the page. this is because the appBar is a constant px size and the page is a dynamic 'vh' size - so I've removed the dynamic vh size from the page so that the height of 'content' would be the height of it's content and added the background color to the _already_ 100% body element.



## formatting 
- removed unnecessary classes that provide existing values (like display='flex' for a grid container) and replaced 'flex' classes with mui's <Box />