### PR TITLE
Fix/use epidemiology number header

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/useClinicalDetails.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/useClinicalDetails.ts
@@ -124,7 +124,7 @@ const useClinicalDetails = (parameters: useClinicalDetailsIncome): useClinicalDe
         const fetchClinicalDetailsLogger = logger.setup('Fetching Clinical Details');
         fetchClinicalDetailsLogger.info('launching clinical data request', Severity.LOW);
         setIsLoading(true);
-        axios.get(`/clinicalDetails/getInvestigatedPatientClinicalDetailsFields?epidemiologyNumber=${epidemiologyNumber}`).then(
+        axios.get(`/clinicalDetails/getInvestigatedPatientClinicalDetailsFields`).then(
             result => {
                 if (result?.data) {
                     fetchClinicalDetailsLogger.info('got results back from the server', Severity.LOW);

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/useContactQuestioning.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/useContactQuestioning.ts
@@ -146,7 +146,7 @@ const useContactQuestioning = (parameters: useContactQuestioningParameters): use
         );
         setIsLoading(true);
         const minimalDate = datesToInvestigate.slice(-1)[0];
-        axios.get(`/contactedPeople/allContacts/${epidemiologyNumber}/${minimalDate?.toISOString()}`)
+        axios.get(`/contactedPeople/allContacts/${minimalDate?.toISOString()}`)
             .then((result: any) => {
                 if (result?.data && result.headers['content-type'].includes('application/json')) {
                     interactedContactsLogger.info(

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/useExposuresAndFlights.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/useExposuresAndFlights.ts
@@ -70,7 +70,7 @@ export const useExposuresAndFlights = (props : Props) => {
 
         fetchExposuresAndFlightsLogger.info('launching exposures and flights request', Severity.LOW);
         setIsLoading(true);
-        axios.get(`/exposure/exposures/${investigationId}`)
+        axios.get(`/exposure/exposures/`)
         .then(result => {
             fetchExposuresAndFlightsLogger.info('got results back from the server', Severity.LOW);
             const data: Exposure[] = result?.data;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/useInteractionsForm.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/useInteractionsForm.ts
@@ -18,8 +18,6 @@ const useInteractionsForm = (props: useInteractionFormIncome): useInteractionFor
         const { alertError } = useCustomSwal();
         const { isPatientHouse } = useContactEvent();
 
-        const epidemiologyNumber = useSelector<StoreStateType, number>(state => state.investigation.epidemiologyNumber);
-
         const shouldParseLocation = (interactionsDataToSave: InteractionEventDialogData) =>
             !isPatientHouse(interactionsDataToSave[InteractionEventDialogFields.PLACE_SUB_TYPE]) &&
                 interactionsDataToSave[InteractionEventDialogFields.LOCATION_ADDRESS];
@@ -31,7 +29,6 @@ const useInteractionsForm = (props: useInteractionFormIncome): useInteractionFor
             const parsedData = {
                 ...interactionsDataToSave,
                 [InteractionEventDialogFields.LOCATION_ADDRESS]: locationAddress,
-                [InteractionEventDialogFields.INVESTIGATION_ID]: epidemiologyNumber
             };
             if (interactionsDataToSave[InteractionEventDialogFields.ID]) {
                 const updateInteractionsLogger = logger.setup('Update Interaction')

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/useInteractionsTab.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/useInteractionsTab.ts
@@ -77,7 +77,7 @@ const useInteractionsTab = (parameters: useInteractionsTabParameters): useIntera
     const getInteractionsTabSettings = () => {
         const interactionsTabSettingsLogger = logger.setup('fetching interactions tab settings data');
         interactionsTabSettingsLogger.info('launching db request', Severity.LOW);
-        axios.get(`/investigationInfo/interactionsTabSettings/${epidemiologyNumber}`).then((result) => {
+        axios.get(`/investigationInfo/interactionsTabSettings`).then((result) => {
             if (result?.data) {
                 interactionsTabSettingsLogger.info('got response successfully', Severity.LOW);
                 setInteractionsTabSettings(result?.data);
@@ -194,7 +194,6 @@ const useInteractionsTab = (parameters: useInteractionsTabParameters): useIntera
         const saveInvestigaionSettingsLogger = logger.setup('Saving investigaion settings family data');
         setIsLoading(true);
         axios.post('/investigationInfo/investigationSettingsFamily', {
-            id: epidemiologyNumber,
             allowUncontactedFamily: true,
         }).then(() => {
             saveInvestigaionSettingsLogger.info('saved to db successfully', Severity.LOW);

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/useInteractionsTab.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/useInteractionsTab.ts
@@ -59,7 +59,7 @@ const useInteractionsTab = (parameters: useInteractionsTabParameters): useIntera
         const loadInvolvedContactsLogger = logger.setup('loading involved contacts');
         loadInvolvedContactsLogger.info('launching db request', Severity.LOW);
 
-        axios.get(`/intersections/involvedContacts/${epidemiologyNumber}`).then((result) => {
+        axios.get(`/intersections/involvedContacts`).then((result) => {
             if (result?.data && result.headers['content-type'].includes('application/json')) {
                 loadInvolvedContactsLogger.info('got response successfully', Severity.LOW);
                 const involvedContacts: InvolvedContact[] = result?.data;
@@ -103,7 +103,7 @@ const useInteractionsTab = (parameters: useInteractionsTabParameters): useIntera
         loadInteractionsLogger.info('launching interactions request', Severity.LOW);
         const minimalDateToFilter = datesToInvestigate.slice(-1)[0];
         setIsLoading(true);
-        axios.get(`/intersections/contactEvent/${epidemiologyNumber}/${minimalDateToFilter?.toISOString()}`)
+        axios.get(`/intersections/contactEvent/${minimalDateToFilter?.toISOString()}`)
         .then((result) => {
             loadInteractionsLogger.info('got results back from the server', Severity.LOW);
             const allInteractions: InteractionEventDialogData[] = result.data.map(convertDBInteractionToInteraction);
@@ -148,7 +148,7 @@ const useInteractionsTab = (parameters: useInteractionsTabParameters): useIntera
                     deletingInteractionsLogger.info('launching interaction delete request', Severity.LOW);
                     setIsLoading(true);
                     axios.delete('/intersections/deleteContactEvent', {
-                        params: { contactEventId, investigationId: epidemiologyNumber }
+                        params: { contactEventId }
                     }).then(() => {
                         deletingInteractionsLogger.info('interaction was deleted successfully', Severity.LOW)
                         postDeleteLoading(areThereFamilyContacts);
@@ -176,7 +176,7 @@ const useInteractionsTab = (parameters: useInteractionsTabParameters): useIntera
                 deleteContactedPersonLogger.info('launching interaction delete request', Severity.LOW);
                 setIsLoading(true);
                 axios.delete('/intersections/contactedPerson', {
-                    params: { contactedPersonId, involvedContactId, investigationId: epidemiologyNumber }
+                    params: { contactedPersonId, involvedContactId}
                 }).then(() => {
                     deleteContactedPersonLogger.info('interaction was deleted successfully', Severity.LOW);
                     postDeleteLoading(isThisFamilyContact);

--- a/client/src/components/App/Content/InvestigationForm/useInvestigationForm.ts
+++ b/client/src/components/App/Content/InvestigationForm/useInvestigationForm.ts
@@ -46,7 +46,7 @@ const useInvestigationForm = (): useInvestigationFormOutcome => {
         tabShowLogger.info('launching amount of contacts request', Severity.LOW);
         const minimalDateToFilter = datesToInvestigate.slice(-1)[0];
         const formattedMinimalDate = typeof minimalDateToFilter !== 'string' ? minimalDateToFilter.toISOString() : minimalDateToFilter;
-        axios.get(`/contactedPeople/allContacts/${epidemiologyNumber}/${formattedMinimalDate}`)
+        axios.get(`/contactedPeople/allContacts/${formattedMinimalDate}`)
         .then((result: any) => {
             tabShowLogger.info('amount of contacts request was successful', Severity.LOW);
             setAreThereContacts(result?.data.length > 0);

--- a/server/src/ClientToDBAPI/ClinicalDetailsRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/ClinicalDetailsRoute/mainRoute.ts
@@ -8,6 +8,7 @@ import { errorStatusCode, graphqlRequest } from '../../GraphqlHTTPRequest';
 import ClinicalDetails from '../../Models/ClinicalDetails/ClinicalDetails';
 import { formatToInsertAndGetAddressIdInput, formatToNullable} from '../../Utils/addressUtils';
 import InsertAndGetAddressIdInput from '../../Models/Address/InsertAndGetAddressIdInput';
+import { handleInvestigationRequest } from '../../middlewares/HandleInvestigationRequest';
 import logger, { invalidDBResponseLog, launchingDBRequestLog, validDBResponseLog } from '../../Logger/Logger';
 import { calculateInvestigationComplexity } from '../../Utils/InvestigationComplexity/InvestigationComplexity';
 import {
@@ -92,15 +93,15 @@ const convertClinicalDetailsFromDB = (result: GetInvestigatedPatientClinicalDeta
     return convertedClincalDetails;
 }
 
-clinicalDetailsRoute.get('/getInvestigatedPatientClinicalDetailsFields', (request: Request, response: Response) => {
-    
+clinicalDetailsRoute.get('/getInvestigatedPatientClinicalDetailsFields', handleInvestigationRequest, (request: Request, response: Response) => {
+    const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const fetchClinicalDetailsFieldsLogger = logger.setup({
         workflow: 'qurey investigation clinical details',
         investigation: response.locals.epidemiologynumber,
         user: response.locals.user.id
     })
 
-    const parameters = { epidemiologyNumber: parseInt(request.query.epidemiologyNumber as string) };
+    const parameters = { epidemiologyNumber };
     fetchClinicalDetailsFieldsLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
 
     graphqlRequest(GET_INVESTIGATED_PATIENT_CLINICAL_DETAILS_BY_EPIDEMIOLOGY_NUMBER, response.locals, parameters).then(
@@ -201,7 +202,7 @@ const saveClinicalDetails = (request: Request, response: Response, baseLog: Init
     });
 }
 
-clinicalDetailsRoute.post('/saveClinicalDetails', (request: Request, response: Response) => {
+clinicalDetailsRoute.post('/saveClinicalDetails', handleInvestigationRequest, (request: Request, response: Response) => {
     const logData = {
         workflow: `saving clinical details tab`,
         investigation: response.locals.epidemiologynumber,
@@ -224,7 +225,7 @@ clinicalDetailsRoute.post('/saveClinicalDetails', (request: Request, response: R
     }
 });
 
-clinicalDetailsRoute.get('/isDeceased/:investigatedPatientId/:isDeceased', (request: Request, response: Response) => {
+clinicalDetailsRoute.get('/isDeceased/:investigatedPatientId/:isDeceased', handleInvestigationRequest, (request: Request, response: Response) => {
     const logData = {
         workflow: 'update whether the pateint is deceased',
         investigation: response.locals.epidemiologynumber,
@@ -248,7 +249,7 @@ clinicalDetailsRoute.get('/isDeceased/:investigatedPatientId/:isDeceased', (requ
     });
 });
 
-clinicalDetailsRoute.get('/isCurrentlyHospitialized/:investigatedPatientId/:isCurrentlyHospitalized', (request: Request, response: Response) => {
+clinicalDetailsRoute.get('/isCurrentlyHospitialized/:investigatedPatientId/:isCurrentlyHospitalized', handleInvestigationRequest, (request: Request, response: Response) => {
     const logData = {
         workflow: 'update whether the pateint is currently hospitialized',
         investigation: response.locals.epidemiologynumber,

--- a/server/src/ClientToDBAPI/ContactedPeople/mainRoute.ts
+++ b/server/src/ClientToDBAPI/ContactedPeople/mainRoute.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 
 import { Severity } from '../../Models/Logger/types';
 import { UPDATE_LIST_OF_CONTACTS } from '../../DBService/ContactedPeople/Mutation';
+import { handleInvestigationRequest } from '../../middlewares/HandleInvestigationRequest';
 import { errorStatusCode, graphqlRequest, validStatusCode } from '../../GraphqlHTTPRequest';
 import logger, { invalidDBResponseLog, launchingDBRequestLog, validDBResponseLog } from '../../Logger/Logger';
 import {

--- a/server/src/ClientToDBAPI/ContactedPeople/mainRoute.ts
+++ b/server/src/ClientToDBAPI/ContactedPeople/mainRoute.ts
@@ -50,7 +50,7 @@ ContactedPeopleRoute.get('/contactStatuses', (request: Request, response: Respon
     });
 });
 
-ContactedPeopleRoute.get('/allContacts/:minimalDateToFilter', (request: Request, response: Response) => {
+ContactedPeopleRoute.get('/allContacts/:minimalDateToFilter', handleInvestigationRequest, (request: Request, response: Response) => {
     const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const allContactsLogger = logger.setup({
         workflow: `query all investigation's contacts`,
@@ -72,7 +72,7 @@ ContactedPeopleRoute.get('/allContacts/:minimalDateToFilter', (request: Request,
         })
 });
 
-ContactedPeopleRoute.post('/interactedContacts',  (request: Request, response: Response) => {
+ContactedPeopleRoute.post('/interactedContacts',  handleInvestigationRequest,  (request: Request, response: Response) => {
     const requestData = request.body;
 
     const epidemiologyNumber = +response.locals.epidemiologynumber;
@@ -106,7 +106,7 @@ ContactedPeopleRoute.post('/interactedContacts',  (request: Request, response: R
         })
 });
 
-ContactedPeopleRoute.post('/excel', async (request: Request, response: Response) => {
+ContactedPeopleRoute.post('/excel',  handleInvestigationRequest, async (request: Request, response: Response) => {
     const excelLogger = logger.setup({
         workflow: `saving contacts execl`,
         investigation: response.locals.epidemiologynumber,

--- a/server/src/ClientToDBAPI/ContactedPeople/mainRoute.ts
+++ b/server/src/ClientToDBAPI/ContactedPeople/mainRoute.ts
@@ -49,13 +49,14 @@ ContactedPeopleRoute.get('/contactStatuses', (request: Request, response: Respon
     });
 });
 
-ContactedPeopleRoute.get('/allContacts/:investigationId/:minimalDateToFilter', (request: Request, response: Response) => {
+ContactedPeopleRoute.get('/allContacts/:minimalDateToFilter', (request: Request, response: Response) => {
+    const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const allContactsLogger = logger.setup({
         workflow: `query all investigation's contacts`,
-        investigation: response.locals.epidemiologynumber,
+        investigation: epidemiologyNumber,
         user: response.locals.user.id
     });
-    const parameters = { investigationId: parseInt(request.params.investigationId), minimalDateToFilter: new Date(request.params.minimalDateToFilter)}
+    const parameters = { investigationId: epidemiologyNumber, minimalDateToFilter: new Date(request.params.minimalDateToFilter)}
     allContactsLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
     graphqlRequest(GET_CONTACTED_PEOPLE, response.locals, parameters)
         .then(result => {

--- a/server/src/ClientToDBAPI/IntersectionsRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/IntersectionsRoute/mainRoute.ts
@@ -84,14 +84,15 @@ const convertDBEvent = (event: ContactEvent) => {
     };
 }
 
-intersectionsRoute.get('/contactEvent/:investigationId/:minimalDateToFilter', (request: Request, response: Response) => {
+intersectionsRoute.get('/contactEvent/:minimalDateToFilter', (request: Request, response: Response) => {
+    const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const contactEventLogger = logger.setup({
         workflow: `query investigation's contact events`,
         user: response.locals.user.id,
-        investigation: response.locals.epidemiologynumber
+        investigation: epidemiologyNumber
     });
 
-    const parameters = {currInvestigation: Number(request.params.investigationId), minimalDateToFilter: new Date(request.params.minimalDateToFilter)};
+    const parameters = {currInvestigation: epidemiologyNumber, minimalDateToFilter: new Date(request.params.minimalDateToFilter)};
     contactEventLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
 
     graphqlRequest(GET_FULL_CONTACT_EVENT_BY_INVESTIGATION_ID, response.locals, parameters)
@@ -106,14 +107,15 @@ intersectionsRoute.get('/contactEvent/:investigationId/:minimalDateToFilter', (r
 });
 
 intersectionsRoute.post('/createContactEvent', (request: Request, response: Response) => {
+    const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const createContactEventLogger = logger.setup({
         workflow: 'create contact event',
         user: response.locals.user.id,
-        investigation: response.locals.epidemiologynumber
+        investigation: epidemiologyNumber
     });
-
     const parameters = {contactEvent: JSON.stringify({
         ...request.body,
+        investigationId : epidemiologyNumber
     })}
     createContactEventLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
     graphqlRequest(CREATE_CONTACT_EVENT, response.locals, parameters)
@@ -128,15 +130,16 @@ intersectionsRoute.post('/createContactEvent', (request: Request, response: Resp
 });
 
 intersectionsRoute.post('/updateContactEvent', (request: Request, response: Response) => {
-
+    const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const updateContactEventLogger = logger.setup({
         workflow: 'update contact event',
         user: response.locals.user.id,
-        investigation: response.locals.epidemiologynumber
+        investigation: epidemiologyNumber,
     });
 
     const parameters = {event: JSON.stringify({
         ...request.body,
+        investigationId : epidemiologyNumber
     })}
     updateContactEventLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
 
@@ -152,14 +155,15 @@ intersectionsRoute.post('/updateContactEvent', (request: Request, response: Resp
 });
 
 intersectionsRoute.delete('/deleteContactEvent', (request: Request, response: Response) => {
+    const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const deleteContactEventLogger = logger.setup({
         workflow: 'delete contact event',
         user: response.locals.user.id,
-        investigation: response.locals.epidemiologynumber
+        investigation: epidemiologyNumber
     });
     const queryVariables = {
         contactEventId: parseInt(request.query.contactEventId as string),
-        investigationId: parseInt(request.query.investigationId as string)
+        investigationId: epidemiologyNumber
     };
     deleteContactEventLogger.info(launchingDBRequestLog(queryVariables), Severity.LOW);
     graphqlRequest(DELETE_CONTACT_EVENT, response.locals, queryVariables)
@@ -174,15 +178,16 @@ intersectionsRoute.delete('/deleteContactEvent', (request: Request, response: Re
 });
 
 intersectionsRoute.delete('/contactedPerson', (request: Request, response: Response) => {
+    const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const contactedPersonLogger = logger.setup({
         workflow: 'delete contacted person',
         user: response.locals.user.id,
-        investigation: response.locals.epidemiologynumber
+        investigation: epidemiologyNumber
     });
     const queryVariables = {
         contactedPersonId: parseInt(request.query.contactedPersonId as string),
         involvedContactId: request.query.involvedContactId ? parseInt(request.query.involvedContactId as string) : null,
-        investigationId: parseInt(request.query.investigationId as string),
+        investigationId: epidemiologyNumber,
     }
     contactedPersonLogger.info(launchingDBRequestLog(queryVariables), Severity.LOW);
     graphqlRequest(DELETE_CONTACTED_PERSON, response.locals, queryVariables)
@@ -210,14 +215,15 @@ const convertInvolvedContact = (contact: InvolvedContactDB) => {
     }
 };
 
-intersectionsRoute.get('/involvedContacts/:investigationId', (request: Request, response: Response) => {
+intersectionsRoute.get('/involvedContacts', (request: Request, response: Response) => {
+    const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const involvedContacts = logger.setup({
         workflow: `query investigation's involved contacts`,
         user: response.locals.user.id,
-        investigation: response.locals.epidemiologynumber
+        investigation: epidemiologyNumber
     });
 
-    const parameters = {currInvestigation: Number(request.params.investigationId)};
+    const parameters = {currInvestigation: epidemiologyNumber};
     involvedContacts.info(launchingDBRequestLog(parameters), Severity.LOW);
 
     graphqlRequest(GET_ALL_INVOLVED_CONTACTS, response.locals, parameters)

--- a/server/src/ClientToDBAPI/IntersectionsRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/IntersectionsRoute/mainRoute.ts
@@ -3,6 +3,7 @@ import {Request, Response, Router} from 'express';
 import { Severity } from '../../Models/Logger/types';
 import {errorStatusCode, graphqlRequest} from '../../GraphqlHTTPRequest';
 import {GetContactTypeResponse} from '../../Models/ContactEvent/GetContactType';
+import { handleInvestigationRequest } from '../../middlewares/HandleInvestigationRequest';
 import { GetContactEventResponse, ContactEvent } from '../../Models/ContactEvent/GetContactEvent';
 import { GetInvolvedContactsResponse, InvolvedContactDB} from '../../Models/ContactEvent/GetInvolvedContacts';
 import logger, { invalidDBResponseLog, launchingDBRequestLog, validDBResponseLog } from '../../Logger/Logger';
@@ -84,7 +85,7 @@ const convertDBEvent = (event: ContactEvent) => {
     };
 }
 
-intersectionsRoute.get('/contactEvent/:minimalDateToFilter', (request: Request, response: Response) => {
+intersectionsRoute.get('/contactEvent/:minimalDateToFilter', handleInvestigationRequest, (request: Request, response: Response) => {
     const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const contactEventLogger = logger.setup({
         workflow: `query investigation's contact events`,
@@ -106,7 +107,7 @@ intersectionsRoute.get('/contactEvent/:minimalDateToFilter', (request: Request, 
     });
 });
 
-intersectionsRoute.post('/createContactEvent', (request: Request, response: Response) => {
+intersectionsRoute.post('/createContactEvent', handleInvestigationRequest, (request: Request, response: Response) => {
     const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const createContactEventLogger = logger.setup({
         workflow: 'create contact event',
@@ -154,7 +155,7 @@ intersectionsRoute.post('/updateContactEvent', (request: Request, response: Resp
         });
 });
 
-intersectionsRoute.delete('/deleteContactEvent', (request: Request, response: Response) => {
+intersectionsRoute.delete('/deleteContactEvent', handleInvestigationRequest, (request: Request, response: Response) => {
     const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const deleteContactEventLogger = logger.setup({
         workflow: 'delete contact event',
@@ -177,7 +178,7 @@ intersectionsRoute.delete('/deleteContactEvent', (request: Request, response: Re
         });
 });
 
-intersectionsRoute.delete('/contactedPerson', (request: Request, response: Response) => {
+intersectionsRoute.delete('/contactedPerson', handleInvestigationRequest, (request: Request, response: Response) => {
     const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const contactedPersonLogger = logger.setup({
         workflow: 'delete contacted person',
@@ -215,7 +216,7 @@ const convertInvolvedContact = (contact: InvolvedContactDB) => {
     }
 };
 
-intersectionsRoute.get('/involvedContacts', (request: Request, response: Response) => {
+intersectionsRoute.get('/involvedContacts', handleInvestigationRequest, (request: Request, response: Response) => {
     const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const involvedContacts = logger.setup({
         workflow: `query investigation's involved contacts`,

--- a/server/src/ClientToDBAPI/InvestigationInfo/mainRoute.ts
+++ b/server/src/ClientToDBAPI/InvestigationInfo/mainRoute.ts
@@ -229,14 +229,15 @@ investigationInfo.post('/resorts', handleInvestigationRequest, (request: Request
         })
 });
 
-investigationInfo.get('/interactionsTabSettings/:id', handleInvestigationRequest, (request: Request, response: Response) => {
+investigationInfo.get('/interactionsTabSettings', handleInvestigationRequest, (request: Request, response: Response) => {
+    const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const settingsFamilyLogger = logger.setup({
         workflow: `query investigation's interactions tab settings`,
         user: response.locals.user.id,
-        investigation: response.locals.epidemiologynumber
+        investigation: epidemiologyNumber
     });
 
-    const parameters = {id: parseInt(request.params.id)};
+    const parameters = {id: epidemiologyNumber};
     settingsFamilyLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
 
     graphqlRequest(GET_INVESTIGAION_SETTINGS_FAMILY_DATA, response.locals, parameters)
@@ -250,13 +251,14 @@ investigationInfo.get('/interactionsTabSettings/:id', handleInvestigationRequest
 });
 
 investigationInfo.post('/investigationSettingsFamily', handleInvestigationRequest, (request: Request, response: Response) => {
+    const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const settingsFamilyLogger = logger.setup({
         workflow: 'save investigation settings family data',
         user: response.locals.user.id,
-        investigation: response.locals.epidemiologynumber,
+        investigation: epidemiologyNumber,
     });
 
-    const queryVariables = {...request.body};
+    const queryVariables = {...request.body , id : epidemiologyNumber};
     settingsFamilyLogger.info(launchingDBRequestLog(queryVariables), Severity.LOW);
 
     return graphqlRequest(UPDATE_INVESTIGAION_SETTINGS_FAMILY_DATA, response.locals, queryVariables)

--- a/server/src/ClientToDBAPI/PersonalDetailsRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/PersonalDetailsRoute/mainRoute.ts
@@ -6,6 +6,7 @@ import { errorStatusCode, graphqlRequest } from '../../GraphqlHTTPRequest';
 import { formatToInsertAndGetAddressIdInput } from '../../Utils/addressUtils';
 import { CREATE_ADDRESS } from '../../DBService/Address/Mutation';
 import InsertAndGetAddressIdInput from '../../Models/Address/InsertAndGetAddressIdInput';
+import { handleInvestigationRequest } from '../../middlewares/HandleInvestigationRequest';
 import logger, { invalidDBResponseLog, launchingDBRequestLog, validDBResponseLog } from '../../Logger/Logger';
 import { calculateInvestigationComplexity } from '../../Utils/InvestigationComplexity/InvestigationComplexity';
 import GetInvestigatedPatientDetails, { PersonalInfoDbData } from '../../Models/PersonalInfo/GetInvestigatedPatientDetails';
@@ -75,7 +76,7 @@ const convertPatientDetailsFromDB = (investigatedPatientDetails: PersonalInfoDbD
     return convertedInvestigatedPatientDetails;
 }
 
-personalDetailsRoute.get('/investigatedPatientPersonalInfoFields', (request: Request, response: Response) => {
+personalDetailsRoute.get('/investigatedPatientPersonalInfoFields', handleInvestigationRequest, (request: Request, response: Response) => {
     const investigatedPatientPersonalInfoFieldsLogger = logger.setup({
         workflow: 'query investigation personal info tab',
         user: response.locals.user.id,
@@ -180,7 +181,7 @@ const savePersonalDetails = (request: Request, response: Response, baseLog: Init
     });
 }
 
-personalDetailsRoute.post('/updatePersonalDetails', (request: Request, response: Response) => {
+personalDetailsRoute.post('/updatePersonalDetails', handleInvestigationRequest, (request: Request, response: Response) => {
     const address = request.body.personalInfoData.address;
     const logData = {
         workflow: 'saving personal details tab',


### PR DESCRIPTION
# The issue
From my undestanding before the epidemiologyNumber header was sent to the server the epideiology number was sent as a param ( or body ).
With the introduction of `HandleInvestigationRequest` the validation is preformed on the header ( that is sent even when the epidemiologyNumber is sent in params/body ) meaning that a request can be sent with a different param than the intruduction number ( causing vulnerability issues )
# The fix
"Cleaned" those function - causing them to be activated only by the header.
W/ user story [1467](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1467/) - added additional routes to the investigation middleware.