### PR TITLE
Feat(postponed investigations card): Add postponed investigations card in admin landing page

### DIFF
--- a/client/src/commons/statusToFilterConvertor.ts
+++ b/client/src/commons/statusToFilterConvertor.ts
@@ -1,4 +1,5 @@
 import FilterRulesDescription from 'models/enums/FilterRulesDescription';
+import InvestigationSubStatusCodes from 'models/enums/InvestigationSubStatusCodes'
 import InvestigationMainStatusCodes from 'models/enums/InvestigationMainStatusCodes';
 
 const statusToFilterConvertor = {
@@ -14,10 +15,10 @@ const statusToFilterConvertor = {
         unassignedUserFilter: true
     },
     [FilterRulesDescription.TRANSFER_REQUEST]: {
-        subStatusFilter: ['נדרשת העברה']
+        subStatusFilter: [InvestigationSubStatusCodes.TRANSFER_REQUEST]
     },
     [FilterRulesDescription.WAITING_FOR_DETAILS]: {
-        subStatusFilter: ['מחכה להשלמת פרטים']
+        subStatusFilter: [InvestigationSubStatusCodes.WAITING_FOR_DETAILS]
     },
     [FilterRulesDescription.UNASSIGNED]: {
         unassignedUserFilter: true

--- a/client/src/commons/statusToFilterConvertor.ts
+++ b/client/src/commons/statusToFilterConvertor.ts
@@ -13,6 +13,9 @@ const statusToFilterConvertor = {
         inactiveUserFilter: true,
         unassignedUserFilter: true
     },
+    [FilterRulesDescription.TRANSFER_REQUEST]: {
+        subStatusFilter: ['נדרשת העברה']
+    },
     [FilterRulesDescription.UNASSIGNED]: {
         unassignedUserFilter: true
     },

--- a/client/src/commons/statusToFilterConvertor.ts
+++ b/client/src/commons/statusToFilterConvertor.ts
@@ -16,6 +16,9 @@ const statusToFilterConvertor = {
     [FilterRulesDescription.TRANSFER_REQUEST]: {
         subStatusFilter: ['נדרשת העברה']
     },
+    [FilterRulesDescription.WAITING_FOR_DETAILS]: {
+        subStatusFilter: ['מחכה להשלמת פרטים']
+    },
     [FilterRulesDescription.UNASSIGNED]: {
         unassignedUserFilter: true
     },

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -163,7 +163,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
 
     const getFilterRules = () => {
         const statusFilterToSet = historyStatusFilter.length > 0 ? filterCreators.STATUS(historyStatusFilter) : null;
-        const subStatusFilterToSet = historySubStatusFilter.length > 0 ? filterCreators.SUB_STATUS(historyStatusFilter) : null;
+        const subStatusFilterToSet = historySubStatusFilter.length > 0 ? filterCreators.SUB_STATUS(historySubStatusFilter) : null;
         const deskFilterToSet = historyDeskFilter.length > 0 ? filterCreators.DESK_ID(historyDeskFilter) : null;
         const timeRangeFilterToSet = historyTimeRange.id !== allTimeRangeId ? filterCreators.TIME_RANGE(historyTimeRange) : null;
         const unAssignedFilterToSet = (historyUnassignedUserFilter && !inactiveUserFilter) ? filterCreators.UNASSIGNED_USER(historyUnassignedUserFilter) : null;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -980,6 +980,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         changeInvestigationsInvestigator,
         statusFilter,
         subStatusFilter,
+        changeSubStatusFilter,
         changeStatusFilter,
         deskFilter,
         changeDeskFilter,
@@ -992,8 +993,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         fetchAllCountyUsers,
         tableTitle, 
         timeRangeFilter,
-        isBadgeInVisible,
-        changeSubStatusFilter
+        isBadgeInVisible
     };
 };
 

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/PostponedCard/PostponedCard.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/PostponedCard/PostponedCard.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Tooltip, Typography, Box, Divider } from '@material-ui/core';
-import NavigateBeforeIcon from '@material-ui/icons/NavigateBefore';
 import { Pause } from '@material-ui/icons';
-
+import NavigateBeforeIcon from '@material-ui/icons/NavigateBefore';
+import { Tooltip, Typography, Box, Divider } from '@material-ui/core';
 
 import FilterRulesVariables from 'models/FilterRulesVariables';
 import statusToFilterConvertor from 'commons/statusToFilterConvertor';

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/PostponedCard/PostponedCard.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/PostponedCard/PostponedCard.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Tooltip, Typography, Box } from '@material-ui/core';
+import NavigateBeforeIcon from '@material-ui/icons/NavigateBefore';
+import { Pause } from '@material-ui/icons';
+
+
+import FilterRulesVariables from 'models/FilterRulesVariables';
+import statusToFilterConvertor from 'commons/statusToFilterConvertor';
+import FilterRulesDescription from 'models/enums/FilterRulesDescription';
+
+import useHoverStyles from '../useHoverStyles';
+import LoadingCard from '../LoadingCard/LoadingCard';
+import useStyles, { cardHeight } from './PostponedCardStyles';
+
+const postponedInvestigationsText = 'חקירות לא משויכות/ משויכות לחוקרים לא פעילים';
+
+const PostponedCard: React.FC<Props> = (props: Props): JSX.Element => {
+    const classes = useStyles();
+    const hoverClasses = useHoverStyles();
+
+    const { onClick, isLoading, postponedInvestigationsCount } = props;
+
+    return (
+        <LoadingCard isLoading={isLoading} height={cardHeight} className={classes.postponedCard}>
+            <div className={classes.investigationAmount}>
+                <Pause className={classes.pauseIcon}/>
+                <Typography className={classes.investigationAmountText}><b>חקירות מושהות</b></Typography>
+            </div>
+            <Tooltip title={postponedInvestigationsText}>
+                <div className={hoverClasses.whiteButtons} onClick={() => onClick(statusToFilterConvertor[FilterRulesDescription.TRANSFER_REQUEST])}>
+                    <Box display='flex'>
+                        <Typography>
+                            <b>
+                                {postponedInvestigationsCount} 
+                                {FilterRulesDescription.TRANSFER_REQUEST}
+                            </b>
+                        </Typography>
+                        <NavigateBeforeIcon className={classes.navigateIcon} />
+                    </Box>
+                </div>
+            </Tooltip>
+        </LoadingCard>
+    )
+}
+
+export default PostponedCard;
+
+interface Props {
+    onClick: (infoFilter: FilterRulesVariables) => void;
+    isLoading: boolean;
+    postponedInvestigationsCount: number;
+}

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/PostponedCard/PostponedCard.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/PostponedCard/PostponedCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Tooltip, Typography, Box } from '@material-ui/core';
+import { Tooltip, Typography, Box, Divider } from '@material-ui/core';
 import NavigateBeforeIcon from '@material-ui/icons/NavigateBefore';
 import { Pause } from '@material-ui/icons';
 
@@ -18,7 +18,7 @@ const PostponedCard: React.FC<Props> = (props: Props): JSX.Element => {
     const classes = useStyles();
     const hoverClasses = useHoverStyles();
 
-    const { onClick, isLoading, postponedInvestigationsCount } = props;
+    const { onClick, isLoading, transferRequestInvestigationsCount, waitingForDetailsInvestigationsCount } = props;
 
     return (
         <LoadingCard isLoading={isLoading} height={cardHeight} className={classes.postponedCard}>
@@ -31,8 +31,22 @@ const PostponedCard: React.FC<Props> = (props: Props): JSX.Element => {
                     <Box display='flex'>
                         <Typography>
                             <b>
-                                {postponedInvestigationsCount} 
-                                {FilterRulesDescription.TRANSFER_REQUEST}
+                                {transferRequestInvestigationsCount} 
+                                {'חקירות ממתינות להעברה'}
+                            </b>
+                        </Typography>
+                        <NavigateBeforeIcon className={classes.navigateIcon} />
+                    </Box>
+                </div>
+            </Tooltip>
+            <Divider/>
+            <Tooltip title={postponedInvestigationsText}>
+                <div className={hoverClasses.whiteButtons} onClick={() => onClick(statusToFilterConvertor[FilterRulesDescription.WAITING_FOR_DETAILS])}>
+                    <Box display='flex'>
+                        <Typography>
+                            <b>
+                                {waitingForDetailsInvestigationsCount}
+                                {'חקירות ממתינות להשלמת פרטים'} 
                             </b>
                         </Typography>
                         <NavigateBeforeIcon className={classes.navigateIcon} />
@@ -48,5 +62,6 @@ export default PostponedCard;
 interface Props {
     onClick: (infoFilter: FilterRulesVariables) => void;
     isLoading: boolean;
-    postponedInvestigationsCount: number;
+    transferRequestInvestigationsCount: number;
+    waitingForDetailsInvestigationsCount: number;
 }

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/PostponedCard/PostponedCard.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/PostponedCard/PostponedCard.tsx
@@ -12,7 +12,11 @@ import useHoverStyles from '../useHoverStyles';
 import LoadingCard from '../LoadingCard/LoadingCard';
 import useStyles, { cardHeight } from './PostponedCardStyles';
 
-const postponedInvestigationsText = 'חקירות לא משויכות/ משויכות לחוקרים לא פעילים';
+const postponedInvestigationsTitle = 'חקירות מושהות';
+const transferRequestText = 'חקירות שתת הסטטוס שלהן הוא נדרשת העברה';
+const transferRequestTitle = 'חקירות הממתינות להעברה';
+const waitingForDetailsText = 'חקירות שתת הסטטוס שלהן הוא מחכה להשלמת פרטים';
+const waitingForDetailsTitle = 'חקירות הממתינות להשלמת פרטים';
 
 const PostponedCard: React.FC<Props> = (props: Props): JSX.Element => {
     const classes = useStyles();
@@ -24,31 +28,29 @@ const PostponedCard: React.FC<Props> = (props: Props): JSX.Element => {
         <LoadingCard isLoading={isLoading} height={cardHeight} className={classes.postponedCard}>
             <div className={classes.investigationAmount}>
                 <Pause className={classes.pauseIcon}/>
-                <Typography className={classes.investigationAmountText}><b>חקירות מושהות</b></Typography>
+                <Typography><b>{postponedInvestigationsTitle}</b></Typography>
             </div>
-            <Tooltip title={postponedInvestigationsText}>
-                <div className={hoverClasses.whiteButtons} onClick={() => onClick(statusToFilterConvertor[FilterRulesDescription.TRANSFER_REQUEST])}>
+            <Tooltip title={transferRequestText}>
+                <div 
+                    className={[classes.filterText, hoverClasses.whiteButtons].join(' ')} 
+                    onClick={() => onClick(statusToFilterConvertor[FilterRulesDescription.TRANSFER_REQUEST], FilterRulesDescription.TRANSFER_REQUEST)}
+                >
                     <Box display='flex'>
-                        <Typography>
-                            <b>
-                                {transferRequestInvestigationsCount} 
-                                {'חקירות ממתינות להעברה'}
-                            </b>
-                        </Typography>
+                    <Typography className={classes.investigationNumberText}><b>{transferRequestInvestigationsCount}</b></Typography>
+                        <Typography className={classes.investigationText}><b>{transferRequestTitle}</b></Typography>
                         <NavigateBeforeIcon className={classes.navigateIcon} />
                     </Box>
                 </div>
             </Tooltip>
             <Divider/>
-            <Tooltip title={postponedInvestigationsText}>
-                <div className={hoverClasses.whiteButtons} onClick={() => onClick(statusToFilterConvertor[FilterRulesDescription.WAITING_FOR_DETAILS])}>
+            <Tooltip title={waitingForDetailsText}>
+                <div  
+                    className={[classes.filterText, hoverClasses.whiteButtons].join(' ')} 
+                    onClick={() => onClick(statusToFilterConvertor[FilterRulesDescription.WAITING_FOR_DETAILS], FilterRulesDescription.WAITING_FOR_DETAILS)}
+                >
                     <Box display='flex'>
-                        <Typography>
-                            <b>
-                                {waitingForDetailsInvestigationsCount}
-                                {'חקירות ממתינות להשלמת פרטים'} 
-                            </b>
-                        </Typography>
+                        <Typography className={classes.investigationNumberText}><b>{waitingForDetailsInvestigationsCount}</b></Typography>
+                        <Typography className={classes.investigationText}><b>{waitingForDetailsTitle}</b></Typography>
                         <NavigateBeforeIcon className={classes.navigateIcon} />
                     </Box>
                 </div>
@@ -60,7 +62,7 @@ const PostponedCard: React.FC<Props> = (props: Props): JSX.Element => {
 export default PostponedCard;
 
 interface Props {
-    onClick: (infoFilter: FilterRulesVariables) => void;
+    onClick: (infoFilter: FilterRulesVariables, FilterRulesDescription: FilterRulesDescription) => void;
     isLoading: boolean;
     transferRequestInvestigationsCount: number;
     waitingForDetailsInvestigationsCount: number;

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/PostponedCard/PostponedCardStyles.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/PostponedCard/PostponedCardStyles.ts
@@ -1,0 +1,31 @@
+import { makeStyles } from '@material-ui/styles';
+
+export const cardHeight = '8vh';
+
+const useStyles = makeStyles({
+    postponedCard: {
+        height: cardHeight,
+        borderRadius: '1vw',
+        padding: '1vh 1vw',
+        cursor: 'pointer',
+    },
+    investigationAmount: {
+        fontSize: '1.2vw',
+        display: 'flex',
+    },
+    investigationNumberText: {
+        color: '#F95959',
+        marginRight: '0.8vw',
+    },
+    investigationAmountText: {
+    },
+    navigateIcon: {
+        backgroundColor: 'WhiteSmoke',
+        borderRadius: '2vw',
+    },
+    pauseIcon: {
+        color: '#FDA815'
+    }
+});
+
+export default useStyles;

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/PostponedCard/PostponedCardStyles.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/PostponedCard/PostponedCardStyles.ts
@@ -1,13 +1,11 @@
 import { makeStyles } from '@material-ui/styles';
 
-export const cardHeight = '8vh';
+export const cardHeight = '16vh';
 
 const useStyles = makeStyles({
     postponedCard: {
-        height: cardHeight,
         borderRadius: '1vw',
         padding: '1vh 1vw',
-        cursor: 'pointer',
     },
     investigationAmount: {
         fontSize: '1.2vw',
@@ -16,15 +14,23 @@ const useStyles = makeStyles({
     investigationNumberText: {
         color: '#F95959',
         marginRight: '0.8vw',
-    },
-    investigationAmountText: {
+        marginTop: '0.5vw',
     },
     navigateIcon: {
         backgroundColor: 'WhiteSmoke',
         borderRadius: '2vw',
+        marginTop: '0.5vw',
     },
     pauseIcon: {
-        color: '#FDA815'
+        marginRight: '0.5vw',
+        color: '#FDA815',
+    },
+    investigationText: {
+        margin: '0.5vw',
+        flex: 'auto' 
+    },
+    filterText: {
+        margin: '0.5vw'
     }
 });
 

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/UnallocatedCard/UnallocatedCard.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/UnallocatedCard/UnallocatedCard.tsx
@@ -24,10 +24,10 @@ const UnallocatedCard: React.FC<Props> = (props: Props): JSX.Element => {
                 <div onClick={() => onClick(statusToFilterConvertor[FilterRulesDescription.UNALLOCATED])}>
                     <div className={classes.investigationAmount}>
                         <Typography className={classes.investigationNumberText}><b>{unallocatedInvestigationsCount}</b></Typography>
-                        <Typography className={classes.investigationAmountText}><b>חקירות</b></Typography>
+                        <Typography><b>חקירות</b></Typography>
                     </div>
                     <Box display='flex'>
-                        <Typography><b>{FilterRulesDescription.UNALLOCATED}</b></Typography>
+                        <Typography className={classes.investigationText}><b>{FilterRulesDescription.UNALLOCATED}</b></Typography>
                         <NavigateBeforeIcon className={classes.navigateIcon} />
                     </Box>
                 </div>

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/UnallocatedCard/UnallocatedCardStyles.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/UnallocatedCard/UnallocatedCardStyles.ts
@@ -4,7 +4,6 @@ export const cardHeight = '8vh';
 
 const useStyles = makeStyles({
     unallocatedCard: {
-        height: cardHeight,
         borderRadius: '1vw',
         padding: '1vh 1vw',
         cursor: 'pointer',
@@ -17,12 +16,14 @@ const useStyles = makeStyles({
         color: '#F95959',
         marginRight: '0.8vw',
     },
-    investigationAmountText: {
-    },
     navigateIcon: {
         backgroundColor: 'WhiteSmoke',
         borderRadius: '2vw',
-    }
+        marginRight: '0.5vw'
+    },
+    investigationText: {
+        flex: 'auto' 
+    },
 });
 
 export default useStyles;

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/adminLandingPage.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/adminLandingPage.tsx
@@ -67,20 +67,22 @@ const AdminLandingPage: React.FC = (): JSX.Element => {
                         onUpdateButtonClicked={updateInvestigationFilterByTime}
                     />
                 </Grid>
-                <Grid item xs={6} md={3}>
-                    <UnallocatedCard
-                        isLoading={isLoading}
-                        onClick={(infoFilter) => redirectToInvestigationTable(infoFilter, FilterRulesDescription.UNALLOCATED)} 
-                        unallocatedInvestigationsCount={investigationsStatistics.unallocatedInvestigations}
-                    />
-                </Grid>
-                <Grid item xs={6} md={3}>
-                    <PostponedCard
-                        isLoading={isLoading}
-                        onClick={(infoFilter) => redirectToInvestigationTable(infoFilter, FilterRulesDescription.TRANSFER_REQUEST)} 
-                        transferRequestInvestigationsCount={investigationsStatistics.transferRequestInvestigations}
-                        waitingForDetailsInvestigationsCount={investigationsStatistics.waitingForDetailsInvestigations}
-                    />
+                <Grid item xs={12} md={2}>
+                    <div>
+                        <UnallocatedCard
+                            isLoading={isLoading}
+                            onClick={(infoFilter) => redirectToInvestigationTable(infoFilter, FilterRulesDescription.UNALLOCATED)} 
+                            unallocatedInvestigationsCount={investigationsStatistics.unallocatedInvestigations}
+                        />
+                    </div>
+                    <div className={classes.gridContainer}>
+                        <PostponedCard
+                            isLoading={isLoading}
+                            onClick={(infoFilter, FilterRulesDescription) => redirectToInvestigationTable(infoFilter, FilterRulesDescription)} 
+                            transferRequestInvestigationsCount={investigationsStatistics.transferRequestInvestigations}
+                            waitingForDetailsInvestigationsCount={investigationsStatistics.waitingForDetailsInvestigations}
+                        />
+                    </div>
                 </Grid>
             </Grid>
         </div>

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/adminLandingPage.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/adminLandingPage.tsx
@@ -78,7 +78,8 @@ const AdminLandingPage: React.FC = (): JSX.Element => {
                     <PostponedCard
                         isLoading={isLoading}
                         onClick={(infoFilter) => redirectToInvestigationTable(infoFilter, FilterRulesDescription.TRANSFER_REQUEST)} 
-                        postponedInvestigationsCount={investigationsStatistics.transferRequestInvestigations}
+                        transferRequestInvestigationsCount={investigationsStatistics.transferRequestInvestigations}
+                        waitingForDetailsInvestigationsCount={investigationsStatistics.waitingForDetailsInvestigations}
                     />
                 </Grid>
             </Grid>

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/adminLandingPage.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/adminLandingPage.tsx
@@ -12,6 +12,7 @@ import DesksFilterCard from './desksFilterCard/desksFilterCard';
 import LastUpdateMessage from './LastUpdateMessage/LastUpdateMessage';
 import InvestigationsInfo from './investigationsInfo/investigationsInfo';
 import TimeRangeFilterCard from './TimeRangeFilterCard/TimeRangeFilterCard';
+import PostponedCard from './PostponedCard/PostponedCard';
 
 const AdminLandingPage: React.FC = (): JSX.Element => {
 
@@ -24,6 +25,9 @@ const AdminLandingPage: React.FC = (): JSX.Element => {
         newInvestigations: 0,
         unassignedInvestigations: 0,
         unallocatedInvestigations: 0,
+        transferRequestInvestigations: 0,
+        waitingForDetailsInvestigations: 0,
+
     });
     const [lastUpdated , setLastUpdated] = useState<Date>(new Date());
 
@@ -68,6 +72,13 @@ const AdminLandingPage: React.FC = (): JSX.Element => {
                         isLoading={isLoading}
                         onClick={(infoFilter) => redirectToInvestigationTable(infoFilter, FilterRulesDescription.UNALLOCATED)} 
                         unallocatedInvestigationsCount={investigationsStatistics.unallocatedInvestigations}
+                    />
+                </Grid>
+                <Grid item xs={6} md={3}>
+                    <PostponedCard
+                        isLoading={isLoading}
+                        onClick={(infoFilter) => redirectToInvestigationTable(infoFilter, FilterRulesDescription.TRANSFER_REQUEST)} 
+                        postponedInvestigationsCount={investigationsStatistics.transferRequestInvestigations}
                     />
                 </Grid>
             </Grid>

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/adminLandingPage.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/adminLandingPage.tsx
@@ -7,12 +7,12 @@ import InvestigationStatistics, { InvesitgationInfoStatistics } from 'models/Inv
 
 import useStyles from './adminLandingPageStyles';
 import useAdminLandingPage from './useAdminLandingPage';
+import PostponedCard from './PostponedCard/PostponedCard';
 import UnallocatedCard from './UnallocatedCard/UnallocatedCard';
 import DesksFilterCard from './desksFilterCard/desksFilterCard';
 import LastUpdateMessage from './LastUpdateMessage/LastUpdateMessage';
 import InvestigationsInfo from './investigationsInfo/investigationsInfo';
 import TimeRangeFilterCard from './TimeRangeFilterCard/TimeRangeFilterCard';
-import PostponedCard from './PostponedCard/PostponedCard';
 
 const AdminLandingPage: React.FC = (): JSX.Element => {
 

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/useHoverStyles.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/useHoverStyles.ts
@@ -4,6 +4,7 @@ import theme from 'styles/theme';
 
 const useStyles = makeStyles({
     whiteButtons: {
+        cursor: 'pointer',
         color: theme.palette.text.secondary,
         '&:hover': {
             color: theme.palette.text.primary

--- a/client/src/models/FilterRulesVariables.ts
+++ b/client/src/models/FilterRulesVariables.ts
@@ -3,6 +3,7 @@ import { TimeRange } from './TimeRange';
 interface FilterRulesVariables {
     deskFilter?: number[],
     statusFilter?: number[],
+    subStatusFilter?: string[],
     unassignedUserFilter?: boolean,
     inactiveUserFilter?: boolean,
     searchQuery?: string,

--- a/client/src/models/InvestigationStatistics.ts
+++ b/client/src/models/InvestigationStatistics.ts
@@ -7,6 +7,8 @@ export interface InvesitgationInfoStatistics {
 interface InvesitgationStatistics extends InvesitgationInfoStatistics {
     allInvestigations: number;
     unallocatedInvestigations: number;
+    transferRequestInvestigations: number;
+    waitingForDetailsInvestigations: number;
 }
 
 export default InvesitgationStatistics;

--- a/client/src/models/enums/FilterRulesDescription.ts
+++ b/client/src/models/enums/FilterRulesDescription.ts
@@ -4,8 +4,8 @@ enum FilterRulesDescription {
     UNASSIGNED = 'לא משויכות',
     INACTIVE = 'מוקצות לחוקרים לא פעילים',
     UNALLOCATED = 'ממתינות להקצאה',
-    TRANSFER_REQUEST = 'חקירות מחכות להעברה',
-    WAITING_FOR_DETAILS = 'חקירות ממתינות להשלמת מידע',
+    TRANSFER_REQUEST = 'נדרשת העברה',
+    WAITING_FOR_DETAILS = 'מחכה להשלמת פרטים',
 };
 
 export default FilterRulesDescription;

--- a/client/src/models/enums/FilterRulesDescription.ts
+++ b/client/src/models/enums/FilterRulesDescription.ts
@@ -4,6 +4,8 @@ enum FilterRulesDescription {
     UNASSIGNED = 'לא משויכות',
     INACTIVE = 'מוקצות לחוקרים לא פעילים',
     UNALLOCATED = 'ממתינות להקצאה',
+    TRANSFER_REQUEST = 'חקירות מחכות להעברה',
+    WAITING_FOR_DETAILS = 'חקירות ממתינות להשלמת מידע',
 };
 
 export default FilterRulesDescription;

--- a/client/src/models/enums/FilterRulesDescription.ts
+++ b/client/src/models/enums/FilterRulesDescription.ts
@@ -4,8 +4,8 @@ enum FilterRulesDescription {
     UNASSIGNED = 'לא משויכות',
     INACTIVE = 'מוקצות לחוקרים לא פעילים',
     UNALLOCATED = 'ממתינות להקצאה',
-    TRANSFER_REQUEST = 'נדרשת העברה',
-    WAITING_FOR_DETAILS = 'מחכה להשלמת פרטים',
+    TRANSFER_REQUEST = 'ממתינות להעברה',
+    WAITING_FOR_DETAILS = 'ממתינות להשלמת פרטים',
 };
 
 export default FilterRulesDescription;

--- a/client/src/models/enums/InvestigationSubStatusCodes.ts
+++ b/client/src/models/enums/InvestigationSubStatusCodes.ts
@@ -1,0 +1,16 @@
+enum InvestigationSubStatusCodes {
+HOSPITALIZED = 'המטופל מאושפז',
+DECEASED = 'המטופל נפטר',
+UNCOOPERATIVE = 'חוסר שיתוף פעולה',
+RETURNED_FROM_ABROAD = 'חזר לחול',
+PHONE_NUMBER_MISSING = 'חסר טלפון',
+PATIENT_DETAILS_MISSING = 'חסרים פרטי מטופל',
+PHONE_UNAVAILABLE = 'טלפון לא זמין',
+UNTRACEABLE = 'לא ניתן לאיתור',
+WAITING_FOR_DETAILS = 'מחכה להשלמת פרטים',
+WAITING_FOR_RESPONSE = 'מחכה למענה',
+REQUESTED_ANOTHER_TIME = 'מטופל מבקש לצלצל אליו בזמן אחר',
+TRANSFER_REQUEST = 'נדרשת העברה',
+}
+
+export default InvestigationSubStatusCodes;

--- a/server/src/DBService/LandingPage/Query.ts
+++ b/server/src/DBService/LandingPage/Query.ts
@@ -246,7 +246,7 @@ query InvestigationStatistics($userFilters: [InvestigationFilter!], $allInvesitg
   }
   transferRequestInvestigations: allInvestigations(
     filter: {and: [
-        {investigationSubStatus: {equalTo: ${TRANSFER_REQUEST}}},
+        {investigationSubStatus: {equalTo: "${TRANSFER_REQUEST}"}},
         $allInvesitgationsFilter
       ]},
     ) {
@@ -254,7 +254,7 @@ query InvestigationStatistics($userFilters: [InvestigationFilter!], $allInvesitg
   }
   waitingForDetailsInvestigations: allInvestigations(
     filter: {and: [
-        {investigationSubStatus: {equalTo: ${WAITING_FOR_DETAILS}}},
+        {investigationSubStatus: {equalTo: "${WAITING_FOR_DETAILS}"}},
         $allInvesitgationsFilter
       ]},
     ) {

--- a/server/src/DBService/LandingPage/Query.ts
+++ b/server/src/DBService/LandingPage/Query.ts
@@ -242,6 +242,22 @@ query InvestigationStatistics($userFilters: [InvestigationFilter!], $allInvesitg
     ) {
     totalCount
   }
+  transferRequestInvestigations: allInvestigations(
+    filter: {and: [
+        {investigationSubStatus: {equalTo: "נדרשת העברה"}},
+        $allInvesitgationsFilter
+      ]},
+    ) {
+    totalCount
+  }
+  waitingForDetailsInvestigations: allInvestigations(
+    filter: {and: [
+        {investigationSubStatus: {equalTo: "מחכה להשלמת פרטים"}},
+        $allInvesitgationsFilter
+      ]},
+    ) {
+    totalCount
+  }
 }
 `;
 

--- a/server/src/DBService/LandingPage/Query.ts
+++ b/server/src/DBService/LandingPage/Query.ts
@@ -2,7 +2,9 @@ import { gql } from 'postgraphile';
 
 import InvestigationMainStatusCodes from '../../Models/InvestigationStatus/InvestigationMainStatusCodes';
 
-const unassignedUserName = 'לא משויך';
+const UNASSIGNED_USER_NAME = 'לא משויך';
+const WAITING_FOR_DETAILS = 'מחכה להשלמת פרטים';
+const TRANSFER_REQUEST = 'נדרשת העברה';
 
 export const USER_INVESTIGATIONS = gql`
 query AllInvestigations($orderBy: String!, $offset: Int!, $size: Int!, $filter: InvestigationFilter) {
@@ -218,7 +220,7 @@ query InvestigationStatistics($userFilters: [InvestigationFilter!], $allInvesitg
   }
   unassignedInvestigations: allInvestigations(filter: {
     userByCreator: {
-      userName: {equalTo: "${unassignedUserName}"}
+      userName: {equalTo: "${UNASSIGNED_USER_NAME}"}
     },
     and: $userFilters
   }) {
@@ -227,7 +229,7 @@ query InvestigationStatistics($userFilters: [InvestigationFilter!], $allInvesitg
   inactiveInvestigations: allInvestigations(filter: {
     userByCreator: {
       isActive: {equalTo: false},
-      userName: {notEqualTo: "${unassignedUserName}"}
+      userName: {notEqualTo: "${UNASSIGNED_USER_NAME}"}
     },
     and: $userFilters
   }) {
@@ -235,7 +237,7 @@ query InvestigationStatistics($userFilters: [InvestigationFilter!], $allInvesitg
   }
   unallocatedInvestigations: allInvestigations(
     filter: {and: [
-        {userByCreator: {or: [{isActive: {equalTo: false}}, {userName: {equalTo: "${unassignedUserName}"}}]}},
+        {userByCreator: {or: [{isActive: {equalTo: false}}, {userName: {equalTo: "${UNASSIGNED_USER_NAME}"}}]}},
         {investigationStatus: {in:[${String(InvestigationMainStatusCodes.NEW)}, ${String(InvestigationMainStatusCodes.IN_PROCESS)}]}},
         $allInvesitgationsFilter
       ]},
@@ -244,7 +246,7 @@ query InvestigationStatistics($userFilters: [InvestigationFilter!], $allInvesitg
   }
   transferRequestInvestigations: allInvestigations(
     filter: {and: [
-        {investigationSubStatus: {equalTo: "נדרשת העברה"}},
+        {investigationSubStatus: {equalTo: ${TRANSFER_REQUEST}}},
         $allInvesitgationsFilter
       ]},
     ) {
@@ -252,7 +254,7 @@ query InvestigationStatistics($userFilters: [InvestigationFilter!], $allInvesitg
   }
   waitingForDetailsInvestigations: allInvestigations(
     filter: {and: [
-        {investigationSubStatus: {equalTo: "מחכה להשלמת פרטים"}},
+        {investigationSubStatus: {equalTo: ${WAITING_FOR_DETAILS}}},
         $allInvesitgationsFilter
       ]},
     ) {
@@ -263,7 +265,7 @@ query InvestigationStatistics($userFilters: [InvestigationFilter!], $allInvesitg
 
 export const GET_UNALLOCATED_INVESTIGATIONS_COUNT = gql`
 query unallocatedInvestigationsCount($allInvesitgationsFilter: [InvestigationFilter!]) {
-  unassignedInvestigations: allInvestigations(filter: {userByCreator: {or: {userName: {equalTo: "${unassignedUserName}"}, isActive: {equalTo: false}}}, and: $allInvesitgationsFilter}) {
+  unassignedInvestigations: allInvestigations(filter: {userByCreator: {or: {userName: {equalTo: "${UNASSIGNED_USER_NAME}"}, isActive: {equalTo: false}}}, and: $allInvesitgationsFilter}) {
     totalCount
   }
 }


### PR DESCRIPTION
Added a new card that lets an admin to access investigations table with transfer request or waiting for details filters (sub status filters) - US  [1285](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1285/)
![image](https://user-images.githubusercontent.com/46684475/105152696-3020ea80-5b10-11eb-8dae-488a746e9f9f.png)
