### PR TITLE
added optional covid patients reset when search query is empty

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/Forms/ExposureForm/ExposureForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/Forms/ExposureForm/ExposureForm.tsx
@@ -48,6 +48,12 @@ const ExposureForm = (props: Props) => {
 	}, [exposureAndFlightsData.exposureSource]);
 
 	useEffect(() => {
+		if(exposureSourceSearchString === "") {
+			setOptionalCovidPatients([]);
+		}
+	}, [exposureSourceSearchString])
+
+	useEffect(() => {
 		setValue(`exposures[${index}].${fieldsNames.placeType}`, exposureAndFlightsData[fieldsNames.placeType])
 		setValue(`exposures[${index}].${fieldsNames.placeSubType}`, exposureAndFlightsData[fieldsNames.placeSubType])
 	}, []);
@@ -97,7 +103,7 @@ const ExposureForm = (props: Props) => {
 				/>
 			</FormRowWithInput>
 
-			{((isOptionalPatientsLoading || optionalCovidPatients?.length > 0) && exposureSourceSearchString !== '') && (
+			{(isOptionalPatientsLoading || optionalCovidPatients?.length > 0) && (
 				<FormRowWithInput fieldName=''>
 					<div className={classes.optionalExposureSources}>
 						{isOptionalPatientsLoading ? (


### PR DESCRIPTION
fixes [1408](https://dev.azure.com/spectrumFactory/CoronaI/_sprints/backlog/CoronaI%20Team/CoronaI/Sprint%2013?workitem=1408)