### PR TITLE
feat(change county for super admin): added the feature and more fixtures

### DIFF
--- a/client/src/Utils/Desk/useDesksUtils.ts
+++ b/client/src/Utils/Desk/useDesksUtils.ts
@@ -1,0 +1,20 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import Desk from 'models/Desk';
+import StoreStateType from 'redux/storeStateType';
+
+const useDesksUtils = () => {
+
+    const displayedCounty = useSelector<StoreStateType, number>(state => state.user.displayedCounty);
+    const desks = useSelector<StoreStateType, Desk[]>(state => state.desk);
+    const countyDesks = useMemo(() => desks.filter(desk => desk.county === displayedCounty), [desks, displayedCounty]);
+    
+    return {
+        displayedCounty,
+        countyDesks
+    }
+
+};
+
+export default useDesksUtils;

--- a/client/src/components/App/App.tsx
+++ b/client/src/components/App/App.tsx
@@ -1,111 +1,15 @@
+import React from 'react';
 import { config } from 'dotenv';
-import { useSelector } from 'react-redux';
-import React, { useState, useEffect } from 'react';
-import axios from 'axios';
 
-import User from 'models/User';
-import logger from 'logger/logger';
-import { Severity } from 'models/Logger';
-import StoreStateType from 'redux/storeStateType';
-import Environment from 'models/enums/Environments';
-import { setUser } from 'redux/User/userActionCreators';
-import { setIsLoading } from 'redux/IsLoading/isLoadingActionCreators';
-
+import useApp from './useApp';
 import Content from './Content/Content';
 import AppToolbar from './AppToolbar/AppToolbar';
 
 config();
 
-type AuthenticationReturn = [{
-    access_token: string;
-    expires_on: Date;
-    id_token: string;
-    provider_name: string;
-    refresh_token: string;
-    user_claims: [{
-        typ: string;
-        val: string;
-    }];
-    user_id: string;
-}];
-
-const userNameClaimType = 'name';
-
-const notInLocalEnv = () => (
-    process.env.REACT_APP_ENVIRONMENT === Environment.PROD ||
-    process.env.REACT_APP_ENVIRONMENT === Environment.DEV_AUTH ||
-    process.env.REACT_APP_ENVIRONMENT === Environment.TEST
-);
-
-const getAuthUserData = async () => {
-    const { protocol, hostname } = window.location;
-    const { data } = await axios.get<AuthenticationReturn>(`${protocol}//${hostname}/.auth/me`);
-    const userId = data[0].user_id.split('@')[0];
-    const userName = data[0].user_claims.find(claim => claim.typ === userNameClaimType)?.val as string;
-    return { userId, userName };
-};
-
-const getStubAuthUserData = () => ({
-    userId: '7',
-    userName: 'stubuser'
-});
-
 const App: React.FC = (): JSX.Element => {
 
-    const user = useSelector<StoreStateType, User>(state => state.user.data);
-    const isUserLoggedIn = useSelector<StoreStateType, boolean>(state => state.user.isLoggedIn);
-
-    const [isSignUpOpen, setIsSignUpOpen] = useState<boolean>(false);
-
-    useEffect(() => {
-        if(!isUserLoggedIn) {
-            initUser();
-        }
-    }, []);
-
-    const initUser = async () => {
-        const initUserLogger = logger.setup('login to the app');
-        const { userId, userName } = notInLocalEnv() ? await getAuthUserData() : getStubAuthUserData();
-        initUserLogger.info('before environment condition', Severity.LOW);
-        fetchUser(userId, userName);
-    };
-
-    const handleSaveUser = () => {
-        handleCloseSignUp();
-        fetchUser(user.id, user.userName);
-    };
-
-    const handleCloseSignUp = () => setIsSignUpOpen(false);
-
-    const fetchUser = (userId: string, userName: string) => {
-        const fetchUserLogger = logger.setup('Getting user details');
-        fetchUserLogger.info('launch request to the server', Severity.LOW);
-        setIsLoading(true);
-        axios.get(`/users/user`).then((result: any) => {
-            if (result && result.data.userById) {
-                fetchUserLogger.info('recived user from the server', Severity.LOW);
-                const userFromDB = result.data.userById;
-                setUser({
-                    ...userFromDB,
-                    id: userId,
-                    userName
-                });
-            } else {
-                fetchUserLogger.warn(`user has not been found due to: ${JSON.stringify(result)}`, Severity.MEDIUM);
-                setUser({
-                    ...user,
-                    id: userId,
-                    userName
-                });
-                setIsSignUpOpen(true);
-            }
-
-            setIsLoading(false);
-        }).catch(err => {
-            fetchUserLogger.warn(`got error from the server: ${err}`, Severity.MEDIUM);
-            setIsLoading(false);
-        })
-    }
+    const { handleCloseSignUp, handleSaveUser, isSignUpOpen } = useApp()
 
     return (
         <>

--- a/client/src/components/App/AppToolbar/AppToolbar.tsx
+++ b/client/src/components/App/AppToolbar/AppToolbar.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { ExitToApp, Home, SupervisorAccount } from '@material-ui/icons';
 import { NavLink, NavLinkProps, useLocation, useHistory } from 'react-router-dom';
-import { AppBar, Toolbar, Typography, Tooltip, IconButton } from '@material-ui/core';
+import { AppBar, Toolbar, Typography, Tooltip, IconButton, Select, MenuItem } from '@material-ui/core';
 
+import County from 'models/County';
 import UserType from 'models/enums/UserType';
+import StoreStateType from 'redux/storeStateType';
 import IsActiveToggle from 'commons/IsActiveToggle/IsActiveToggle';
+import { setDisplayedCounty } from 'redux/User/userActionCreators';
 import { adminLandingPageRoute, landingPageRoute, usersManagementRoute, indexRoute } from 'Utils/Routes/Routes';
 
 import useStyles from './AppToolbarStyles';
@@ -35,7 +39,11 @@ const StatePersistentNavLink = (props: NavLinkProps) => {
 };
 
 const AppToolbar: React.FC = (): JSX.Element => {
-  const { user, isActive, logout, setUserActivityStatus, countyDisplayName } = useAppToolbar();
+  const { user, isActive, logout, setUserActivityStatus } = useAppToolbar();
+
+  const displayedCounty = useSelector<StoreStateType, number>(state => state.user.displayedCounty);
+  const districtCounties = useSelector<StoreStateType, County[]>(state => state.county.districtCounties);
+  const countyDisplayName = useSelector<StoreStateType, string>(state => state.user.data.countyByInvestigationGroup.displayName);
 
   const classes = useStyles();
   const location = useLocation();
@@ -81,10 +89,42 @@ const AppToolbar: React.FC = (): JSX.Element => {
           <Typography className={classes.greetUserText}>
             שלום, {user.userName}
           </Typography>
-          {countyDisplayName &&
-            <Typography>
-              הינך מחובר/ת לנפת <b>{countyDisplayName}</b>
-            </Typography>
+          {
+            user.userType === UserType.SUPER_ADMIN ?
+              <Select
+                className={classes.countySelect}
+                value={displayedCounty}
+                onChange={(event) => setDisplayedCounty(event.target.value as number)}
+                classes={{icon: classes.countySelect}}
+                disableUnderline
+                MenuProps={{
+                  anchorOrigin: {
+                      vertical: 'bottom',
+                      horizontal: 'left'
+                  },
+                  transformOrigin: {
+                    vertical: 'top',
+                    horizontal: 'left'
+                  },
+                  getContentAnchorEl: null
+                }}
+                renderValue={(value) => 
+                  <Typography>נפת <b>{districtCounties.find(county => county.id === value)?.displayName}</b></Typography>
+                }
+              >
+                {
+                  districtCounties.map(county => 
+                    <MenuItem key={county.id} value={county.id}>
+                        {`נפת  ${county.displayName}`}
+                    </MenuItem>
+                  )
+                }
+              </Select>
+            :
+              countyDisplayName &&
+              <Typography>
+                הינך מחובר/ת לנפת <b>{countyDisplayName}</b>
+              </Typography>
           }
         </div>
       </Toolbar>

--- a/client/src/components/App/AppToolbar/AppToolbarStyles.ts
+++ b/client/src/components/App/AppToolbar/AppToolbarStyles.ts
@@ -53,6 +53,12 @@ const useStyles = makeStyles((theme: Theme) => ({
         color: 'white',
         padding: theme.spacing(1),
         marginLeft: theme.spacing(1)
+    },
+    countySelect: {
+        color: 'white',
+        '&:focus': {
+            opacity: 'unset'
+        }
     }
 }));
 

--- a/client/src/components/App/AppToolbar/AppToolbarStyles.ts
+++ b/client/src/components/App/AppToolbar/AppToolbarStyles.ts
@@ -57,7 +57,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     countySelect: {
         color: 'white',
         '&:focus': {
-            opacity: 'unset'
+            opacity: 1
         }
     }
 }));

--- a/client/src/components/App/AppToolbar/useAppToolbar.tsx
+++ b/client/src/components/App/AppToolbar/useAppToolbar.tsx
@@ -1,25 +1,23 @@
+import axios from 'axios';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import axios from 'axios';
-import { persistor } from 'redux/store';
 
 import User from 'models/User';
 import logger from 'logger/logger';
+import { persistor } from 'redux/store';
 import { Severity } from 'models/Logger';
 import { indexRoute } from 'Utils/Routes/Routes';
 import StoreStateType from 'redux/storeStateType';
+import { UserState } from 'redux/User/userReducer';
 import { setIsActive } from 'redux/User/userActionCreators';
 import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
-import { UserState } from 'redux/User/userReducer';
 
 export interface useTopToolbarOutcome  {
     logout: () => void;
     setUserActivityStatus: (isActive: boolean) => Promise<any>;
-    getCountyByUser: () => void;
     user: User;
     isActive: boolean | null;
-    countyDisplayName: string;
 }
 
 const useAppToolbar = () :  useTopToolbarOutcome => {
@@ -27,13 +25,10 @@ const useAppToolbar = () :  useTopToolbarOutcome => {
     const history = useHistory();
     const { alertError } = useCustomSwal();
     
-    const [countyDisplayName, setCountyDisplayName] = React.useState<string>('');
-
     const getUserActivityStatusLogger = logger.setup('GraphQL request to the DB');
 
     React.useEffect(() => {
         if (user.isLoggedIn) {
-            getCountyByUser();
             getUserActivityStatus();
         }
     }, [user.isLoggedIn]);
@@ -75,27 +70,11 @@ const useAppToolbar = () :  useTopToolbarOutcome => {
         });
     }
 
-    const getCountyByUser = () => {
-        const getCountyByUserLogger = logger.setup('GraphQL request to the DB');
-        getCountyByUserLogger.info('started fetching county display name by user', Severity.LOW);
-        axios.get('counties/county/displayName').then((result) => {
-            if(result.data){
-                setCountyDisplayName(result.data);
-                getCountyByUserLogger.info('fetched county display name by user successfully', Severity.LOW);
-            }
-        }).catch((error) => {
-            alertError('לא הצלחנו לקבל את הלשכה שלך');
-            getCountyByUserLogger.error(`error in fetching county display name by user ${error}`, Severity.HIGH);
-        });
-    }
-
     return {
         user: user.data,
         isActive: user.data.isActive,
         logout,
         setUserActivityStatus,
-        getCountyByUser,
-        countyDisplayName
     }
 };
 

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/DeskFilter/DeskFilter.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/DeskFilter/DeskFilter.tsx
@@ -49,6 +49,6 @@ export default DeskFilter;
 
 interface Props {
     desks: Desk[];
-    filteredDesks: number[];
+    filteredDesks: (number | null)[];
     onFilterChange: (event: React.ChangeEvent<{}>, selectedDesks: Desk[]) => void;
 };

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -105,7 +105,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
     const desks = useSelector<StoreStateType, Desk[]>(state => state.desk).filter(desk => desk.county === displayedCounty);
 
     const countyDesks : Desk[] = useMemo(() =>
-        [...desks.filter(desk => desk.county === displayedCounty), { id: -1, deskName: 'לא שוייך לדסק', county: displayedCounty}]
+        [...desks.filter(desk => desk.county === displayedCounty), { id: null, deskName: 'לא שוייך לדסק', county: displayedCounty}]
     , [desks, displayedCounty])
 
     const totalPageCount = Math.ceil(totalCount / rowsPerPage);
@@ -135,10 +135,10 @@ const InvestigationTable: React.FC = (): JSX.Element => {
         const allUsersOfCountyArray: InvestigatorOption[] = Array.from(allCountyUsers, ([id, value]) => ({ id, value }));
         if (deskFilter.length > 0) {
             allUsersOfCountyArray.filter(({ value }) => {
-                if (!value.deskByDeskId) {
+                if (!value.deskByDeskId?.id) {
                     return false;
                 }
-                return deskFilter.includes(value.deskByDeskId.id);
+                return deskFilter.includes(value.deskByDeskId.id as number);
             });
         }
         return allUsersOfCountyArray;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -18,6 +18,7 @@ import userType from 'models/enums/UserType';
 import SortOrder from 'models/enums/SortOrder';
 import StoreStateType from 'redux/storeStateType';
 import SearchBar from 'commons/SearchBar/SearchBar';
+import useDesksUtils from 'Utils/Desk/useDesksUtils';
 import InvestigatorOption from 'models/InvestigatorOption';
 import { adminLandingPageRoute } from 'Utils/Routes/Routes';
 import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
@@ -101,12 +102,12 @@ const InvestigationTable: React.FC = (): JSX.Element => {
     });
 
     const user = useSelector<StoreStateType, User>(state => state.user.data);
-    const displayedCounty = useSelector<StoreStateType, number>(state => state.user.displayedCounty);
-    const desks = useSelector<StoreStateType, Desk[]>(state => state.desk).filter(desk => desk.county === displayedCounty);
 
-    const countyDesks : Desk[] = useMemo(() =>
-        [...desks.filter(desk => desk.county === displayedCounty), { id: null, deskName: 'לא שוייך לדסק', county: displayedCounty}]
-    , [desks, displayedCounty])
+    const { countyDesks, displayedCounty } = useDesksUtils();
+
+    const desksToTransfer : Desk[] = useMemo(() =>
+        [...countyDesks, { id: null, deskName: 'לא שוייך לדסק', county: displayedCounty}]
+    , [countyDesks])
 
     const totalPageCount = Math.ceil(totalCount / rowsPerPage);
 
@@ -138,7 +139,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                 if (!value.deskByDeskId?.id) {
                     return false;
                 }
-                return deskFilter.includes(value.deskByDeskId.id as number);
+                return deskFilter.includes(value.deskByDeskId.id);
             });
         }
         return allUsersOfCountyArray;
@@ -263,7 +264,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                 </Grid>
                 <Grid item xs={2} >
                     <DeskFilter
-                        desks={countyDesks}
+                        desks={desksToTransfer}
                         filteredDesks={deskFilter}
                         onFilterChange={(event, value) => changeDeskFilter(value)} 
                     />
@@ -366,7 +367,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                             groupColor={investigationColor.current.get(indexedRow.groupId)}
                                             selected={selectedRow.epidemiologyNumber === indexedRow.epidemiologyNumber}
                                             deskAutoCompleteClicked={deskAutoCompleteClicked}
-                                            desks={countyDesks}
+                                            desks={desksToTransfer}
                                             indexedRow={indexedRow}
                                             row={row}
                                             isGroupShown={isGroupShown}
@@ -411,7 +412,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                                         groupColor={investigationColor.current.get(indexedRow.groupId)}
                                                         selected={selectedRow.epidemiologyNumber === indexedRow.epidemiologyNumber}
                                                         deskAutoCompleteClicked={deskAutoCompleteClicked}
-                                                        desks={countyDesks}
+                                                        desks={desksToTransfer}
                                                         indexedRow={indexedGroupedInvestigationRow}
                                                         row={row}
                                                         isGroupShown={isGroupShown}
@@ -458,7 +459,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
             <Slide direction='up' in={checkedIndexedRows.length > 0} mountOnEnter unmountOnExit>
                 <InvestigationTableFooter
                     checkedIndexedRows={checkedIndexedRows}
-                    allDesks={countyDesks}
+                    allDesks={desksToTransfer}
                     onDialogClose={() => setCheckedIndexedRows([])}
                     tableRows={tableRows}
                     fetchTableData={fetchTableData}

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableFooter/InvestigationTableFooter.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableFooter/InvestigationTableFooter.tsx
@@ -37,7 +37,7 @@ const multipleAssignments = 'הקצאות';
 
 const InvestigationTableFooter: React.FC<Props> = React.forwardRef((props: Props, ref) => {
 
-    const { checkedIndexedRows, allDesks, allCounties, fetchInvestigators,
+    const { checkedIndexedRows, allDesks, fetchInvestigators,
             onDialogClose, tableRows, allGroupedInvestigations, onDeskChange,
             onDeskGroupChange, onCountyChange, onCountyGroupChange, fetchTableData, 
             fetchInvestigationsByGroupId, allocateInvestigationToInvestigator } = props;
@@ -163,7 +163,6 @@ const InvestigationTableFooter: React.FC<Props> = React.forwardRef((props: Props
                 onCountyTransfer={handleConfirmCountiesDialog}
                 onClose={handleCloseDesksDialog}
                 allDesks={allDesks}
-                allCounties={allCounties}
                 onSuccess={onTransferSuccess}
             />
             <InvestigatorAllocationDialog
@@ -193,7 +192,6 @@ interface Props {
     onDialogClose: () => void;
     checkedIndexedRows: IndexedInvestigation[];
     allDesks: Desk[];
-    allCounties: County[];
     fetchInvestigators: () => Promise<InvestigatorOption[]>;
     tableRows: InvestigationTableRow[];
     allGroupedInvestigations: Map<string, InvestigationTableRow[]>;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableFooter/TransferInvestigationsDialogs/TransferInvestigationCounty.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableFooter/TransferInvestigationsDialogs/TransferInvestigationCounty.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { SweetAlertResult } from 'sweetalert2';
 import { Autocomplete } from '@material-ui/lab';
 import { yupResolver } from '@hookform/resolvers';
@@ -6,6 +7,7 @@ import { FormProvider, Controller, useForm } from 'react-hook-form';
 import { Button, DialogActions, TextField, Typography, useTheme } from '@material-ui/core';
 
 import County from 'models/County';
+import StoreStateType from 'redux/storeStateType';
 import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
 
 import useStyles from './TransferDialogsStyles';
@@ -26,13 +28,15 @@ const TransferInvestigationCounty = (props: Props) => {
 
     const theme = useTheme();
 
-    const { allCounties, onClose, onConfirm, onSuccess } = props;
+    const { onClose, onConfirm, onSuccess } = props;
 
     const methods = useForm({
         mode: 'all',
         resolver: yupResolver(validationSchema),
         defaultValues
     })
+
+    const allCounties = useSelector<StoreStateType, County[]>(state => state.county.allCounties);
 
     const onDialogConfirm = (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
@@ -125,7 +129,6 @@ const TransferInvestigationCounty = (props: Props) => {
 }
 
 interface Props {
-    allCounties: County[];
     onClose: () => void;
     onConfirm: (updatedCounty: County, transferReason: string) => void;
     onSuccess: () => Promise<SweetAlertResult<any>>

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableFooter/TransferInvestigationsDialogs/TransferInvestigationTabs.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableFooter/TransferInvestigationsDialogs/TransferInvestigationTabs.tsx
@@ -40,7 +40,7 @@ const TabPanel = (props: TabPanelProps) => {
 
 const TransferInvestigationTabs = (props: Props) => {
 
-    const { allDesks, allCounties, onClose, onDeskTransfer, onCountyTransfer, onSuccess } = props;
+    const { allDesks, onClose, onDeskTransfer, onCountyTransfer, onSuccess } = props;
 
     const [value, setValue] = React.useState(0);
 
@@ -66,7 +66,6 @@ const TransferInvestigationTabs = (props: Props) => {
                 <TransferInvestigationCounty
                     onConfirm={onCountyTransfer}
                     onClose={onClose}
-                    allCounties={allCounties}
                     onSuccess={onSuccess}
                 />
             </TabPanel>
@@ -91,7 +90,6 @@ interface TabPanelProps {
 interface Props {
     open: boolean;
     allDesks: Desk[];
-    allCounties: County[];
     onClose: () => void;
     onDeskTransfer: (updatedDesk: Desk, transferReason: string) => void;
     onCountyTransfer: (updatedCounty: County, transferReason: string) => void;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableFooter/TransferInvestigationsDialogs/TransferInvestigationTabsDialog.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableFooter/TransferInvestigationsDialogs/TransferInvestigationTabsDialog.tsx
@@ -12,7 +12,7 @@ const TITLE = 'העברת חקירות';
 
 const TransferInvestigationDialog = (props: Props) => {
 
-    const { allDesks, allCounties, open, onClose, onDeskTransfer, onCountyTransfer, onSuccess } = props;
+    const { allDesks, open, onClose, onDeskTransfer, onCountyTransfer, onSuccess } = props;
 
     const classes = useStyles();
 
@@ -27,7 +27,6 @@ const TransferInvestigationDialog = (props: Props) => {
                 <TransferInvestigationTabs
                     open={open}
                     allDesks={allDesks}
-                    allCounties={allCounties}
                     onDeskTransfer={onDeskTransfer}
                     onCountyTransfer={onCountyTransfer}
                     onClose={onClose}
@@ -44,7 +43,6 @@ interface Props {
     onDeskTransfer: (updatedDesk: Desk, transferReason: string) => void;
     onCountyTransfer: (updatedCounty: County, transferReason: string) => void;
     allDesks: Desk[];
-    allCounties: County[];
     onSuccess: () => Promise<SweetAlertResult<any>>
 
 }

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
@@ -15,7 +15,7 @@ import { IndexedInvestigationData } from './InvestigationTablesHeaders';
 
 export type StatusFilter = InvestigationMainStatusCodes[];
 export type SubStatusFilter = string[];
-export type DeskFilter = number[];
+export type DeskFilter = number[] | (number | null)[];
 
 export interface HistoryState {
     filterRules?: any;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
@@ -33,10 +33,8 @@ export interface useInvestigationTableParameters {
     currentPage: number;
     allGroupedInvestigations: Map<string, InvestigationTableRow[]>;
     setSelectedRow: React.Dispatch<React.SetStateAction<SelectedRow>>;
-    setAllCounties: React.Dispatch<React.SetStateAction<County[]>>;
     setAllStatuses: React.Dispatch<React.SetStateAction<InvestigationMainStatus[]>>;
     setAllSubStatuses: React.Dispatch<React.SetStateAction<InvestigationSubStatus[]>>;
-    setAllDesks: React.Dispatch<React.SetStateAction<Desk[]>>;
     setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
     setAllGroupedInvestigations: React.Dispatch<React.SetStateAction<Map<string, InvestigationTableRow[]>>>;
     investigationColor: MutableRefObject<Map<string, string>>;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -120,7 +120,6 @@ export const DEFAULT_SELECTED_ROW: SelectedRow = {
 };
 
 const TABLE_REFRESH_INTERVAL = 30;
-const FETCH_ERROR_TITLE = 'אופס... לא הצלחנו לשלוף';
 const UPDATE_ERROR_TITLE = 'לא הצלחנו לעדכן את החקירה';
 const OPEN_INVESTIGATION_ERROR_TITLE = 'לא הצלחנו לפתוח את החקירה';
 export const transferredSubStatus = 'נדרשת העברה';
@@ -129,8 +128,8 @@ const welcomeMessage = 'היי, אלו הן החקירות שהוקצו לך ה�
 const noInvestigationsMessage = 'היי,אין חקירות לביצוע!';
 
 const useInvestigationTable = (parameters: useInvestigationTableParameters): useInvestigationTableOutcome => {
-    const { setSelectedRow, setAllCounties, setAllStatuses, setAllSubStatuses, setAllDesks, currentPage, setCurrentPage, setAllGroupedInvestigations, allGroupedInvestigations,
-        investigationColor } = parameters;
+    const { setSelectedRow, setAllStatuses, currentPage, setCurrentPage, setAllGroupedInvestigations, allGroupedInvestigations,
+        investigationColor, setAllSubStatuses } = parameters;
 
     const classes = useStyle(false);
     const { alertError } = useCustomSwal();
@@ -186,6 +185,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
     const user = useSelector<StoreStateType, User>(state => state.user.data);
     const isLoggedIn = useSelector<StoreStateType, boolean>(state => state.user.isLoggedIn);
     const isLoading = useSelector<StoreStateType, boolean>(state => state.isLoading);
+    const displayedCounty = useSelector<StoreStateType, number>(state => state.user.displayedCounty);
     const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
     const axiosInterceptorId = useSelector<StoreStateType, number>(state => state.investigation.axiosInterceptorId);
     const windowTabsBroadcastChannel = useRef(new BroadcastChannel(BC_TABS_NAME));
@@ -271,23 +271,6 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         setIsAdminLandingRedirect(false);
     };
 
-    const fetchAllDesksByCountyId = () => {
-        const desksByCountyIdLogger = logger.setup('Getting Desks by county id');
-        axios.get('/desks/county')
-            .then((result) => {
-                if (result?.data && result.headers['content-type'].includes('application/json')) {
-                    desksByCountyIdLogger.info('The desks were fetched successfully', Severity.LOW);
-                    setAllDesks([{ id: null, deskName: 'לא שוייך לדסק' }, ...result.data]);
-                } else {
-                    desksByCountyIdLogger.error('Got 200 status code but results structure isnt as expected', Severity.HIGH);
-                }
-            })
-            .catch((err) => {
-                alertError('לא הצלחנו לשלוף את כל הדסקים האפשריים לסינון');
-                desksByCountyIdLogger.error(err, Severity.HIGH);
-            })
-    }
-
     const canChangeStatusNewToInProcess = (investigationStatus: Number, investigationInvestigator?: string) => {
         return investigationStatus === InvestigationMainStatusCodes.NEW &&
             (user.userType === userType.INVESTIGATOR || investigationInvestigator === user.id);
@@ -332,7 +315,6 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
     useEffect(() => {
         fetchAllInvestigationStatuses();
         fetchAllInvestigationSubStatuses();
-        fetchAllDesksByCountyId();
         startWaiting();
     }, []);
 
@@ -369,12 +351,12 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             orderBy,
             size: rowsPerPage,
             currentPage,
-            filterRules: Object.values(filterRules).reduce((obj, item) => Object.assign(obj, item) , {})
+            filterRules: Object.values(filterRules).reduce((obj, item) => Object.assign(obj, item) , {}),
         };
 
         if (user.userType === userType.ADMIN || user.userType === userType.SUPER_ADMIN) {
             investigationsLogger.info('user is admin so landingPage/groupInvestigations route is chosen', Severity.LOW);
-            return axios.post('landingPage/groupInvestigations', requestData)
+            return axios.post('landingPage/groupInvestigations', {...requestData, county: displayedCounty})
         }
 
         investigationsLogger.info('user isnt admin so landingPage/investigations route is chosen', Severity.LOW);
@@ -390,7 +372,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         countyUsersLogger.info('requesting the server the connected admin group users', Severity.LOW);
         const countyUsers: Map<string, User> = new Map();
         try {
-            const result = await axios.get('/users/group');
+            const result = await axios.get(`/users/group/${displayedCounty}`);
             if (result && result.data) {
                 result.data.forEach((user: any) => {
                     countyUsers.set(user.id, {
@@ -413,24 +395,6 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         .sort((fisrtUser, secondUser) => sortUsersByAvailability(fisrtUser[1], secondUser[1])));
         return sortedCountyUsers;
     }
-    
-    const fetchAllCounties = () => {
-        const fetchAllCountiesLogger = logger.setup('GraphQL request to the DB');
-        axios.get('/counties').then((result: any) => {
-            const allCounties: County[] = [];
-            result && result.data && result.data.forEach((county: any) => {
-                allCounties.push({
-                    id: county.id,
-                    displayName: `${county.district} - ${county.displayName}`
-                })
-            });
-            fetchAllCountiesLogger.info('fetched all the counties successfully', Severity.LOW);
-            setAllCounties(allCounties);
-        }).catch(err => {
-            fetchAllCountiesLogger.error(err, Severity.HIGH);
-            alertError(FETCH_ERROR_TITLE);
-        });
-    }
 
     const getFormattedDate = (date: string) => {
         return format(truncateDate(date), 'dd/MM')
@@ -440,9 +404,6 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         const fetchInvestigationsLogger = logger.setup('Getting Investigations');
         if (isLoggedIn) {
             setIsLoading(true);
-            if (user.userType === userType.ADMIN || user.userType === userType.SUPER_ADMIN) {
-                fetchAllCounties();
-            }
             fetchInvestigationsLogger.info(`launching the selected request to the DB ordering by ${orderBy}`, Severity.LOW);
             fetchInvestigationsAxiosRequest()
                 .then((response: any) => {
@@ -451,7 +412,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
                     const { data } = response;
                     let allInvestigationsRawData: any = [];
 
-                    if (user.investigationGroup !== -1) {
+                    if (displayedCounty !== -1) {
                         fetchInvestigationsLogger.info('user investigation group is valid', Severity.LOW);
                         if (data && data.allInvestigations) {
                             fetchInvestigationsLogger.info('got investigations from the DB', Severity.LOW);
@@ -556,7 +517,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             fetchTableData();
         }
         setIsBadgeInVisible(!Boolean(Object.values(filterRules).find(item => item !== null)))
-    }, [isLoggedIn, filterRules, orderBy, currentPage]);
+    }, [isLoggedIn, filterRules, orderBy, currentPage, displayedCounty]);
 
     const onInvestigationRowClick = (investigationRow: { [T in keyof IndexedInvestigationData]: any }) => {
         const investigationClickLogger = logger.setupVerbose({
@@ -661,25 +622,25 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         }
     }
 
-    const getInvestigationsOldValues = (investigations: InvestigationTableRow[], key: TableKeys, countyValue?: number) => (
+    const getInvestigationsOldValues = (investigations: InvestigationTableRow[], key: TableKeys, isCounty?: boolean) => (
         investigations
-        .map(investigation => `${investigation.epidemiologyNumber}: ${countyValue || convertToIndexedRow(investigation)[key as TableHeadersNames]}`)
+        .map(investigation => `${investigation.epidemiologyNumber}: ${isCounty ? investigation.county.id : convertToIndexedRow(investigation)[key as TableHeadersNames]}`)
         .join(', ')
     )
 
     const logInvestigationTransfer = (epidemiologyNumbers: number[], key: TableKeys, newValue: number | string, reason?: string) => {
-        const countyValue : number | undefined = key  === HiddenTableKeys.county ? user.investigationGroup : undefined;
         const investigations =  rows.filter(investigation => epidemiologyNumbers.includes(investigation.epidemiologyNumber))
-        const investigationsPreviousValues = getInvestigationsOldValues(investigations, key, countyValue);
+        const investigationsPreviousValues = getInvestigationsOldValues(investigations, key, key  === HiddenTableKeys.county);
         return `launching request to transfer the investigations ${key} to ${newValue} from their old values: {${investigationsPreviousValues}} ${reason ? `due to ${reason}` : ''}`;
     }
 
     const logGroupTransfer = (groupIds: string[], key: TableKeys, newValue: number | string, reason?: string) => {
-        const countyValue = key  === HiddenTableKeys.county ? user.investigationGroup : undefined;
         const groups =  Array.from(allGroupedInvestigations.keys()).filter(groupId => groupIds.includes(groupId))
         const investigationsPreviousValues = groups
-        .map(groupId => `group ${groupId}- investigations:{${getInvestigationsOldValues(allGroupedInvestigations.get(groupId) as InvestigationTableRow[], key, countyValue)}}`)
+        .map(groupId => `group ${groupId}- investigations:{${getInvestigationsOldValues
+            (allGroupedInvestigations.get(groupId) as InvestigationTableRow[], key, key  === HiddenTableKeys.county)}}`)
         .join(', ');
+        console.log(`launching request to transfer the groups investigations ${key} to ${newValue} from their old values: ${investigationsPreviousValues} ${reason ? `due to ${reason}` : ''}`)
         return `launching request to transfer the groups investigations ${key} to ${newValue} from their old values: ${investigationsPreviousValues} ${reason ? `due to ${reason}` : ''}`;
     }
 
@@ -696,6 +657,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             await axios.post('/users/changeGroupInvestigator', {
                 groupIds,
                 user: investigator?.id,
+                county: displayedCounty
             });
             changeGroupsInvestigatorLogger.info(`the investigator have been changed successfully for groups ${joinedGroupIds}`, Severity.LOW);
         } catch (error) {
@@ -731,7 +693,8 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             await axios.post('/landingPage/changeGroupDesk', {
                 groupIds,
                 desk: newSelectedDesk?.id,
-                reason: transferReason
+                reason: transferReason,
+                county: displayedCounty
             });
             changeDeskLogger.info(logGroupTransfer(groupIds, TableHeadersNames.investigationDesk, newSelectedDesk?.deskName || '', transferReason), Severity.LOW);
             setSelectedRow(DEFAULT_SELECTED_ROW);
@@ -747,8 +710,8 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         try {
             axios.post('/users/changeGroupCounty', {
                 groupIds,
-                county: newSelectedCounty?.id,
-                transferReason
+                county: displayedCounty,
+                transferReason,
             });
             changeCountyLogger.info(logGroupTransfer(groupIds, HiddenTableKeys.county, newSelectedCounty?.id || '', transferReason), Severity.LOW);
             setSelectedRow(DEFAULT_SELECTED_ROW);

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -122,6 +122,7 @@ export const DEFAULT_SELECTED_ROW: SelectedRow = {
 const TABLE_REFRESH_INTERVAL = 30;
 const UPDATE_ERROR_TITLE = 'לא הצלחנו לעדכן את החקירה';
 const OPEN_INVESTIGATION_ERROR_TITLE = 'לא הצלחנו לפתוח את החקירה';
+const FETCH_ERROR_TITLE = 'אופס... לא הצלחנו לשלוף'
 export const transferredSubStatus = 'נדרשת העברה';
 
 const welcomeMessage = 'היי, אלו הן החקירות שהוקצו לך היום. בואו נקטע את שרשראות ההדבקה!';

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -641,7 +641,6 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         .map(groupId => `group ${groupId}- investigations:{${getInvestigationsOldValues
             (allGroupedInvestigations.get(groupId) as InvestigationTableRow[], key, key  === HiddenTableKeys.county)}}`)
         .join(', ');
-        console.log(`launching request to transfer the groups investigations ${key} to ${newValue} from their old values: ${investigationsPreviousValues} ${reason ? `due to ${reason}` : ''}`)
         return `launching request to transfer the groups investigations ${key} to ${newValue} from their old values: ${investigationsPreviousValues} ${reason ? `due to ${reason}` : ''}`;
     }
 

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/adminLandingPage.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/adminLandingPage.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 import { Grid, Typography } from '@material-ui/core';
 
-import useAppToolbar from 'components/App/AppToolbar/useAppToolbar';
+import StoreStateType from 'redux/storeStateType';
 import FilterRulesDescription from 'models/enums/FilterRulesDescription';
 import InvestigationStatistics, { InvesitgationInfoStatistics } from 'models/InvestigationStatistics';
 
@@ -27,13 +28,14 @@ const AdminLandingPage: React.FC = (): JSX.Element => {
     });
     const [lastUpdated , setLastUpdated] = useState<Date>(new Date());
 
-    const { countyDisplayName } = useAppToolbar();
     const { redirectToInvestigationTable , fetchInvestigationStatistics, 
             updateInvestigationFilterByDesks, updateInvestigationFilterByTime} = useAdminLandingPage({
         setIsLoading,
         setInvestigationsStatistics,
         setLastUpdated,
     });
+
+    const countyDisplayName = useSelector<StoreStateType, string>(state => state.user.data.countyByInvestigationGroup.displayName);
 
     return (
         <div className={classes.content}>

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCard.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCard.tsx
@@ -1,9 +1,8 @@
-import React, { useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import React from 'react';
 import { Box, CardContent, Typography } from '@material-ui/core';
 
 import Desk from 'models/Desk';
-import StoreStateType from 'redux/storeStateType';
+import useDesksUtils from 'Utils/Desk/useDesksUtils';
 import CustomCheckbox from 'commons/CheckBox/CustomCheckbox';
 
 import LoadingCard from '../LoadingCard/LoadingCard';
@@ -21,12 +20,10 @@ const DesksFilterCard = (props: Props): JSX.Element => {
     const { onUpdateButtonClicked } = props;
     const { filteredDesks, clearAllDesks, onDeskClicked } = useDesksFilterCard();
 
-    const displayedCounty = useSelector<StoreStateType, number>(state => state.user.displayedCounty);
-    const desks = useSelector<StoreStateType, Desk[]>(state => state.desk);
-    const countyDesks = useMemo(() => desks.filter(desk => desk.county === displayedCounty), [desks, displayedCounty]);
+    const { countyDesks } = useDesksUtils();
 
     return (
-        <LoadingCard isLoading={desks.length === 0} width={cardWidth} height={cardHeight} className={classes.desksCard}>
+        <LoadingCard isLoading={countyDesks.length === 0} width={cardWidth} height={cardHeight} className={classes.desksCard}>
             <CardContent>
                 <Box display='flex' flexDirection='column' className={classes.desksCardContent}>
                     <Typography variant='h6'>
@@ -46,9 +43,9 @@ const DesksFilterCard = (props: Props): JSX.Element => {
                                     checkboxElements={[{
                                         key: desk.id,
                                         value: desk.id,
-                                        checked: filteredDesks.includes(desk.id as number),
+                                        checked: filteredDesks.includes(desk.id!),
                                         labelText: desk.deskName,
-                                        onChange: () => onDeskClicked(desk.id as number)
+                                        onChange: () => onDeskClicked(desk.id!)
                                     }]}
                                 />
                             ))

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCard.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCard.tsx
@@ -46,9 +46,9 @@ const DesksFilterCard = (props: Props): JSX.Element => {
                                     checkboxElements={[{
                                         key: desk.id,
                                         value: desk.id,
-                                        checked: filteredDesks.includes(desk.id),
+                                        checked: filteredDesks.includes(desk.id as number),
                                         labelText: desk.deskName,
-                                        onChange: () => onDeskClicked(desk.id)
+                                        onChange: () => onDeskClicked(desk.id as number)
                                     }]}
                                 />
                             ))

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCard.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCard.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { Box, CardContent, Typography } from '@material-ui/core';
 
 import Desk from 'models/Desk';
+import StoreStateType from 'redux/storeStateType';
 import CustomCheckbox from 'commons/CheckBox/CustomCheckbox';
 
 import LoadingCard from '../LoadingCard/LoadingCard';
@@ -17,10 +19,14 @@ const DesksFilterCard = (props: Props): JSX.Element => {
 
     const classes = useStyles();
     const { onUpdateButtonClicked } = props;
-    const { desks, isLoading, filteredDesks, clearAllDesks, onDeskClicked } = useDesksFilterCard();
+    const { filteredDesks, clearAllDesks, onDeskClicked } = useDesksFilterCard();
+
+    const displayedCounty = useSelector<StoreStateType, number>(state => state.user.displayedCounty);
+    const desks = useSelector<StoreStateType, Desk[]>(state => state.desk);
+    const countyDesks = useMemo(() => desks.filter(desk => desk.county === displayedCounty), [desks, displayedCounty]);
 
     return (
-        <LoadingCard isLoading={isLoading} width={cardWidth} height={cardHeight} className={classes.desksCard}>
+        <LoadingCard isLoading={desks.length === 0} width={cardWidth} height={cardHeight} className={classes.desksCard}>
             <CardContent>
                 <Box display='flex' flexDirection='column' className={classes.desksCardContent}>
                     <Typography variant='h6'>
@@ -35,7 +41,7 @@ const DesksFilterCard = (props: Props): JSX.Element => {
                     />
                     <div className={classes.desksWrapper}>
                         {
-                            desks.map((desk: Desk) => (
+                            countyDesks.map((desk: Desk) => (
                                 <CustomCheckbox
                                     checkboxElements={[{
                                         key: desk.id,

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/useDesksFilterCard.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/useDesksFilterCard.ts
@@ -1,35 +1,13 @@
-import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-
-import Desk from 'models/Desk';
-import logger from 'logger/logger';
-import { Severity } from 'models/Logger';
 
 import { HistoryState } from '../../InvestigationTable/InvestigationTableInterfaces';
 
 const useDesksFilterCard = () => {
     
-    const [desks, setDesks] = useState<Desk[]>([]);
-    const [isLoading, setIsLoading] = useState<boolean>(true);
     const [filteredDesks, setFilteredDesks] = useState<number[]>([]);
     
     const history = useHistory<HistoryState>();    
-
-    const fetchDesks = () => {
-        const fetchDesksLogger = logger.setup('Getting desks');
-        fetchDesksLogger.info('launching desks request', Severity.LOW);
-        setIsLoading(true);
-        axios.get('/desks/county').then(response => {
-            fetchDesksLogger.info('The desks were fetched successfully', Severity.LOW);
-            const { data } = response;
-            setDesks(data);
-            setIsLoading(false);
-        }).catch(err => {
-            fetchDesksLogger.error(`got error from the server: ${err}`, Severity.HIGH);
-            setIsLoading(false);
-        })
-    }
 
     const getHistoryData = () => {
         const { location: { state } } = history;
@@ -38,7 +16,6 @@ const useDesksFilterCard = () => {
     }
     
     useEffect(() => {
-        fetchDesks();
         getHistoryData();
     }, []);
 
@@ -55,8 +32,6 @@ const useDesksFilterCard = () => {
     }
 
     return {
-        desks,
-        isLoading,
         filteredDesks,
         clearAllDesks,
         onDeskClicked,

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/useDesksFilterCard.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/useDesksFilterCard.ts
@@ -11,7 +11,7 @@ const useDesksFilterCard = () => {
 
     const getHistoryData = () => {
         const { location: { state } } = history;
-        const deskFilter = state?.deskFilter;
+        const deskFilter = state?.deskFilter as number[];
         setFilteredDesks(deskFilter || []);
     }
     

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/useAdminLandingPage.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/useAdminLandingPage.ts
@@ -1,9 +1,11 @@
 import axios from 'axios';
+import { useSelector } from 'react-redux';
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import logger from 'logger/logger';
 import { Severity } from 'models/Logger';
+import StoreStateType from 'redux/storeStateType';
 import { landingPageRoute } from 'Utils/Routes/Routes';
 import { defaultTimeRange } from 'models/enums/timeRanges'
 import { TimeRange, TimeRangeDates } from 'models/TimeRange';
@@ -18,6 +20,7 @@ export const allTimeRangeId = 10;
 const useAdminLandingPage = (parameters: Parameters) => {
 
     const history = useHistory<HistoryState>();
+    const displayedCounty = useSelector<StoreStateType, number>(state => state.user.displayedCounty);
 
     const getInvestigationInfoFilter = () => {
         const { location: { state } } = history;
@@ -66,7 +69,7 @@ const useAdminLandingPage = (parameters: Parameters) => {
     useEffect(() => {
         fetchInvestigationStatistics();
         updateFilterHistory();
-    }, [investigationInfoFilter])
+    }, [investigationInfoFilter, displayedCounty])
 
     const fetchInvestigationStatistics = () => {
         const unallocatedCountLogger = logger.setup('query investigation statistics');
@@ -74,7 +77,8 @@ const useAdminLandingPage = (parameters: Parameters) => {
         setIsLoading(true);
         axios.post<InvesitgationStatistics>('/landingPage/investigationStatistics', {
             ...investigationInfoFilter,
-            timeRangeFilter: investigationInfoFilter.timeRangeFilter as TimeRangeDates
+            timeRangeFilter: investigationInfoFilter.timeRangeFilter as TimeRangeDates,
+            county: displayedCounty
         })
         .then((response) => {
             unallocatedCountLogger.info('launching db request', Severity.LOW);

--- a/client/src/components/App/Content/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/components/App/Content/SignUp/SignUpForm/SignUpForm.tsx
@@ -7,6 +7,8 @@ import { Grid, TextField } from '@material-ui/core';
 import { useForm, FormProvider, Controller } from 'react-hook-form';
 
 import City from 'models/City';
+import Desk from 'models/Desk';
+import County from 'models/County';
 import SignUpUser from 'models/SignUpUser';
 import FormMode from 'models/enums/FormMode';
 import StoreStateType from 'redux/storeStateType';
@@ -66,9 +68,11 @@ const GenericAlphabetTextField : React.FC<GenericAlphabetTextFieldProps> =
 const SignUpForm: React.FC<Props> = ({ defaultValues, handleSaveUser, mode }: Props) => {
     const classes = useStyles();
     
-    const { counties, languages, sourcesOrganization, desks, createUser } = useSignUpForm({ handleSaveUser });
+    const { languages, sourcesOrganization, createUser } = useSignUpForm({ handleSaveUser });
 
     const cities = useSelector<StoreStateType, Map<string, City>>(state => state.cities);
+    const counties = useSelector<StoreStateType, County[]>(state => state.county.allCounties);
+    const desks = useSelector<StoreStateType, Desk[]>(state => state.desk);
     
     const methods = useForm<SignUpUser>({
         mode: 'all',
@@ -258,7 +262,7 @@ const SignUpForm: React.FC<Props> = ({ defaultValues, handleSaveUser, mode }: Pr
                                     <Autocomplete
                                         disabled={shouldDisableFields}
                                         options={counties}
-                                        getOptionLabel={(option) => option ? option.displayName : option}
+                                        getOptionLabel={(option) => option?.displayName}
                                         value={props.value}
                                         onChange={(event, selectedCounty) => {
                                             props.onChange(selectedCounty ? selectedCounty.id : null)
@@ -287,7 +291,7 @@ const SignUpForm: React.FC<Props> = ({ defaultValues, handleSaveUser, mode }: Pr
                                     options={desks}
                                     disabled={shouldDisableFields}
                                     value={props.value}
-                                    getOptionLabel={(option) => option ? (mode === FormMode.READ ? option.name.deskName: option.name) : option}
+                                    getOptionLabel={(option) => option?.deskName}
                                     onChange={(event, selectedDesk) => {
                                         props.onChange(selectedDesk ? selectedDesk.id : null)
                                     }}

--- a/client/src/components/App/Content/SignUp/SignUpForm/useSignUpForm.ts
+++ b/client/src/components/App/Content/SignUp/SignUpForm/useSignUpForm.ts
@@ -1,10 +1,8 @@
 import axios  from 'axios';
 import { useState, useEffect } from 'react';
 
-import Desk from 'models/Desk';
 import City from 'models/City';
 import logger from 'logger/logger';
-import County from 'models/County';
 import Language from 'models/Language';
 import { Severity } from 'models/Logger';
 import SignUpUser from 'models/SignUpUser';
@@ -15,9 +13,7 @@ import { setIsLoading } from 'redux/IsLoading/isLoadingActionCreators';
 
 const useSignUp = ({ handleSaveUser }: useSignUpFormInCome) : useSignUpFormOutCome  => {
 
-    const [counties, setCounties] = useState<County[]>([]);
     const [languages, setLanguages] = useState<Language[]>([]);
-    const [desks, setDesks] = useState<Desk[]>([]);
     const [sourcesOrganization, setSourcesOrganization] = useState<SourceOrganization[]>([]);
 
     const { alertError } = useCustomSwal();
@@ -37,20 +33,6 @@ const useSignUp = ({ handleSaveUser }: useSignUpFormInCome) : useSignUpFormOutCo
             .catch(() => {
                 alertError('לא ניתן היה לקבל ערים');
                 fetchCitiesLogger.error('didnt get results back from the server', Severity.HIGH);
-            });
-    };
-
-    const fetchCounties = () => {
-        const fetchCountiesLogger = logger.setup('Fetching counties');
-        fetchCountiesLogger.info('launching counties request', Severity.LOW);
-        return axios.get('/counties')
-            .then(result => {
-                result?.data && setCounties(result?.data);
-                fetchCountiesLogger.info('got results back from the server', Severity.LOW);
-            })
-            .catch(() => {
-                alertError('לא ניתן היה לקבל נפות');
-                fetchCountiesLogger.error('didnt get results back from the server', Severity.HIGH);       
             });
     };
 
@@ -81,27 +63,13 @@ const useSignUp = ({ handleSaveUser }: useSignUpFormInCome) : useSignUpFormOutCo
                 fetchLanguagesLogger.error('didnt get results back from the server', Severity.HIGH);    
             });
     }
-    
-    const fetchDesks = () => {
-        const fetchDesksLogger = logger.setup('Getting desks');
-        fetchDesksLogger.info('launching desks request', Severity.LOW);
-        return axios.get('/desks').then(response => {
-            fetchDesksLogger.info('The desks were fetched successfully', Severity.LOW);
-            const { data } = response;
-            setDesks(data);
-        }).catch(err => {
-            fetchDesksLogger.error(`got error from the server: ${err}`, Severity.HIGH);
-        });
-    }
 
     useEffect(() => {
         setIsLoading(true);
         Promise.all([
         fetchCities(),
-        fetchCounties(),
         fetchSourcesOrganization(),
         fetchLanguages(),
-        fetchDesks(),
         ])
         .finally(() => setIsLoading(false))
     }, [])
@@ -122,9 +90,7 @@ const useSignUp = ({ handleSaveUser }: useSignUpFormInCome) : useSignUpFormOutCo
     }
 
     return {
-        counties, 
         languages,
-        desks,
         sourcesOrganization,
         createUser
     }
@@ -134,8 +100,6 @@ interface useSignUpFormInCome {
 }
 
 interface useSignUpFormOutCome {
-    desks: Desk[];
-    counties: County[];
     languages: Language[];
     sourcesOrganization: SourceOrganization[];
     createUser: (data: SignUpUser) => void;

--- a/client/src/components/App/Content/UsersManagement/UsersManagement.tsx
+++ b/client/src/components/App/Content/UsersManagement/UsersManagement.tsx
@@ -1,26 +1,28 @@
-import React, { useState } from 'react';
 import {
     Grid, TableContainer, Paper, Table, TableHead, TableRow, TableCell, TableBody,
     IconButton, Tooltip, TableSortLabel, Badge, Typography, Collapse, MenuItem, Select
 } from '@material-ui/core';
+import { useSelector } from 'react-redux';
 import { Pagination } from '@material-ui/lab';
 import { PersonPin } from '@material-ui/icons';
+import React, { useState, useMemo } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFilter } from '@fortawesome/free-solid-svg-icons';
 
 import Desk from 'models/Desk';
 import County from 'models/County';
 import SortOrder from 'models/enums/SortOrder';
+import StoreStateType from 'redux/storeStateType';
 import SearchBar from 'commons/SearchBar/SearchBar';
 import IsActiveToggle from 'commons/IsActiveToggle/IsActiveToggle';
 import { get } from 'Utils/auxiliaryFunctions/auxiliaryFunctions';
 
-import { UsersManagementTableHeaders, UsersManagementTableHeadersNames } from './UsersManagementTableHeaders';
 import useStyles from './UsersManagementStyles';
-import useUsersManagementTable from './useUsersManagement';
-import UserInfoDialog from './UserInfoDialog/UserInfoDialog';
 import UsersFilter from './UsersFilter/UsersFilter';
 import filterCreators from './UsersFilter/FilterCreators';
+import useUsersManagementTable from './useUsersManagement';
+import UserInfoDialog from './UserInfoDialog/UserInfoDialog';
+import { UsersManagementTableHeaders, UsersManagementTableHeadersNames } from './UsersManagementTableHeaders';
 
 const rowsPerPage: number = 100;
 export const defaultPage: number = 1;
@@ -43,7 +45,9 @@ const UsersManagement: React.FC = () => {
     const [cellNameSort, setCellNameSort] = useState<CellNameSort>({ name: '', direction: undefined });
     const [isFilterOpen, setIsFilterOpen] = React.useState<boolean>(false);
 
-    const { users, counties, desks, sourcesOrganization, userTypes, languages,
+    const allCounties = useSelector<StoreStateType, County[]>(state => state.county.allCounties);
+
+    const { users, sourcesOrganization, userTypes, languages,
             totalCount, userDialog, isBadgeInVisible, watchUserInfo, handleCloseDialog, handleFilterChange, setUserActivityStatus,
             setUserSourceOrganization, setUserDesk, setUserCounty } =
             useUsersManagementTable({ page, rowsPerPage, cellNameSort, setPage });
@@ -51,6 +55,10 @@ const UsersManagement: React.FC = () => {
     const totalPages: number = Math.ceil(totalCount / rowsPerPage);
 
     const classes = useStyles();
+
+    const displayedCounty = useSelector<StoreStateType, number>(state => state.user.displayedCounty);
+    const desks = useSelector<StoreStateType, Desk[]>(state => state.desk);
+    const countyDesks = useMemo(() => desks.filter(desk => desk.county === displayedCounty), [desks, displayedCounty]);
 
     const handleSortOrder = (cellName: string) => {
         if (!notActiveSortFields.includes(cellName)) {
@@ -104,7 +112,7 @@ const UsersManagement: React.FC = () => {
                         variant='outlined'
                     >
                         {
-                            desks.map((desk: Desk) => (
+                            countyDesks.map((desk: Desk) => (
                                 <MenuItem
                                     key={desk.id}
                                     value={desk.id}>
@@ -168,7 +176,7 @@ const UsersManagement: React.FC = () => {
                         variant='outlined'
                     >
                         {
-                            counties.map((county: County) => (
+                            allCounties.map((county: County) => (
                                 <MenuItem
                                     key={county.id}
                                     value={county.id}>
@@ -214,7 +222,7 @@ const UsersManagement: React.FC = () => {
                     <UsersFilter
                         sourcesOrganization={sourcesOrganization}
                         languages={languages}
-                        counties={counties}
+                        counties={allCounties}
                         userTypes={userTypes}
                         handleFilterChange={handleFilterChange}
                         handleCloseFitler={() => setIsFilterOpen(false)}

--- a/client/src/components/App/Content/UsersManagement/UsersManagement.tsx
+++ b/client/src/components/App/Content/UsersManagement/UsersManagement.tsx
@@ -115,7 +115,7 @@ const UsersManagement: React.FC = () => {
                             countyDesks.map((desk: Desk) => (
                                 <MenuItem
                                     key={desk.id}
-                                    value={desk.id}>
+                                    value={desk.id as number}>
                                     {desk.deskName}
                                 </MenuItem>
                             ))

--- a/client/src/components/App/Content/UsersManagement/UsersManagement.tsx
+++ b/client/src/components/App/Content/UsersManagement/UsersManagement.tsx
@@ -2,10 +2,10 @@ import {
     Grid, TableContainer, Paper, Table, TableHead, TableRow, TableCell, TableBody,
     IconButton, Tooltip, TableSortLabel, Badge, Typography, Collapse, MenuItem, Select
 } from '@material-ui/core';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Pagination } from '@material-ui/lab';
 import { PersonPin } from '@material-ui/icons';
-import React, { useState, useMemo } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFilter } from '@fortawesome/free-solid-svg-icons';
 
@@ -14,6 +14,7 @@ import County from 'models/County';
 import SortOrder from 'models/enums/SortOrder';
 import StoreStateType from 'redux/storeStateType';
 import SearchBar from 'commons/SearchBar/SearchBar';
+import useDesksUtils from 'Utils/Desk/useDesksUtils';
 import IsActiveToggle from 'commons/IsActiveToggle/IsActiveToggle';
 import { get } from 'Utils/auxiliaryFunctions/auxiliaryFunctions';
 
@@ -56,9 +57,7 @@ const UsersManagement: React.FC = () => {
 
     const classes = useStyles();
 
-    const displayedCounty = useSelector<StoreStateType, number>(state => state.user.displayedCounty);
-    const desks = useSelector<StoreStateType, Desk[]>(state => state.desk);
-    const countyDesks = useMemo(() => desks.filter(desk => desk.county === displayedCounty), [desks, displayedCounty]);
+    const { countyDesks } = useDesksUtils();
 
     const handleSortOrder = (cellName: string) => {
         if (!notActiveSortFields.includes(cellName)) {
@@ -115,7 +114,7 @@ const UsersManagement: React.FC = () => {
                             countyDesks.map((desk: Desk) => (
                                 <MenuItem
                                     key={desk.id}
-                                    value={desk.id as number}>
+                                    value={desk.id!}>
                                     {desk.deskName}
                                 </MenuItem>
                             ))

--- a/client/src/components/App/useApp.ts
+++ b/client/src/components/App/useApp.ts
@@ -1,0 +1,160 @@
+import axios from 'axios';
+import { config } from 'dotenv';
+import { useSelector } from 'react-redux';
+import { useEffect, useState } from 'react';
+
+import User from 'models/User';
+import logger from 'logger/logger';
+import { Severity } from 'models/Logger';
+import UserType from 'models/enums/UserType';
+import StoreStateType from 'redux/storeStateType';
+import Environment from 'models/enums/Environments';
+import { setUser } from 'redux/User/userActionCreators';
+import { initialUserState } from 'redux/User/userReducer';
+import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
+import { setCounties } from 'redux/County/countyActionCreators';
+import { setIsLoading } from 'redux/IsLoading/isLoadingActionCreators';
+import { setDesks } from 'redux/Desk/deskActionCreators';
+
+config();
+
+type AuthenticationReturn = [{
+    access_token: string;
+    expires_on: Date;
+    id_token: string;
+    provider_name: string;
+    refresh_token: string;
+    user_claims: [{
+        typ: string;
+        val: string;
+    }];
+    user_id: string;
+}];
+
+const notInLocalEnv = () => (
+    process.env.REACT_APP_ENVIRONMENT === Environment.PROD ||
+    process.env.REACT_APP_ENVIRONMENT === Environment.DEV_AUTH ||
+    process.env.REACT_APP_ENVIRONMENT === Environment.TEST
+);
+
+const userNameClaimType = 'name';
+
+const getAuthUserData = async () => {
+    const { protocol, hostname } = window.location;
+    const { data } = await axios.get<AuthenticationReturn>(`${protocol}//${hostname}/.auth/me`);
+    const userId = data[0].user_id.split('@')[0];
+    const userName = data[0].user_claims.find(claim => claim.typ === userNameClaimType)?.val as string;
+    return { userId, userName };
+};
+
+const getStubAuthUserData = () => ({
+    userId: '7',
+    userName: 'stubuser'
+});
+
+const useApp = () => {
+
+    const user = useSelector<StoreStateType, User>(state => state.user.data);
+    const isUserLoggedIn = useSelector<StoreStateType, boolean>(state => state.user.isLoggedIn);
+
+    const [isSignUpOpen, setIsSignUpOpen] = useState<boolean>(false);
+    const { alertError } = useCustomSwal();
+
+    const initUser = async () => {
+        const initUserLogger = logger.setup('login to the app');
+        const { userId, userName } = notInLocalEnv() ? await getAuthUserData() : getStubAuthUserData();
+        initUserLogger.info('before environment condition', Severity.LOW);
+        fetchUser(userId, userName);
+    };
+
+    const handleSaveUser = () => {
+        handleCloseSignUp();
+        fetchUser(user.id, user.userName);
+    };
+
+    const handleCloseSignUp = () => setIsSignUpOpen(false);
+
+    const fetchUser = (userId: string, userName: string) => {
+        const fetchUserLogger = logger.setup('Getting user details');
+        fetchUserLogger.info('launch request to the server', Severity.LOW);
+        setIsLoading(true);
+        axios.get(`/users/user`).then((result: any) => {
+            if (result && result.data.userById) {
+                fetchUserLogger.info('recived user from the server', Severity.LOW);
+                const userFromDB = result.data.userById;
+                setUser({
+                    ...userFromDB,
+                    id: userId,
+                    userName
+                });
+            } else {
+                fetchUserLogger.warn(`user has not been found due to: ${JSON.stringify(result)}`, Severity.MEDIUM);
+                setUser({
+                    ...user,
+                    id: userId,
+                    userName
+                });
+                setIsSignUpOpen(true);
+            }
+
+            setIsLoading(false);
+        }).catch(err => {
+            fetchUserLogger.warn(`got error from the server: ${err}`, Severity.MEDIUM);
+            setIsLoading(false);
+        })
+    }
+
+    const fetchAllCounties = () => {
+        const fetchAllCountiesLogger = logger.setup('GraphQL request to the DB');
+        axios.get('/counties')
+        .then((result: any) => {
+            if (result.data && result.headers['content-type'].includes('application/json')) {
+                fetchAllCountiesLogger.info('fetched all the counties successfully', Severity.LOW);
+                setCounties(result.data, user.countyByInvestigationGroup.districtId);
+            } else {
+                fetchAllCountiesLogger.info('got 200 but bad structure', Severity.LOW);
+            }
+        }).catch(err => {
+            fetchAllCountiesLogger.error(err, Severity.HIGH);
+            alertError('לא ניתן לשלוף את הנפות של המחוז');
+        });
+    }
+    
+    const fetchDesks = () => {
+        const fetchDesksLogger = logger.setup('Getting desks');
+        fetchDesksLogger.info('launching desks request', Severity.LOW);
+        return axios.get('/desks')
+        .then(result => {
+            if (result.data && result.headers['content-type'].includes('application/json')) {
+                fetchDesksLogger.info('The desks were fetched successfully', Severity.LOW);
+                setDesks(result.data);
+            } else {
+                fetchDesksLogger.info('got 200 but bad structure', Severity.LOW);
+            }
+        }).catch(err => {
+            fetchDesksLogger.error(`got error from the server: ${err}`, Severity.HIGH);
+        });
+    }
+
+    useEffect(() => {
+        if(!isUserLoggedIn) {
+            initUser();
+        }
+        fetchDesks();
+    }, []);
+
+
+    useEffect(() => {
+        if((user !== initialUserState.data && user.userType === UserType.ADMIN || user.userType === UserType.SUPER_ADMIN) || isSignUpOpen) {
+            fetchAllCounties();
+        }
+    }, [user, isSignUpOpen]);
+
+    return {
+        isSignUpOpen,
+        handleSaveUser, 
+        handleCloseSignUp
+    }
+}
+
+export default useApp;

--- a/client/src/models/County.ts
+++ b/client/src/models/County.ts
@@ -1,6 +1,9 @@
+import District from './District';
+
 interface County {
     id: number;
     displayName: string;
+    district: District;
 }
 
 export default County;

--- a/client/src/models/CountyReducer.ts
+++ b/client/src/models/CountyReducer.ts
@@ -1,0 +1,7 @@
+import County from './County';
+interface CountyReducer {
+    allCounties: County[];
+    districtCounties: County[];
+}
+
+export default CountyReducer;

--- a/client/src/models/Desk.ts
+++ b/client/src/models/Desk.ts
@@ -1,5 +1,5 @@
 interface Desk {
-    id: number;
+    id: number | null;
     deskName: string;
     county: number;
 }

--- a/client/src/models/Desk.ts
+++ b/client/src/models/Desk.ts
@@ -1,6 +1,7 @@
 interface Desk {
     id: number;
     deskName: string;
+    county: number;
 }
 
 export default Desk;

--- a/client/src/models/District.ts
+++ b/client/src/models/District.ts
@@ -1,0 +1,6 @@
+interface District {
+    id: number;
+    displayName: string;
+}
+
+export default District;

--- a/client/src/models/User.ts
+++ b/client/src/models/User.ts
@@ -21,7 +21,8 @@ interface User {
 };
 
 interface CountyByInvestigationGroup {
-    districtId: number
+    districtId: number,
+    displayName: string
 };
 
 export default User;

--- a/client/src/redux/County/countyActionCreators.ts
+++ b/client/src/redux/County/countyActionCreators.ts
@@ -1,0 +1,11 @@
+import County from 'models/County';
+
+import {store} from '../store';
+import * as actionTypes from './countyActionTypes';
+
+export const setCounties = (counties: County[], userDistrict: number): void => {
+    store.dispatch({
+        type: actionTypes.SET_COUNTIES,
+        payload: {counties, userDistrict}
+    })
+}

--- a/client/src/redux/County/countyActionTypes.ts
+++ b/client/src/redux/County/countyActionTypes.ts
@@ -1,0 +1,10 @@
+import County from 'models/County';
+
+export const SET_COUNTIES = 'SET_COUNTIES';
+
+interface SetCounties {
+    type: typeof SET_COUNTIES,
+    payload: { counties: County[], userDistrict: number }
+}
+
+export type countyAction = SetCounties;

--- a/client/src/redux/County/countyReducer.ts
+++ b/client/src/redux/County/countyReducer.ts
@@ -1,0 +1,19 @@
+import CountyReducer from 'models/CountyReducer';
+
+import * as Actions from './countyActionTypes';
+
+const initialState: CountyReducer = {allCounties: [], districtCounties: []};
+
+const countyReducer = (state = initialState, action: Actions.countyAction): CountyReducer => {
+    switch (action.type) {
+        case Actions.SET_COUNTIES: {
+            return {
+                allCounties: action.payload.counties,
+                districtCounties: action.payload.counties.filter(county => county.district.id === action.payload.userDistrict)
+            }
+        }
+        default: return state;
+    }
+}
+
+export default countyReducer;

--- a/client/src/redux/Desk/deskActionCreators.ts
+++ b/client/src/redux/Desk/deskActionCreators.ts
@@ -1,0 +1,11 @@
+import County from 'models/County';
+
+import {store} from '../store';
+import * as actionTypes from './deskActionTypes';
+
+export const setDesks = (desks: County[]): void => {
+    store.dispatch({
+        type: actionTypes.SET_DESKS,
+        payload: {desks}
+    })
+}

--- a/client/src/redux/Desk/deskActionTypes.ts
+++ b/client/src/redux/Desk/deskActionTypes.ts
@@ -1,0 +1,10 @@
+import Desk from 'models/Desk';
+
+export const SET_DESKS = 'SET_DESKS';
+
+interface SetDesks {
+    type: typeof SET_DESKS,
+    payload: { desks: Desk[] }
+}
+
+export type deskAction = SetDesks;

--- a/client/src/redux/Desk/deskReducer.ts
+++ b/client/src/redux/Desk/deskReducer.ts
@@ -1,0 +1,14 @@
+import Desk from 'models/Desk';
+
+import * as Actions from './deskActionTypes';
+
+const initialState: Desk[] = [];
+
+const deskReducer = (state = initialState, action: Actions.deskAction): Desk[] => {
+    switch (action.type) {
+        case Actions.SET_DESKS: return action.payload.desks
+        default: return state;
+    }
+}
+
+export default deskReducer;

--- a/client/src/redux/User/userActionCreators.ts
+++ b/client/src/redux/User/userActionCreators.ts
@@ -16,3 +16,10 @@ export const setIsActive = (isActive: boolean) => {
         payload: {isActive}
     });
 }
+
+export const setDisplayedCounty = (county: number) => {
+    store.dispatch({
+        type: actionTypes.SET_DISPLAYED_COUNTY,
+        payload: {county}
+    });
+}

--- a/client/src/redux/User/userActionTypes.ts
+++ b/client/src/redux/User/userActionTypes.ts
@@ -2,7 +2,7 @@ import User from 'models/User';
 
 export const SET_USER = 'SET_USER';
 export const SET_IS_ACTIVE = 'SET_IS_ACTIVE';
-
+export const SET_DISPLAYED_COUNTY = 'SET_DISPLAYED_COUNTY';
 interface SetUser {
     type: typeof SET_USER,
     payload: { user: User }
@@ -13,4 +13,9 @@ interface SetIsActive {
     payload: { isActive: boolean }
 };
 
-export type UserAction = SetUser | SetIsActive;
+interface SetDisplayedCounty {
+    type: typeof SET_DISPLAYED_COUNTY,
+    payload: { county: number }
+};
+
+export type UserAction = SetUser | SetIsActive | SetDisplayedCounty;

--- a/client/src/redux/User/userReducer.ts
+++ b/client/src/redux/User/userReducer.ts
@@ -6,6 +6,7 @@ import * as Actions from './userActionTypes';
 export interface UserState {
     data: User;
     isLoggedIn: boolean;
+    displayedCounty: number;
 }
 
 export const initialUserState: UserState = {
@@ -24,10 +25,12 @@ export const initialUserState: UserState = {
         sourceOrganization: '',
         deskName: '',
         countyByInvestigationGroup: {
-            districtId: -1
+            districtId: -1,
+            displayName: ''
         }
     },
-    isLoggedIn: false
+    isLoggedIn: false,
+    displayedCounty: -1
 }
 
 const userReducer = (state = initialUserState, action: Actions.UserAction): UserState => {
@@ -35,11 +38,16 @@ const userReducer = (state = initialUserState, action: Actions.UserAction): User
         case Actions.SET_USER: return {
             ...state,
             data: action.payload.user,
-            isLoggedIn: true
+            isLoggedIn: true,
+            displayedCounty: action.payload.user.investigationGroup
         };
         case Actions.SET_IS_ACTIVE: return {
             ...state,
             data: { ...state.data, isActive: action.payload.isActive }
+        };
+        case Actions.SET_DISPLAYED_COUNTY: return {
+            ...state,
+            displayedCounty: action.payload.county
         };
         default: return state;
     }

--- a/client/src/redux/rootReducers.ts
+++ b/client/src/redux/rootReducers.ts
@@ -16,6 +16,8 @@ import investigationReducer from './Investigation/investigationReducer';
 import isInInvestigationReducer from './IsInInvestigations/isInInvestigationReducer';
 import educationGradeReducer from './EducationGrade/educationGradeReducer';
 import placetypeReducer from './PlaceTypes/placetypeReducer';
+import countyReducer from './County/countyReducer';
+import deskReducer from './Desk/deskReducer';
 
 export default combineReducers<StoreStateType>({
      occupations: occupationsReducer,
@@ -32,5 +34,7 @@ export default combineReducers<StoreStateType>({
      formsValidations: formReducer,
      address: addressReducer,
      educationGrades: educationGradeReducer,
-     placeSubTypesByTypes: placetypeReducer
+     placeSubTypesByTypes: placetypeReducer,
+     county: countyReducer,
+     desk: deskReducer,
 }) as unknown as Reducer<CombinedState<StoreStateType>, AnyAction>;

--- a/client/src/redux/storeStateType.ts
+++ b/client/src/redux/storeStateType.ts
@@ -1,14 +1,15 @@
+import Desk from 'models/Desk';
 import City from 'models/City';
 import Country from 'models/Country';
-import FlattenedDBAddress from 'models/DBAddress';
 import ContactType from 'models/ContactType';
+import CountyReducer from 'models/CountyReducer';
+import FlattenedDBAddress from 'models/DBAddress';
+import EducationGrade from 'models/EducationGrade';
 import InvestigationRedux from 'models/InvestigationRedux';
+import PlacesSubTypesByTypes from 'models/PlacesSubTypesByTypes';
 import InvestigationMainStatus from 'models/InvestigationMainStatus';
 
 import { UserState } from './User/userReducer';
-import EducationGrade from 'models/EducationGrade';
-import PlacesSubTypesByTypes from 'models/PlacesSubTypesByTypes';
-
 export default interface StoreStateType {
     user: UserState;
     isLoading: boolean;
@@ -25,4 +26,6 @@ export default interface StoreStateType {
     formsValidations: { [key: number]: (boolean | null)[] };
     address: FlattenedDBAddress;
     educationGrades: EducationGrade[];
+    county: CountyReducer;
+    desk: Desk[]
 };

--- a/server/src/ClientToDBAPI/CountiesRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/CountiesRoute/mainRoute.ts
@@ -1,9 +1,9 @@
 import { Router, Request, Response } from 'express';
 
 import { Severity } from '../../Models/Logger/types';
+import { GET_ALL_COUNTIES } from '../../DBService/Counties/Query';
 import { errorStatusCode, graphqlRequest } from '../../GraphqlHTTPRequest';
 import GetAllCountiesResponse from '../../Models/User/GetAllCountiesResponse';
-import { GET_COUNTY_DISPLAY_NAME_BY_USER, GET_ALL_COUNTIES } from '../../DBService/Counties/Query';
 import logger, { invalidDBResponseLog, launchingDBRequestLog, validDBResponseLog } from '../../Logger/Logger';
 
 const countiesRoute = Router();
@@ -12,38 +12,14 @@ countiesRoute.get('', (request: Request, response: Response) => {
     const getCountiesLogger = logger.setup({
         workflow: 'query all counties',
     });
+    getCountiesLogger.info(launchingDBRequestLog(), Severity.LOW);
     graphqlRequest(GET_ALL_COUNTIES, response.locals)
         .then((result: GetAllCountiesResponse) => {
             getCountiesLogger.info(validDBResponseLog, Severity.LOW);
-            const counties = result.data.allCounties.nodes.map((county: any) => ({
-                ...county,
-                district: county.district.displayName
-            }));
-            response.send(counties);
+            response.send(result.data.allCounties.nodes);
         })
         .catch((error) => {
             getCountiesLogger.error(invalidDBResponseLog(error), Severity.HIGH);
-            response.status(errorStatusCode).send(error);
-        });
-});
-
-
-countiesRoute.get('/county/displayName', (request: Request, response: Response) => {
-    const countyByUserLogger = logger.setup({
-        workflow: 'query county display name by user',
-        user: response.locals.user.id
-    });
-
-    const paramertes = { id: +response.locals.user.investigationGroup };
-    countyByUserLogger.info(launchingDBRequestLog(paramertes), Severity.LOW);
-
-    graphqlRequest(GET_COUNTY_DISPLAY_NAME_BY_USER, response.locals, paramertes)
-        .then(result => {
-            countyByUserLogger.info(validDBResponseLog, Severity.LOW);
-            return response.send(result.data.countyById.displayName as string);
-        })
-        .catch(error => {
-            countyByUserLogger.error(invalidDBResponseLog(error), Severity.HIGH);
             response.status(errorStatusCode).send(error);
         });
 });

--- a/server/src/ClientToDBAPI/DesksRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/DesksRoute/mainRoute.ts
@@ -2,8 +2,8 @@ import { Router, Request, Response } from 'express';
 
 import { Severity } from '../../Models/Logger/types';
 import GetAllDesks from '../../Models/Desk/GetAllDesks';
+import { ALL_DESKS_QUERY } from '../../DBService/Desk/Query';
 import { errorStatusCode, graphqlRequest } from '../../GraphqlHTTPRequest';
-import { ALL_DESKS_QUERY, DESKS_BY_COUNTY_ID } from '../../DBService/Desk/Query';
 import logger, { invalidDBResponseLog, launchingDBRequestLog, validDBResponseLog } from '../../Logger/Logger';
 
 const router = Router();
@@ -25,25 +25,4 @@ router.get('/', (request: Request, response: Response) => {
         response.sendStatus(errorStatusCode).send(error);
     })
 });
-
-router.get('/county', (request: Request, response: Response) => {
-    const countyLogger = logger.setup({
-        workflow: 'query desks by county id',
-        user: response.locals.user.id,
-        investigation: response.locals.epidemiologynumber
-    });
-    
-    const parameters = { countyId: +response.locals.user.investigationGroup };
-    countyLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
-    graphqlRequest(DESKS_BY_COUNTY_ID, response.locals, parameters)
-    .then((res: GetAllDesks) => {
-        countyLogger.info(validDBResponseLog, Severity.LOW);
-        response.send(res.data.allDesks.nodes);
-    })
-    .catch(error => {
-        countyLogger.error(invalidDBResponseLog(error), Severity.HIGH);
-        response.sendStatus(errorStatusCode).send(error);
-    })
-});
-
 export default router;

--- a/server/src/ClientToDBAPI/LandingPageRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/LandingPageRoute/mainRoute.ts
@@ -60,14 +60,14 @@ landingPageRoute.post('/groupInvestigations', adminMiddleWare, (request: Request
         investigation: response.locals.epidemiologynumber
     })
 
-    const { orderBy, size, currentPage, filterRules } = request.body;
+    const { orderBy, size, currentPage, filterRules, county } = request.body;
     const filterBy = {
         ...filterRules,
         userByCreator: {
             ...filterRules.userByCreator,
             countyByInvestigationGroup: {
                 id: {
-                    equalTo: +response.locals.user.investigationGroup
+                    equalTo: +county
                 }
             }
         },
@@ -81,7 +81,7 @@ landingPageRoute.post('/groupInvestigations', adminMiddleWare, (request: Request
     };
     groupInvestigationsLogger.info(launchingDBRequestLog(getInvestigationsParameters), Severity.LOW);
 
-    graphqlRequest(GROUP_INVESTIGATIONS(+response.locals.user.investigationGroup), response.locals, getInvestigationsParameters)
+    graphqlRequest(GROUP_INVESTIGATIONS(+county), response.locals, getInvestigationsParameters)
         .then(result => {
             groupInvestigationsLogger.info(validDBResponseLog, Severity.LOW);
             response.send({
@@ -165,7 +165,7 @@ landingPageRoute.post('/changeGroupDesk', adminMiddleWare, (request: Request, re
     const parameters = { 
         desk: request.body.desk,
         selectedGroups: request.body.groupIds,
-        userCounty: response.locals.user.investigationGroup, 
+        userCounty: request.body.county, 
         reason:  request.body.reason || ''
     }
     changeGroupDeskLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
@@ -189,6 +189,7 @@ landingPageRoute.post('/investigationStatistics', adminMiddleWare ,(request: Req
 
     const desks = request.body.deskFilter;
     const timeRange = request.body.timeRangeFilter; 
+    const county = request.body.county; 
 
     const desksFilter = desks
                         ? { deskId : { in : desks}} 
@@ -201,7 +202,7 @@ landingPageRoute.post('/investigationStatistics', adminMiddleWare ,(request: Req
     const userFilters = {
         userByCreator: {
             countyByInvestigationGroup: {
-                id: {equalTo: response.locals.user.investigationGroup}
+                id: {equalTo: county}
             }
         },
         ...desksFilter,

--- a/server/src/ClientToDBAPI/UsersRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/UsersRoute/mainRoute.ts
@@ -1,19 +1,19 @@
 import { Router, Request, Response } from 'express';
 
 import User from '../../Models/User/User';
-import { Service, Severity } from '../../Models/Logger/types';
+import { Severity } from '../../Models/Logger/types';
+import { adminMiddleWare } from '../../middlewares/Authentication';
 import CreateUserResponse from '../../Models/User/CreateUserResponse';
 import { graphqlRequest, errorStatusCode } from '../../GraphqlHTTPRequest';
 import GetAllUserTypesResponse from '../../Models/User/GetAllUserTypesResponse';
 import GetAllSourceOrganizations from '../../Models/User/GetAllSourceOrganizations';
-import { adminMiddleWare, superAdminMiddleWare } from '../../middlewares/Authentication';
 import GetAllLanguagesResponse, { Language } from '../../Models/User/GetAllLanguagesResponse';
 import logger, { invalidDBResponseLog, launchingDBRequestLog, validDBResponseLog } from '../../Logger/Logger';
 import { UPDATE_IS_USER_ACTIVE, UPDATE_INVESTIGATOR, CREATE_USER, UPDATE_COUNTY_BY_USER, UPDATE_INVESTIGATOR_BY_GROUP_ID,
          UPDATE_SOURCE_ORGANIZATION, UPDATE_DESK, UPDATE_COUNTY } from '../../DBService/Users/Mutation';
 import {
     GET_IS_USER_ACTIVE, GET_USER_BY_ID, GET_ACTIVE_GROUP_USERS,
-    GET_ALL_LANGUAGES, GET_ALL_SOURCE_ORGANIZATION, GET_USERS_BY_DISTRICT_ID, GET_ALL_USER_TYPES, GET_USERS_BY_COUNTY_ID
+    GET_ALL_LANGUAGES, GET_ALL_SOURCE_ORGANIZATION, GET_ALL_USER_TYPES, GET_USERS_BY_COUNTY_ID
 } from '../../DBService/Users/Query';
 
 const usersRoute = Router();
@@ -187,7 +187,7 @@ usersRoute.post('/changeGroupInvestigator', adminMiddleWare, (request: Request, 
     const parameters = { 
         newInvestigator: request.body.user,
         selectedGroups: request.body.groupIds,
-        userCounty: response.locals.user.investigationGroup
+        userCounty: request.body.county
     }
     changeGroupInvestigatorLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
 
@@ -211,7 +211,7 @@ usersRoute.post('/changeGroupCounty', adminMiddleWare, (request: Request, respon
     const parameters = { 
         newInvestigator: `${unassignedUserPrefix}${request.body.county}`,
         selectedGroups: request.body.groupIds,
-        userCounty: response.locals.user.investigationGroup,
+        userCounty: request.body.county,
         wasInvestigationTransferred: true
     }
     changeGroupCountyLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
@@ -244,19 +244,20 @@ usersRoute.get('/userTypes', (request: Request, response: Response) => {
         })
 })
 
-usersRoute.get('/group', adminMiddleWare, (request: Request, response: Response) => {
+usersRoute.get('/group/:county', adminMiddleWare, (request: Request, response: Response) => {
     const groupLogger = logger.setup({
         workflow: `query investigators by county`,
         user: response.locals.user.id,
     });
 
-    const parameters = { inputCountyId: +response.locals.user.investigationGroup };
+    const parameters = { inputCountyId: parseInt(request.params.county) };
     groupLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
 
     graphqlRequest(GET_ACTIVE_GROUP_USERS, response.locals, parameters)
         .then(result => {
             groupLogger.info(validDBResponseLog, Severity.LOW);
-            const resData = JSON.parse(result.data.getInvestigatorListByCountyFunction.json);
+            const usersJson = result.data.getInvestigatorListByCountyFunction.json;
+            const resData = usersJson ? JSON.parse(usersJson) : [];
             const users: User[] = resData.map((user: any) => ({
                 ...user,
                 languages: user.languages.map((language: any) => language),
@@ -354,42 +355,6 @@ usersRoute.post('', (request: Request, response: Response) => {
         });
 });
 
-usersRoute.post('/district', superAdminMiddleWare, (request: Request, response: Response) => {
-    const districtLogger = logger.setup({
-        workflow: 'query users by current user district',
-        user: response.locals.user.id
-    });
-
-    const { page } = request.body;
-    const parameters = {
-        offset: calculateOffset(page.number, page.size),
-        size: page.size,
-        orderBy: [request.body.orderBy ? request.body.orderBy : 'NATURAL'],
-        filter: {
-            countyByInvestigationGroup: {
-                districtByDistrictId: {
-                    id: {
-                        equalTo: response.locals.user.countyByInvestigationGroup.districtId
-                    }
-                }
-            },
-            ...request.body.filter
-        }
-    }
-    districtLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
-    graphqlRequest(GET_USERS_BY_DISTRICT_ID,response.locals,parameters)
-        .then(result => {
-            districtLogger.info(validDBResponseLog, Severity.LOW);
-            const totalCount = result.data.allUsers.totalCount;
-            const users = result.data.allUsers.nodes.map(convertToUser);
-            response.send({ users, totalCount });
-        })
-        .catch(error => {
-            districtLogger.error(invalidDBResponseLog(error), Severity.HIGH);
-            response.sendStatus(errorStatusCode).send(error);
-        })
-});
-
 usersRoute.post('/county', adminMiddleWare, (request: Request, response: Response) => {
     const countyLogger = logger.setup({
         workflow: 'query users by current user\'s county id',
@@ -403,7 +368,7 @@ usersRoute.post('/county', adminMiddleWare, (request: Request, response: Respons
         filter: {
             countyByInvestigationGroup: {
                 id: {
-                    equalTo: +response.locals.user.investigationGroup
+                    equalTo: +request.body.county
                 }
             },
             ...request.body.filter

--- a/server/src/DBService/Counties/Query.ts
+++ b/server/src/DBService/Counties/Query.ts
@@ -7,17 +7,10 @@ query allCounties {
       id
       displayName
       district: districtByDistrictId {
+        id
         displayName
       }
     }
-  }
-}
-`;
-
-export const GET_COUNTY_DISPLAY_NAME_BY_USER = gql`
-query getCounty($id: Int!) {
-  countyById(id: $id) {
-    displayName
   }
 }
 `;

--- a/server/src/DBService/Desk/Query.ts
+++ b/server/src/DBService/Desk/Query.ts
@@ -5,18 +5,9 @@ query AllDesks {
   allDesks {
     nodes {
       id
-      name: deskName
+      deskName
+      county: countyId
     }
-  }
-}
-`
-export const DESKS_BY_COUNTY_ID = gql`
-query DesksByCounty($countyId: Int!) {
-  allDesks(filter: {countyId: {equalTo: $countyId}}) {
-      nodes {
-        id
-        deskName
-      }
   }
 }
 `

--- a/server/src/DBService/InvestigationInfo/Query.ts
+++ b/server/src/DBService/InvestigationInfo/Query.ts
@@ -77,6 +77,9 @@ query InvestigationCreator($epidemiologynumber: Int!) {
     userByCreator {
       investigationGroup
       id
+      districtId: countyByInvestigationGroup {
+        districtId
+      }
     }
   }
 }

--- a/server/src/DBService/LandingPage/Query.ts
+++ b/server/src/DBService/LandingPage/Query.ts
@@ -150,19 +150,6 @@ query AllInvestigations($orderBy: String!, $offset: Int!, $size: Int!, $filter: 
 }
 `;
 
-export const GET_USER_BY_ID = gql`
-query GetUserById($userId: String!) {
-  userById(id: $userId) {
-    id
-    investigationGroup
-    phoneNumber
-    serialNumber
-    userName
-    userType
-  }
-}
-`;
-
 export const GET_ALL_INVESTIGATION_STATUS = gql`
 query allInvestigationStatuses {
   allInvestigationStatuses(orderBy: DISPLAY_NAME_ASC) {

--- a/server/src/DBService/Users/Query.ts
+++ b/server/src/DBService/Users/Query.ts
@@ -19,6 +19,7 @@ query GetUser($id: String!) {
       userName
       userType
       countyByInvestigationGroup {
+        displayName
         districtId
       }
     }
@@ -58,51 +59,6 @@ query allLanguages {
     nodes {
       displayName
     }
-  }
-}
-`;
-
-export const GET_USERS_BY_DISTRICT_ID = gql`
-query usersQuery($offset: Int!, $size: Int!, $orderBy: [UsersOrderBy!], $filter: UserFilter!) {
-  allUsers(
-    first: $size, 
-    offset: $offset, 
-    orderBy: $orderBy,
-    filter: $filter
-  ) {
-    nodes {
-      id
-      fullName
-      userName
-      phoneNumber
-      mail
-      identityNumber
-      isActive
-      cityByCity {
-        displayName
-      }
-      isActive
-      userLanguagesByUserId {
-        nodes {
-          language
-        }
-      }
-      userTypeByUserType {
-        displayName
-      }
-      countyByInvestigationGroup {
-        id,
-        displayName
-      }
-      sourceOrganizationBySourceOrganization {
-        displayName
-      }
-      deskByDeskId {
-        id,
-        deskName
-      }
-    }
-    totalCount
   }
 }
 `;


### PR DESCRIPTION
### This PR includes:
1. Added the feature of changing the displayed county for super admins.
2. On user management route, the users displayed are always of the displayed county, and not of the user’s district(as there was for super admin)
3. Due to the changes, I moved both the desks and counties to redux, and added the displayedCounty data to the redux as well
4. Changed the Desk model: added the district and changed the id to be nullable, due to the change commited on the unassigned desk ID