### PR TITLE
fix/investigationTable crashes on invalid date

### DIFF
--- a/client/src/commons/DatePick/DateRangePick.tsx
+++ b/client/src/commons/DatePick/DateRangePick.tsx
@@ -17,6 +17,7 @@ const DateRangePick: React.FC<Props> = (props: Props): JSX.Element => {
                     maxDate={maxDate}
                     value={startDate}
                     onChange={onStartDateChange}
+                    helperText={null}
                 />
             </Grid>
             <Grid item xs={2}>
@@ -27,6 +28,7 @@ const DateRangePick: React.FC<Props> = (props: Props): JSX.Element => {
                     maxDate={maxDate}
                     value={endDate}
                     onChange={onEndDateChange}
+                    helperText={null}
                 />
             </Grid>
         </Grid>

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/TableFilter/useTableFilter.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/TableFilter/useTableFilter.ts
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { format , isValid} from 'date-fns';
 import { useEffect, useState } from 'react';
 
 import { TimeRange } from 'models/TimeRange';
@@ -35,11 +35,15 @@ const useTableFilter = (props : Props) => {
     }
 
     const onStartDateSelect = (startDateInput: Date) => {
-        setDisplayTimeRange({...displayTimeRange, startDate: format(startDateInput,'yyyy-MM-dd')})
+        if(isValid(startDateInput)){
+            setDisplayTimeRange({...displayTimeRange, startDate: format(startDateInput,'yyyy-MM-dd')})
+        }
     }
 
     const onEndDateSelect = (endDateInput :Date) => {
-        setDisplayTimeRange({...displayTimeRange, endDate: format(endDateInput,'yyyy-MM-dd')})       
+        if(isValid(endDateInput)){
+            setDisplayTimeRange({...displayTimeRange, endDate: format(endDateInput,'yyyy-MM-dd')})       
+        }
     }
 
     return {


### PR DESCRIPTION
issue was that the state of the filter was changed to `Invalid Date` whenever the date was invalid (I.E starting to write a date on the keyboard)

Fixes [1418](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1418/)

added an exception to the state change 
removed helper text incase of min/max error