### PR TITLE
Fix/grouped investigation form disabled rows

### DIFF
--- a/client/src/commons/Contexts/GroupedInvestigationFormContext.ts
+++ b/client/src/commons/Contexts/GroupedInvestigationFormContext.ts
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+
+import { IdToCheck } from 'Utils/Contacts/useDuplicateContactId';
+
+export interface GroupedInvestigationContext {
+    groupedInvestigationContacts: number[]; 
+    allContactIds: IdToCheck[];
+};
+
+const initialContacts: GroupedInvestigationContext = {
+    groupedInvestigationContacts: [],
+    allContactIds: []
+};
+
+export const groupedInvestigationsContext = createContext<GroupedInvestigationContext>(initialContacts);
+export const GroupedInvestigationsContextProvider = groupedInvestigationsContext.Provider;

--- a/client/src/commons/Contexts/GroupedInvestigationFormContext.ts
+++ b/client/src/commons/Contexts/GroupedInvestigationFormContext.ts
@@ -3,12 +3,14 @@ import { createContext } from 'react';
 import { IdToCheck } from 'Utils/Contacts/useDuplicateContactId';
 
 export interface GroupedInvestigationContext {
-    groupedInvestigationContacts: number[]; 
+    groupedInvestigationContacts: number[];
+    setGroupedInvestigationContacts: React.Dispatch<React.SetStateAction<number[]>>;
     allContactIds: IdToCheck[];
 };
 
 const initialContacts: GroupedInvestigationContext = {
     groupedInvestigationContacts: [],
+    setGroupedInvestigationContacts: () => {},
     allContactIds: []
 };
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionDialog.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionDialog.tsx
@@ -28,6 +28,9 @@ const InteractionDialog = (props: Props) => {
     const [isAddingContacts, setIsAddingContacts] = React.useState(false);
     const [groupedInvestigationContacts, setGroupedInvestigationContacts] = useState<number[]>([]);
     const groupedInvestigationsContextState = useContext(groupedInvestigationsContext);
+    groupedInvestigationsContextState.groupedInvestigationContacts = groupedInvestigationContacts;
+    groupedInvestigationsContextState.setGroupedInvestigationContacts = setGroupedInvestigationContacts;
+
     const methods = useForm<InteractionEventDialogData>({
         defaultValues: interactionData,
         mode: 'all',
@@ -182,8 +185,6 @@ const InteractionDialog = (props: Props) => {
                         />
                         <ContactsTabs 
                             isVisible={isAddingContacts}
-                            groupedInvestigationContacts={groupedInvestigationContacts}
-                            setGroupedInvestigationContacts={setGroupedInvestigationContacts}
                         />
                     </form>
                 </DialogContent>

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionDialog.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionDialog.tsx
@@ -103,6 +103,13 @@ const InteractionDialog = (props: Props) => {
         }
     };
 
+    const allContactsIds: IdToCheck[] = interactions.map(interaction => interaction.contacts).flat().map((contact) => {
+        return ({
+            id: contact[InteractionEventContactFields.IDENTIFICATION_NUMBER],
+            serialId: contact[InteractionEventContactFields.ID]
+        })
+    });
+    
     const onSubmit = (data: InteractionEventDialogData) => {
         if (!data.contacts) {
             data.contacts = [];
@@ -110,12 +117,6 @@ const InteractionDialog = (props: Props) => {
         addFamilyMemberContacts(data.contacts);
 
         const interactionDataToSave = convertData(data);
-        const allContactsIds: IdToCheck[] = interactions.map(interaction => interaction.contacts).flat().map((contact) => {
-            return ({
-                id: contact[InteractionEventContactFields.IDENTIFICATION_NUMBER],
-                serialId: contact[InteractionEventContactFields.ID]
-            })
-        });
 
         const newIds: IdToCheck[] = interactionDataToSave[InteractionEventDialogFields.CONTACTS].map((contact: Contact) => {
             return ({
@@ -180,6 +181,7 @@ const InteractionDialog = (props: Props) => {
                         />
                         <ContactsTabs 
                             isVisible={isAddingContacts}
+                            allContactIds={allContactsIds}
                             groupedInvestigationContacts={groupedInvestigationContacts}
                             setGroupedInvestigationContacts={setGroupedInvestigationContacts}
                         />

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionDialog.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionDialog.tsx
@@ -7,6 +7,7 @@ import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Tooltip } fr
 import Contact from 'models/Contact';
 import InvolvedContact from 'models/InvolvedContact';
 import PlaceSubType from 'models/PlaceSubType';
+import { groupedInvestigationsContext } from 'commons/Contexts/GroupedInvestigationFormContext';
 import InteractionEventDialogData from 'models/Contexts/InteractionEventDialogData';
 import InteractionEventDialogFields from 'models/enums/InteractionsEventDialogContext/InteractionEventDialogFields';
 import InteractionEventContactFields from 'models/enums/InteractionsEventDialogContext/InteractionEventContactFields';
@@ -26,7 +27,7 @@ const InteractionDialog = (props: Props) => {
     const { isOpen, dialogTitle, loadInteractions, loadInvolvedContacts, interactions, onDialogClose, interactionData, isNewInteraction } = props;
     const [isAddingContacts, setIsAddingContacts] = React.useState(false);
     const [groupedInvestigationContacts, setGroupedInvestigationContacts] = useState<number[]>([]);
-
+    const groupedInvestigationsContextState = useContext(groupedInvestigationsContext);
     const methods = useForm<InteractionEventDialogData>({
         defaultValues: interactionData,
         mode: 'all',
@@ -103,7 +104,7 @@ const InteractionDialog = (props: Props) => {
         }
     };
 
-    const allContactsIds: IdToCheck[] = interactions.map(interaction => interaction.contacts).flat().map((contact) => {
+    groupedInvestigationsContextState.allContactIds = interactions.map(interaction => interaction.contacts).flat().map((contact) => {
         return ({
             id: contact[InteractionEventContactFields.IDENTIFICATION_NUMBER],
             serialId: contact[InteractionEventContactFields.ID]
@@ -125,7 +126,7 @@ const InteractionDialog = (props: Props) => {
             })
         });
 
-        const contactsIdsToCheck: IdToCheck[] = allContactsIds.concat(newIds);
+        const contactsIdsToCheck: IdToCheck[] = groupedInvestigationsContextState.allContactIds;
         if (!checkDuplicateIdsForInteractions(contactsIdsToCheck)) {
             saveInteractions(interactionDataToSave);
         }
@@ -181,7 +182,6 @@ const InteractionDialog = (props: Props) => {
                         />
                         <ContactsTabs 
                             isVisible={isAddingContacts}
-                            allContactIds={allContactsIds}
                             groupedInvestigationContacts={groupedInvestigationContacts}
                             setGroupedInvestigationContacts={setGroupedInvestigationContacts}
                         />

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/ContactsTabs.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/ContactsTabs.tsx
@@ -5,7 +5,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Divider, Tab, Tabs, useTheme } from '@material-ui/core';
 
 import useFormStyles from 'styles/formStyles';
-import { IdToCheck } from 'Utils/Contacts/useDuplicateContactId';
 
 import Forms from './Forms';
 import useStyles from './ContactsTabsStyles';
@@ -15,7 +14,7 @@ const familyMembersLabel = 'בני משפחה';
 const groupedInvestigationsLabel = 'חקירות מקובצות';
 
 const ContactsTabs = (props : Props) => {
-    const {isVisible , groupedInvestigationContacts , setGroupedInvestigationContacts, allContactIds} = props;
+    const {isVisible , groupedInvestigationContacts , setGroupedInvestigationContacts} = props;
 
     const [currentTab, setTab] = React.useState<number>(0);
     const formClasses = useFormStyles();
@@ -46,7 +45,6 @@ const ContactsTabs = (props : Props) => {
                 currentTab={currentTab}
                 groupedInvestigationContacts={groupedInvestigationContacts}
                 setGroupedInvestigationContacts={setGroupedInvestigationContacts}
-                allContactIds={allContactIds}
             />
         </div>
     );
@@ -56,7 +54,6 @@ interface Props {
     isVisible: boolean; 
     groupedInvestigationContacts: number[]; 
     setGroupedInvestigationContacts:  React.Dispatch<React.SetStateAction<number[]>>;
-    allContactIds: IdToCheck[];
 }
 
 export default ContactsTabs;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/ContactsTabs.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/ContactsTabs.tsx
@@ -14,7 +14,7 @@ const familyMembersLabel = 'בני משפחה';
 const groupedInvestigationsLabel = 'חקירות מקובצות';
 
 const ContactsTabs = (props : Props) => {
-    const {isVisible , groupedInvestigationContacts , setGroupedInvestigationContacts} = props;
+    const {isVisible} = props;
 
     const [currentTab, setTab] = React.useState<number>(0);
     const formClasses = useFormStyles();
@@ -43,8 +43,6 @@ const ContactsTabs = (props : Props) => {
             <Divider orientation='vertical' variant='fullWidth' light={true} />
             <Forms
                 currentTab={currentTab}
-                groupedInvestigationContacts={groupedInvestigationContacts}
-                setGroupedInvestigationContacts={setGroupedInvestigationContacts}
             />
         </div>
     );
@@ -52,8 +50,6 @@ const ContactsTabs = (props : Props) => {
 
 interface Props {
     isVisible: boolean; 
-    groupedInvestigationContacts: number[]; 
-    setGroupedInvestigationContacts:  React.Dispatch<React.SetStateAction<number[]>>;
 }
 
 export default ContactsTabs;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/ContactsTabs.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/ContactsTabs.tsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Divider, Tab, Tabs, useTheme } from '@material-ui/core';
 
 import useFormStyles from 'styles/formStyles';
+import { IdToCheck } from 'Utils/Contacts/useDuplicateContactId';
 
 import Forms from './Forms';
 import useStyles from './ContactsTabsStyles';
@@ -14,7 +15,7 @@ const familyMembersLabel = 'בני משפחה';
 const groupedInvestigationsLabel = 'חקירות מקובצות';
 
 const ContactsTabs = (props : Props) => {
-    const {isVisible , groupedInvestigationContacts , setGroupedInvestigationContacts} = props;
+    const {isVisible , groupedInvestigationContacts , setGroupedInvestigationContacts, allContactIds} = props;
 
     const [currentTab, setTab] = React.useState<number>(0);
     const formClasses = useFormStyles();
@@ -45,6 +46,7 @@ const ContactsTabs = (props : Props) => {
                 currentTab={currentTab}
                 groupedInvestigationContacts={groupedInvestigationContacts}
                 setGroupedInvestigationContacts={setGroupedInvestigationContacts}
+                allContactIds={allContactIds}
             />
         </div>
     );
@@ -54,6 +56,7 @@ interface Props {
     isVisible: boolean; 
     groupedInvestigationContacts: number[]; 
     setGroupedInvestigationContacts:  React.Dispatch<React.SetStateAction<number[]>>;
+    allContactIds: IdToCheck[];
 }
 
 export default ContactsTabs;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/Forms.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/Forms.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 
 import useFormStyles from 'styles/formStyles';
+import { IdToCheck } from 'Utils/Contacts/useDuplicateContactId';
 
 import FamilyMembersForm from './FamilyMembers/FamilyMembersForm';
 import ManualContactsForm from './ManualContactsForm/ManualContactsForm';
 import GroupedInvestigationsTab from './GroupedInvestigations/GroupedInvestigationsTab';
 
 const Forms = (props: Props) => {
-    const { currentTab,  groupedInvestigationContacts, setGroupedInvestigationContacts} = props;
+    const { currentTab,  groupedInvestigationContacts, setGroupedInvestigationContacts, allContactIds} = props;
     const formClasses = useFormStyles();
 
     const contactFormTabs = [
@@ -16,6 +17,7 @@ const Forms = (props: Props) => {
         { 
             id: 2, 
             Component: <GroupedInvestigationsTab 
+                            allContactIds={allContactIds}
                             groupedInvestigationContacts={groupedInvestigationContacts}
                             setGroupedInvestigationContacts={setGroupedInvestigationContacts}
                         />
@@ -37,6 +39,7 @@ interface Props {
     currentTab: number;
     groupedInvestigationContacts: number[]; 
     setGroupedInvestigationContacts:  React.Dispatch<React.SetStateAction<number[]>>;
+    allContactIds: IdToCheck[];
 }
 
 export default Forms;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/Forms.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/Forms.tsx
@@ -1,26 +1,19 @@
 import React from 'react'
 
 import useFormStyles from 'styles/formStyles';
-import { IdToCheck } from 'Utils/Contacts/useDuplicateContactId';
 
 import FamilyMembersForm from './FamilyMembers/FamilyMembersForm';
 import ManualContactsForm from './ManualContactsForm/ManualContactsForm';
 import GroupedInvestigationsTab from './GroupedInvestigations/GroupedInvestigationsTab';
 
 const Forms = (props: Props) => {
-    const { currentTab,  groupedInvestigationContacts, setGroupedInvestigationContacts} = props;
+    const { currentTab } = props;
     const formClasses = useFormStyles();
 
     const contactFormTabs = [
         { id: 0, Component: <ManualContactsForm /> },
         { id: 1, Component: <FamilyMembersForm /> },
-        { 
-            id: 2, 
-            Component: <GroupedInvestigationsTab 
-                            groupedInvestigationContacts={groupedInvestigationContacts}
-                            setGroupedInvestigationContacts={setGroupedInvestigationContacts}
-                        />
-        }
+        { id: 2, Component: <GroupedInvestigationsTab /> }
     ];
 
     return (
@@ -36,8 +29,6 @@ const Forms = (props: Props) => {
 
 interface Props {
     currentTab: number;
-    groupedInvestigationContacts: number[]; 
-    setGroupedInvestigationContacts:  React.Dispatch<React.SetStateAction<number[]>>;
 }
 
 export default Forms;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/Forms.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/Forms.tsx
@@ -8,7 +8,7 @@ import ManualContactsForm from './ManualContactsForm/ManualContactsForm';
 import GroupedInvestigationsTab from './GroupedInvestigations/GroupedInvestigationsTab';
 
 const Forms = (props: Props) => {
-    const { currentTab,  groupedInvestigationContacts, setGroupedInvestigationContacts, allContactIds} = props;
+    const { currentTab,  groupedInvestigationContacts, setGroupedInvestigationContacts} = props;
     const formClasses = useFormStyles();
 
     const contactFormTabs = [
@@ -17,7 +17,6 @@ const Forms = (props: Props) => {
         { 
             id: 2, 
             Component: <GroupedInvestigationsTab 
-                            allContactIds={allContactIds}
                             groupedInvestigationContacts={groupedInvestigationContacts}
                             setGroupedInvestigationContacts={setGroupedInvestigationContacts}
                         />
@@ -39,7 +38,6 @@ interface Props {
     currentTab: number;
     groupedInvestigationContacts: number[]; 
     setGroupedInvestigationContacts:  React.Dispatch<React.SetStateAction<number[]>>;
-    allContactIds: IdToCheck[];
 }
 
 export default Forms;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/ContactsForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/ContactsForm.tsx
@@ -9,18 +9,18 @@ import InvestigationAccordion from './InvestigationAccordion/InvestigationAccord
 const formHeadline = 'מאומתים המקובצים לחקירה :';
 
 const ContactsForm = (props: Props) => {
-    const { contacts , reason ,groupedInvestigationContacts, setGroupedInvestigationContacts, allContactIds} = props;
+    const { investigations , reason ,groupedInvestigationContacts, setGroupedInvestigationContacts, allContactIds} = props;
 
     return (
         <>
             <Typography variant='h5'>{formHeadline}</Typography>
             <Typography variant='h6'>{`סיבת הקיבוץ: ${reason}`}</Typography>
             {
-                contacts.map((contact , index) => {
+                investigations.map((investigation , index) => {
                     return (
                         <InvestigationAccordion
                             key={index}
-                            contact={contact}
+                            investigation={investigation}
                             allContactIds={allContactIds}
                             selectedRows={groupedInvestigationContacts}
                             setSelectedRows={setGroupedInvestigationContacts}
@@ -35,7 +35,7 @@ const ContactsForm = (props: Props) => {
 
 interface Props {
     reason : string;
-    contacts : ConnectedInvestigation[];
+    investigations : ConnectedInvestigation[];
     groupedInvestigationContacts: number[]; 
     setGroupedInvestigationContacts:  React.Dispatch<React.SetStateAction<number[]>>;
     allContactIds: IdToCheck[];

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/ContactsForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/ContactsForm.tsx
@@ -9,7 +9,7 @@ import InvestigationAccordion from './InvestigationAccordion/InvestigationAccord
 const formHeadline = 'מאומתים המקובצים לחקירה :';
 
 const ContactsForm = (props: Props) => {
-    const { investigations , reason ,groupedInvestigationContacts, setGroupedInvestigationContacts, allContactIds} = props;
+    const { investigations , reason ,groupedInvestigationContacts, setGroupedInvestigationContacts} = props;
 
     return (
         <>
@@ -21,7 +21,6 @@ const ContactsForm = (props: Props) => {
                         <InvestigationAccordion
                             key={index}
                             investigation={investigation}
-                            allContactIds={allContactIds}
                             selectedRows={groupedInvestigationContacts}
                             setSelectedRows={setGroupedInvestigationContacts}
                         />
@@ -38,7 +37,6 @@ interface Props {
     investigations : ConnectedInvestigation[];
     groupedInvestigationContacts: number[]; 
     setGroupedInvestigationContacts:  React.Dispatch<React.SetStateAction<number[]>>;
-    allContactIds: IdToCheck[];
 }
 
 export default ContactsForm;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/ContactsForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/ContactsForm.tsx
@@ -1,6 +1,7 @@
-import React , {useState} from 'react'
+import React from 'react'
 import { Typography } from '@material-ui/core';
 
+import { IdToCheck } from 'Utils/Contacts/useDuplicateContactId';
 import ConnectedInvestigation from 'models/GroupedInvestigationContacts/ConnectedInvestigation';
 
 import InvestigationAccordion from './InvestigationAccordion/InvestigationAccordion';
@@ -8,7 +9,7 @@ import InvestigationAccordion from './InvestigationAccordion/InvestigationAccord
 const formHeadline = 'מאומתים המקובצים לחקירה :';
 
 const ContactsForm = (props: Props) => {
-    const { contacts , reason ,groupedInvestigationContacts, setGroupedInvestigationContacts} = props;
+    const { contacts , reason ,groupedInvestigationContacts, setGroupedInvestigationContacts, allContactIds} = props;
 
     return (
         <>
@@ -20,6 +21,7 @@ const ContactsForm = (props: Props) => {
                         <InvestigationAccordion
                             key={index}
                             contact={contact}
+                            allContactIds={allContactIds}
                             selectedRows={groupedInvestigationContacts}
                             setSelectedRows={setGroupedInvestigationContacts}
                         />
@@ -36,6 +38,7 @@ interface Props {
     contacts : ConnectedInvestigation[];
     groupedInvestigationContacts: number[]; 
     setGroupedInvestigationContacts:  React.Dispatch<React.SetStateAction<number[]>>;
+    allContactIds: IdToCheck[];
 }
 
 export default ContactsForm;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/ContactsForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/ContactsForm.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { Typography } from '@material-ui/core';
 
-import { IdToCheck } from 'Utils/Contacts/useDuplicateContactId';
+import { groupedInvestigationsContext } from 'commons/Contexts/GroupedInvestigationFormContext';
 import ConnectedInvestigation from 'models/GroupedInvestigationContacts/ConnectedInvestigation';
 
 import InvestigationAccordion from './InvestigationAccordion/InvestigationAccordion';
@@ -9,8 +9,8 @@ import InvestigationAccordion from './InvestigationAccordion/InvestigationAccord
 const formHeadline = 'מאומתים המקובצים לחקירה :';
 
 const ContactsForm = (props: Props) => {
-    const { investigations , reason ,groupedInvestigationContacts, setGroupedInvestigationContacts} = props;
-
+    const { investigations , reason } = props;
+    const { groupedInvestigationContacts } = useContext(groupedInvestigationsContext);
     return (
         <>
             <Typography variant='h5'>{formHeadline}</Typography>
@@ -21,8 +21,6 @@ const ContactsForm = (props: Props) => {
                         <InvestigationAccordion
                             key={index}
                             investigation={investigation}
-                            selectedRows={groupedInvestigationContacts}
-                            setSelectedRows={setGroupedInvestigationContacts}
                         />
                     )
                 })
@@ -35,8 +33,6 @@ const ContactsForm = (props: Props) => {
 interface Props {
     reason : string;
     investigations : ConnectedInvestigation[];
-    groupedInvestigationContacts: number[]; 
-    setGroupedInvestigationContacts:  React.Dispatch<React.SetStateAction<number[]>>;
 }
 
 export default ContactsForm;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/AccordionContent.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/AccordionContent.tsx
@@ -1,7 +1,6 @@
-import React , {useContext} from 'react';
+import React from 'react';
 import { AccordionDetails, Grid } from '@material-ui/core';
 
-import {groupedInvestigationsContext} from 'commons/Contexts/GroupedInvestigationFormContext';
 import ContactEvent from 'models/GroupedInvestigationContacts/ContactEvent';
 
 import useAccordionContent from './useAccordionContent';
@@ -11,14 +10,7 @@ import SelectedRowsMessage from './SelectedRowsMessage/SelectedRowsMessage';
 const AccordionContent = (props: Props) => {
     const { events, selectedRows, setSelectedRows} = props;
 
-    const { allContactIds } = useContext(groupedInvestigationsContext);
-    const existingIds = allContactIds.map(contact => {
-        if(contact.id) { 
-            return contact.id;
-        }
-        return "";
-    })!;
-    const { getCurrentSelectedRowsLength } = useAccordionContent({events , selectedRows});   
+    const { getCurrentSelectedRowsLength , existingIds } = useAccordionContent({events , selectedRows});   
 
     return (
         <AccordionDetails>

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/AccordionContent.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/AccordionContent.tsx
@@ -8,17 +8,15 @@ import ContactsTable from './ContactsTable/ContactsTable';
 import SelectedRowsMessage from './SelectedRowsMessage/SelectedRowsMessage';
 
 const AccordionContent = (props: Props) => {
-    const { events, selectedRows, setSelectedRows} = props;
+    const { events } = props;
 
-    const { getCurrentSelectedRowsLength , existingIds } = useAccordionContent({events , selectedRows});   
+    const { getCurrentSelectedRowsLength , existingIds } = useAccordionContent({events});   
 
     return (
         <AccordionDetails>
             <Grid container>
                 <Grid xs={12}>
                     <ContactsTable
-                        selectedRows={selectedRows}
-                        setSelectedRows={setSelectedRows}
                         events={events}
                         existingIds={existingIds}
                     />
@@ -34,8 +32,6 @@ const AccordionContent = (props: Props) => {
 }
 
 interface Props {
-    selectedRows : number[];
-    setSelectedRows: React.Dispatch<React.SetStateAction<number[]>>;
     events : ContactEvent[];
 }
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/AccordionContent.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/AccordionContent.tsx
@@ -1,9 +1,7 @@
-import React from 'react';
-import { useFormContext } from 'react-hook-form';
+import React , {useContext} from 'react';
 import { AccordionDetails, Grid } from '@material-ui/core';
 
-import Contact from 'models/Contact';
-import { IdToCheck } from 'Utils/Contacts/useDuplicateContactId';
+import {groupedInvestigationsContext} from 'commons/Contexts/GroupedInvestigationFormContext';
 import ContactEvent from 'models/GroupedInvestigationContacts/ContactEvent';
 
 import useAccordionContent from './useAccordionContent';
@@ -11,9 +9,9 @@ import ContactsTable from './ContactsTable/ContactsTable';
 import SelectedRowsMessage from './SelectedRowsMessage/SelectedRowsMessage';
 
 const AccordionContent = (props: Props) => {
-    const { events, selectedRows, setSelectedRows, allContactIds} = props;
-    const { getValues } = useFormContext();
+    const { events, selectedRows, setSelectedRows} = props;
 
+    const { allContactIds } = useContext(groupedInvestigationsContext);
     const existingIds = allContactIds.map(contact => {
         if(contact.id) { 
             return contact.id;
@@ -47,7 +45,6 @@ interface Props {
     selectedRows : number[];
     setSelectedRows: React.Dispatch<React.SetStateAction<number[]>>;
     events : ContactEvent[];
-    allContactIds: IdToCheck[];
 }
 
 export default AccordionContent;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/AccordionContent.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/AccordionContent.tsx
@@ -3,7 +3,7 @@ import { useFormContext } from 'react-hook-form';
 import { AccordionDetails, Grid } from '@material-ui/core';
 
 import Contact from 'models/Contact';
-
+import { IdToCheck } from 'Utils/Contacts/useDuplicateContactId';
 import ContactEvent from 'models/GroupedInvestigationContacts/ContactEvent';
 
 import useAccordionContent from './useAccordionContent';
@@ -11,10 +11,15 @@ import ContactsTable from './ContactsTable/ContactsTable';
 import SelectedRowsMessage from './SelectedRowsMessage/SelectedRowsMessage';
 
 const AccordionContent = (props: Props) => {
-    const { events, selectedRows, setSelectedRows} = props;
+    const { events, selectedRows, setSelectedRows, allContactIds} = props;
     const { getValues } = useFormContext();
 
-    const existingIds = getValues().contacts?.map((contact : Contact)=> contact.identificationNumber) || []; 
+    const existingIds = allContactIds.map(contact => {
+        if(contact.id) { 
+            return contact.id;
+        }
+        return "";
+    })!;
     const { getCurrentSelectedRowsLength } = useAccordionContent({events , selectedRows});   
 
     return (
@@ -42,6 +47,7 @@ interface Props {
     selectedRows : number[];
     setSelectedRows: React.Dispatch<React.SetStateAction<number[]>>;
     events : ContactEvent[];
+    allContactIds: IdToCheck[];
 }
 
 export default AccordionContent;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/AccordionContent.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/AccordionContent.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
+import { useFormContext } from 'react-hook-form';
 import { AccordionDetails, Grid } from '@material-ui/core';
+
+import Contact from 'models/Contact';
 
 import ContactEvent from 'models/GroupedInvestigationContacts/ContactEvent';
 
@@ -9,7 +12,9 @@ import SelectedRowsMessage from './SelectedRowsMessage/SelectedRowsMessage';
 
 const AccordionContent = (props: Props) => {
     const { events, selectedRows, setSelectedRows} = props;
+    const { getValues } = useFormContext();
 
+    const existingIds = getValues().contacts?.map((contact : Contact)=> contact.identificationNumber) || []; 
     const { getCurrentSelectedRowsLength } = useAccordionContent({events , selectedRows});   
 
     return (
@@ -20,6 +25,7 @@ const AccordionContent = (props: Props) => {
                         selectedRows={selectedRows}
                         setSelectedRows={setSelectedRows}
                         events={events}
+                        existingIds={existingIds}
                     />
                 </Grid>
                 <Grid xs={12}>

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/ContactsTable.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/ContactsTable.tsx
@@ -7,15 +7,13 @@ import TableRows from './TableRows/TableRows';
 import TableHeader from './TableHeader/TableHeader';
 
 const ContactsTable = (props: Props) => {
-    const { events, selectedRows , setSelectedRows, existingIds} = props;
+    const { events, existingIds} = props;
 
     return (
         <Table>
             <TableHeader />
             <TableRows 
-                selectedRows={selectedRows}
                 existingIds={existingIds}
-                setSelectedRows={setSelectedRows}
                 events={events}
             />
         </Table>
@@ -23,8 +21,6 @@ const ContactsTable = (props: Props) => {
 }
 
 interface Props {
-    selectedRows : number[];
-    setSelectedRows: React.Dispatch<React.SetStateAction<number[]>>;
     events : ContactEvent[];
     existingIds: string[];
 }

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/ContactsTable.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/ContactsTable.tsx
@@ -7,13 +7,14 @@ import TableRows from './TableRows/TableRows';
 import TableHeader from './TableHeader/TableHeader';
 
 const ContactsTable = (props: Props) => {
-    const { events, selectedRows , setSelectedRows} = props;
-    
+    const { events, selectedRows , setSelectedRows, existingIds} = props;
+
     return (
         <Table>
             <TableHeader />
             <TableRows 
                 selectedRows={selectedRows}
+                existingIds={existingIds}
                 setSelectedRows={setSelectedRows}
                 events={events}
             />
@@ -25,6 +26,7 @@ interface Props {
     selectedRows : number[];
     setSelectedRows: React.Dispatch<React.SetStateAction<number[]>>;
     events : ContactEvent[];
+    existingIds: string[];
 }
 
 export default ContactsTable

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/TableRows/TableRows.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/TableRows/TableRows.tsx
@@ -1,18 +1,20 @@
-import React from 'react'
+import React , { useContext } from 'react'
 import { TableBody , TableRow , TableCell, Checkbox } from '@material-ui/core';
 
 import formatDate from 'Utils/DateUtils/formatDate';
 import useInvolvedContact from 'Utils/vendor/useInvolvedContact';
 import ContactEvent from 'models/GroupedInvestigationContacts/ContactEvent';
+import { groupedInvestigationsContext } from 'commons/Contexts/GroupedInvestigationFormContext';
 
 import useStyles from './tableRowsStyles';
 import useTableRows from './useTableRows';
 
 const TableRows = (props: Props) => {
-    const { events , selectedRows , setSelectedRows , existingIds} = props;
+    const { events , existingIds} = props;
+    const groupedInvestigationsContextState = useContext(groupedInvestigationsContext);
     const classes = useStyles();
     const { isInvolvedThroughFamily } = useInvolvedContact();
-    const { handleCheckboxToggle } = useTableRows({selectedRows , setSelectedRows});
+    const { handleCheckboxToggle } = useTableRows();
 
     return (
         <TableBody>
@@ -38,7 +40,7 @@ const TableRows = (props: Props) => {
                             } = person.personByPersonInfo;
                             const isolationCity = person.addressByIsolationAddress?.cityByCity?.displayName;
 
-                            const isRowSelected = selectedRows.indexOf(id) !== -1;
+                            const isRowSelected = groupedInvestigationsContextState.groupedInvestigationContacts.indexOf(id) !== -1;
                             const isRowDisabled = existingIds.indexOf(identificationNumber) !== -1;
                             const rowClass = isRowDisabled 
                                                 ? classes.disabled
@@ -75,8 +77,6 @@ const TableRows = (props: Props) => {
 }
 
 interface Props {
-    selectedRows : number[]
-    setSelectedRows: React.Dispatch<React.SetStateAction<number[]>>;
     events : ContactEvent[];
     existingIds: string[];
 }

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/TableRows/TableRows.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/TableRows/TableRows.tsx
@@ -8,11 +8,11 @@ import useStyles from './tableRowsStyles';
 import useTableRows from './useTableRows';
 
 const TableRows = (props: Props) => {
-    const { events , selectedRows , setSelectedRows} = props;
+    const { events , selectedRows , setSelectedRows, existingIds} = props;
     const classes = useStyles();
     
     const { handleCheckboxToggle } = useTableRows({selectedRows , setSelectedRows});
-    
+
     return (
         <TableBody>
             {
@@ -21,6 +21,7 @@ const TableRows = (props: Props) => {
 
                     return nodes.map((person) => {
                         const {id} = person;
+                        
                         const {
                             firstName,
                             lastName,
@@ -33,10 +34,18 @@ const TableRows = (props: Props) => {
                         const isolationCity = person.addressByIsolationAddress?.cityByCity?.displayName;
 
                         const isRowSelected = selectedRows.indexOf(id) !== -1;
+                        const isRowDisabled = existingIds.indexOf(identificationNumber) !== -1;
+                        const rowClass = isRowDisabled 
+                                            ? classes.disabled
+                                            : isRowSelected 
+                                                ? classes.selected
+                                                : ''
+
                         return (
-                            <TableRow key={id} className={isRowSelected ? classes.selected : ''}>
+                            <TableRow key={id} className={rowClass}>
                                 <TableCell>
                                     <Checkbox
+                                        disabled={isRowDisabled}
                                         color='primary'
                                         checked={isRowSelected}
                                         onClick={() => handleCheckboxToggle(id)}
@@ -62,7 +71,8 @@ const TableRows = (props: Props) => {
 interface Props {
     selectedRows : number[]
     setSelectedRows: React.Dispatch<React.SetStateAction<number[]>>;
-    events : ContactEvent[]
+    events : ContactEvent[];
+    existingIds: string[];
 }
 
 export default TableRows

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/TableRows/TableRows.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/TableRows/TableRows.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { TableBody , TableRow , TableCell, Checkbox } from '@material-ui/core';
 
 import formatDate from 'Utils/DateUtils/formatDate';
+import useInvolvedContact from 'Utils/vendor/useInvolvedContact';
 import ContactEvent from 'models/GroupedInvestigationContacts/ContactEvent';
 
 import useStyles from './tableRowsStyles';
@@ -10,7 +11,8 @@ import useTableRows from './useTableRows';
 const TableRows = (props: Props) => {
     const { events , selectedRows , setSelectedRows, existingIds} = props;
     const classes = useStyles();
-    
+    const { isInvolvedThroughFamily } = useInvolvedContact();
+
     const { handleCheckboxToggle } = useTableRows({selectedRows , setSelectedRows});
 
     return (
@@ -20,47 +22,52 @@ const TableRows = (props: Props) => {
                     const { nodes } = event.contactedPeopleByContactEvent;
 
                     return nodes.map((person) => {
-                        const {id} = person;
+                        const {involvedContactByInvolvedContactId} = person;
+                        const isFamily = involvedContactByInvolvedContactId && isInvolvedThroughFamily(involvedContactByInvolvedContactId.involvementReason);
                         
-                        const {
-                            firstName,
-                            lastName,
-                            identificationType,
-                            identificationNumber,
-                            birthDate,
-                            phoneNumber,
-                            additionalPhoneNumber
-                        } = person.personByPersonInfo;
-                        const isolationCity = person.addressByIsolationAddress?.cityByCity?.displayName;
+                        if(!isFamily) {
+                            const {id} = person;
+                            
+                            const {
+                                firstName,
+                                lastName,
+                                identificationType,
+                                identificationNumber,
+                                birthDate,
+                                phoneNumber,
+                                additionalPhoneNumber
+                            } = person.personByPersonInfo;
+                            const isolationCity = person.addressByIsolationAddress?.cityByCity?.displayName;
 
-                        const isRowSelected = selectedRows.indexOf(id) !== -1;
-                        const isRowDisabled = existingIds.indexOf(identificationNumber) !== -1;
-                        const rowClass = isRowDisabled 
-                                            ? classes.disabled
-                                            : isRowSelected 
-                                                ? classes.selected
-                                                : ''
+                            const isRowSelected = selectedRows.indexOf(id) !== -1;
+                            const isRowDisabled = existingIds.indexOf(identificationNumber) !== -1;
+                            const rowClass = isRowDisabled 
+                                                ? classes.disabled
+                                                : isRowSelected 
+                                                    ? classes.selected
+                                                    : ''
 
-                        return (
-                            <TableRow key={id} className={rowClass}>
-                                <TableCell>
-                                    <Checkbox
-                                        disabled={isRowDisabled}
-                                        color='primary'
-                                        checked={isRowSelected}
-                                        onClick={() => handleCheckboxToggle(id)}
-                                    />
-                                </TableCell>
-                                <TableCell>{firstName}</TableCell>
-                                <TableCell>{lastName}</TableCell>
-                                <TableCell>{identificationType}</TableCell>
-                                <TableCell>{identificationNumber}</TableCell>
-                                <TableCell>{formatDate(new Date(birthDate))}</TableCell>
-                                <TableCell>{phoneNumber}</TableCell>
-                                <TableCell>{additionalPhoneNumber}</TableCell>
-                                <TableCell>{isolationCity}</TableCell>
-                            </TableRow>
-                        )
+                            return (
+                                <TableRow key={id} className={rowClass}>
+                                    <TableCell>
+                                        <Checkbox
+                                            disabled={isRowDisabled}
+                                            color='primary'
+                                            checked={isRowSelected}
+                                            onClick={() => handleCheckboxToggle(id)}
+                                        />
+                                    </TableCell>
+                                    <TableCell>{firstName}</TableCell>
+                                    <TableCell>{lastName}</TableCell>
+                                    <TableCell>{identificationType}</TableCell>
+                                    <TableCell>{identificationNumber}</TableCell>
+                                    <TableCell>{formatDate(new Date(birthDate))}</TableCell>
+                                    <TableCell>{phoneNumber}</TableCell>
+                                    <TableCell>{additionalPhoneNumber}</TableCell>
+                                    <TableCell>{isolationCity}</TableCell>
+                                </TableRow>
+                            )
+                        }
                     })
                 })
             }

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/TableRows/TableRows.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/TableRows/TableRows.tsx
@@ -9,10 +9,9 @@ import useStyles from './tableRowsStyles';
 import useTableRows from './useTableRows';
 
 const TableRows = (props: Props) => {
-    const { events , selectedRows , setSelectedRows, existingIds} = props;
+    const { events , selectedRows , setSelectedRows , existingIds} = props;
     const classes = useStyles();
     const { isInvolvedThroughFamily } = useInvolvedContact();
-
     const { handleCheckboxToggle } = useTableRows({selectedRows , setSelectedRows});
 
     return (

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/TableRows/tableRowsStyles.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/TableRows/tableRowsStyles.ts
@@ -4,6 +4,9 @@ const useStyles = makeStyles(() => ({
     selected: {
         backgroundColor: 'rgb(202, 222, 234)'
     },
+    disabled: {
+        backgroundColor: 'rgb(0, 0, 0, 0.15)'
+    }
 }));
 
 export default useStyles;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/TableRows/useTableRows.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/TableRows/useTableRows.ts
@@ -1,12 +1,15 @@
-const useTableRows = (props : Props) => {
-    const { selectedRows, setSelectedRows } = props;
-    
+import { useContext } from 'react';
+
+import { groupedInvestigationsContext } from 'commons/Contexts/GroupedInvestigationFormContext';
+
+const useTableRows = () => {
+    const groupedInvestigationsContextState = useContext(groupedInvestigationsContext);
     const handleCheckboxToggle = (id : number) => {
-        const rowIndex = selectedRows.indexOf(id);
+        const rowIndex = groupedInvestigationsContextState.groupedInvestigationContacts.indexOf(id);
         if(rowIndex === -1) {
-            setSelectedRows([...selectedRows , id])
+            groupedInvestigationsContextState.setGroupedInvestigationContacts([...groupedInvestigationsContextState.groupedInvestigationContacts , id]);
         } else {
-            setSelectedRows(selectedRows.filter(row => row !== id))
+            groupedInvestigationsContextState.setGroupedInvestigationContacts(groupedInvestigationsContextState.groupedInvestigationContacts.filter(row => row !== id));
         }
     }
 
@@ -15,9 +18,5 @@ const useTableRows = (props : Props) => {
     }
 }
 
-interface Props {
-    selectedRows: number[];
-    setSelectedRows: React.Dispatch<React.SetStateAction<number[]>>;
-}
 
 export default useTableRows;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/useAccordionContent.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/useAccordionContent.ts
@@ -1,6 +1,10 @@
+import { useContext } from 'react';
 import ContactEvent from 'models/GroupedInvestigationContacts/ContactEvent';
 
+import { groupedInvestigationsContext } from 'commons/Contexts/GroupedInvestigationFormContext';
+
 const useAccordionContent = (props: Props) => {
+    const { allContactIds } = useContext(groupedInvestigationsContext);
     const { selectedRows , events } = props;
     const getCurrentSelectedRowsLength = () => {
         let count = 0;
@@ -15,8 +19,17 @@ const useAccordionContent = (props: Props) => {
 
         return count;
     }
+
+    const existingIds = allContactIds.map(contact => {
+        if(contact.id) { 
+            return contact.id;
+        }
+        return "";
+    })!;
+
     return {
-        getCurrentSelectedRowsLength
+        getCurrentSelectedRowsLength,
+        existingIds
     }
 }
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/useAccordionContent.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/useAccordionContent.ts
@@ -4,15 +4,15 @@ import ContactEvent from 'models/GroupedInvestigationContacts/ContactEvent';
 import { groupedInvestigationsContext } from 'commons/Contexts/GroupedInvestigationFormContext';
 
 const useAccordionContent = (props: Props) => {
-    const { allContactIds } = useContext(groupedInvestigationsContext);
-    const { selectedRows , events } = props;
+    const { allContactIds , groupedInvestigationContacts } = useContext(groupedInvestigationsContext);
+    const { events } = props;
     const getCurrentSelectedRowsLength = () => {
         let count = 0;
         events.forEach(
             event => event.contactedPeopleByContactEvent.nodes.forEach(
                 person => {
                     const { id } = person;
-                    selectedRows.includes(id) && count++;
+                    groupedInvestigationContacts.includes(id) && count++;
                 }
             )
         );
@@ -34,7 +34,6 @@ const useAccordionContent = (props: Props) => {
 }
 
 interface Props {
-    selectedRows : number[];
     events : ContactEvent[];
 }
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/InvestigationAccordion.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/InvestigationAccordion.tsx
@@ -9,7 +9,7 @@ import AccordionContent from './AccordionContent/AccordionContent';
 import AccordionHeadline from './AccordionHeadline/AccordionHeadline';
 
 const InvestigationAccordion = (props: Props) => {
-    const { selectedRows , investigation , setSelectedRows, allContactIds} = props;
+    const { selectedRows , investigation , setSelectedRows} = props;
     const { epidemiologyNumber , contactEventsByInvestigationId , investigatedPatientByInvestigatedPatientId } = investigation;
     const { fullName , identityNumber } = investigatedPatientByInvestigatedPatientId.covidPatientByCovidPatient;
 
@@ -26,7 +26,6 @@ const InvestigationAccordion = (props: Props) => {
                 selectedRows={selectedRows}
                 setSelectedRows={setSelectedRows}
                 events={contactEventsByInvestigationId.nodes}
-                allContactIds={allContactIds}
             />
         </Accordion>
     )
@@ -36,7 +35,6 @@ interface Props {
     selectedRows: number[];
     setSelectedRows: React.Dispatch<React.SetStateAction<number[]>>;
     investigation: ConnectedInvestigation;
-    allContactIds: IdToCheck[];
 }
 
 export default InvestigationAccordion;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/InvestigationAccordion.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/InvestigationAccordion.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Accordion } from '@material-ui/core';
 
+import { IdToCheck } from 'Utils/Contacts/useDuplicateContactId';
 import ConnectedInvestigation from 'models/GroupedInvestigationContacts/ConnectedInvestigation';
 
 import useStyles from './accordionStyles';
@@ -8,7 +9,7 @@ import AccordionContent from './AccordionContent/AccordionContent';
 import AccordionHeadline from './AccordionHeadline/AccordionHeadline';
 
 const InvestigationAccordion = (props: Props) => {
-    const { selectedRows , contact , setSelectedRows} = props;
+    const { selectedRows , contact , setSelectedRows, allContactIds} = props;
     const { epidemiologyNumber , contactEventsByInvestigationId , investigatedPatientByInvestigatedPatientId } = contact;
     const { fullName , identityNumber } = investigatedPatientByInvestigatedPatientId.covidPatientByCovidPatient;
 
@@ -25,6 +26,7 @@ const InvestigationAccordion = (props: Props) => {
                 selectedRows={selectedRows}
                 setSelectedRows={setSelectedRows}
                 events={contactEventsByInvestigationId.nodes}
+                allContactIds={allContactIds}
             />
         </Accordion>
     )
@@ -34,6 +36,7 @@ interface Props {
     selectedRows: number[];
     setSelectedRows: React.Dispatch<React.SetStateAction<number[]>>;
     contact: ConnectedInvestigation;
+    allContactIds: IdToCheck[];
 }
 
 export default InvestigationAccordion;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/InvestigationAccordion.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/InvestigationAccordion.tsx
@@ -9,8 +9,8 @@ import AccordionContent from './AccordionContent/AccordionContent';
 import AccordionHeadline from './AccordionHeadline/AccordionHeadline';
 
 const InvestigationAccordion = (props: Props) => {
-    const { selectedRows , contact , setSelectedRows, allContactIds} = props;
-    const { epidemiologyNumber , contactEventsByInvestigationId , investigatedPatientByInvestigatedPatientId } = contact;
+    const { selectedRows , investigation , setSelectedRows, allContactIds} = props;
+    const { epidemiologyNumber , contactEventsByInvestigationId , investigatedPatientByInvestigatedPatientId } = investigation;
     const { fullName , identityNumber } = investigatedPatientByInvestigatedPatientId.covidPatientByCovidPatient;
 
     const classes = useStyles();
@@ -35,7 +35,7 @@ const InvestigationAccordion = (props: Props) => {
 interface Props {
     selectedRows: number[];
     setSelectedRows: React.Dispatch<React.SetStateAction<number[]>>;
-    contact: ConnectedInvestigation;
+    investigation: ConnectedInvestigation;
     allContactIds: IdToCheck[];
 }
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/InvestigationAccordion.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/InvestigationAccordion.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Accordion } from '@material-ui/core';
 
-import { IdToCheck } from 'Utils/Contacts/useDuplicateContactId';
 import ConnectedInvestigation from 'models/GroupedInvestigationContacts/ConnectedInvestigation';
 
 import useStyles from './accordionStyles';
@@ -9,7 +8,7 @@ import AccordionContent from './AccordionContent/AccordionContent';
 import AccordionHeadline from './AccordionHeadline/AccordionHeadline';
 
 const InvestigationAccordion = (props: Props) => {
-    const { selectedRows , investigation , setSelectedRows} = props;
+    const { investigation } = props;
     const { epidemiologyNumber , contactEventsByInvestigationId , investigatedPatientByInvestigatedPatientId } = investigation;
     const { fullName , identityNumber } = investigatedPatientByInvestigatedPatientId.covidPatientByCovidPatient;
 
@@ -23,8 +22,6 @@ const InvestigationAccordion = (props: Props) => {
                 identityNumber={identityNumber}
             />
             <AccordionContent 
-                selectedRows={selectedRows}
-                setSelectedRows={setSelectedRows}
                 events={contactEventsByInvestigationId.nodes}
             />
         </Accordion>
@@ -32,8 +29,6 @@ const InvestigationAccordion = (props: Props) => {
 }
 
 interface Props {
-    selectedRows: number[];
-    setSelectedRows: React.Dispatch<React.SetStateAction<number[]>>;
     investigation: ConnectedInvestigation;
 }
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/GroupedInvestigationForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/GroupedInvestigationForm.tsx
@@ -21,7 +21,7 @@ const GroupedInvestigationForm = (props: Props) => {
     const { groupId, groupedInvestigationContacts, setGroupedInvestigationContacts, allContactIds} = props;
 
     const [contacts, setContacts] = useState<ConnectedInvestigationContact>(initialState);
-    const nodes = contacts.investigationsByGroupId.nodes;
+    const {nodes} = contacts.investigationsByGroupId;
 
     useGroupedInvestigationsTab({groupId , setContacts});
 
@@ -31,7 +31,7 @@ const GroupedInvestigationForm = (props: Props) => {
                 text={noContactsText}
               />
             : <ContactsForm 
-                contacts={nodes}
+                investigations={nodes}
                 reason={contacts.otherReason||contacts.investigationGroupReasonByReason.displayName}
                 groupedInvestigationContacts={groupedInvestigationContacts}
                 setGroupedInvestigationContacts={setGroupedInvestigationContacts}

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/GroupedInvestigationForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/GroupedInvestigationForm.tsx
@@ -1,5 +1,6 @@
 import React , { useState } from 'react'
 
+import { IdToCheck } from 'Utils/Contacts/useDuplicateContactId';
 import ConnectedInvestigationContact from 'models/GroupedInvestigationContacts/ConnectedInvestigationContact';
 
 import ContactsForm from './ContactsForm/ContactsForm';
@@ -17,7 +18,7 @@ const initialState = {
 }
 
 const GroupedInvestigationForm = (props: Props) => {
-    const { groupId, groupedInvestigationContacts, setGroupedInvestigationContacts} = props;
+    const { groupId, groupedInvestigationContacts, setGroupedInvestigationContacts, allContactIds} = props;
 
     const [contacts, setContacts] = useState<ConnectedInvestigationContact>(initialState);
     const nodes = contacts.investigationsByGroupId.nodes;
@@ -34,6 +35,7 @@ const GroupedInvestigationForm = (props: Props) => {
                 reason={contacts.otherReason||contacts.investigationGroupReasonByReason.displayName}
                 groupedInvestigationContacts={groupedInvestigationContacts}
                 setGroupedInvestigationContacts={setGroupedInvestigationContacts}
+                allContactIds={allContactIds}
             />
     )
 }
@@ -42,6 +44,7 @@ interface Props {
     groupId : string;
     groupedInvestigationContacts: number[]; 
     setGroupedInvestigationContacts:  React.Dispatch<React.SetStateAction<number[]>>;
+    allContactIds: IdToCheck[];
 }
 
 export default GroupedInvestigationForm

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/GroupedInvestigationForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/GroupedInvestigationForm.tsx
@@ -17,7 +17,7 @@ const initialState = {
 }
 
 const GroupedInvestigationForm = (props: Props) => {
-    const { groupId, groupedInvestigationContacts, setGroupedInvestigationContacts} = props;
+    const { groupId } = props;
 
     const [contacts, setContacts] = useState<ConnectedInvestigationContact>(initialState);
     const {nodes} = contacts.investigationsByGroupId;
@@ -32,16 +32,12 @@ const GroupedInvestigationForm = (props: Props) => {
             : <ContactsForm 
                 investigations={nodes}
                 reason={contacts.otherReason||contacts.investigationGroupReasonByReason.displayName}
-                groupedInvestigationContacts={groupedInvestigationContacts}
-                setGroupedInvestigationContacts={setGroupedInvestigationContacts}
             />
     )
 }
 
 interface Props {
     groupId : string;
-    groupedInvestigationContacts: number[]; 
-    setGroupedInvestigationContacts:  React.Dispatch<React.SetStateAction<number[]>>;
 }
 
 export default GroupedInvestigationForm

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/GroupedInvestigationForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/GroupedInvestigationForm.tsx
@@ -1,6 +1,5 @@
 import React , { useState } from 'react'
 
-import { IdToCheck } from 'Utils/Contacts/useDuplicateContactId';
 import ConnectedInvestigationContact from 'models/GroupedInvestigationContacts/ConnectedInvestigationContact';
 
 import ContactsForm from './ContactsForm/ContactsForm';
@@ -18,7 +17,7 @@ const initialState = {
 }
 
 const GroupedInvestigationForm = (props: Props) => {
-    const { groupId, groupedInvestigationContacts, setGroupedInvestigationContacts, allContactIds} = props;
+    const { groupId, groupedInvestigationContacts, setGroupedInvestigationContacts} = props;
 
     const [contacts, setContacts] = useState<ConnectedInvestigationContact>(initialState);
     const {nodes} = contacts.investigationsByGroupId;
@@ -35,7 +34,6 @@ const GroupedInvestigationForm = (props: Props) => {
                 reason={contacts.otherReason||contacts.investigationGroupReasonByReason.displayName}
                 groupedInvestigationContacts={groupedInvestigationContacts}
                 setGroupedInvestigationContacts={setGroupedInvestigationContacts}
-                allContactIds={allContactIds}
             />
     )
 }
@@ -44,7 +42,6 @@ interface Props {
     groupId : string;
     groupedInvestigationContacts: number[]; 
     setGroupedInvestigationContacts:  React.Dispatch<React.SetStateAction<number[]>>;
-    allContactIds: IdToCheck[];
 }
 
 export default GroupedInvestigationForm

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationsTab.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationsTab.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react'
 
+import { IdToCheck } from 'Utils/Contacts/useDuplicateContactId';
+
 import useStyles from './groupedInvestigationFormStyles'; 
 import ErrorMessage from './ErrorMessage/ErrorMessage';
 import useGroupedInvestigationsTab from './useGroupedInvestigationsTab';
@@ -8,7 +10,7 @@ import GroupedInvestigationForm from './GroupedInvestigationForm/GroupedInvestig
 const notGroupedText = 'החקירה אינה מקובצת';
 
 const GroupedInvestigationsTab = (props: Props) => {
-    const { groupedInvestigationContacts, setGroupedInvestigationContacts} = props;
+    const { groupedInvestigationContacts, setGroupedInvestigationContacts , allContactIds} = props;
     const classes = useStyles();
     const [groupId, setGroupId] = useState<string>("");
     useGroupedInvestigationsTab({setGroupId});
@@ -23,6 +25,7 @@ const GroupedInvestigationsTab = (props: Props) => {
                         groupId={groupId}
                         groupedInvestigationContacts={groupedInvestigationContacts}
                         setGroupedInvestigationContacts={setGroupedInvestigationContacts}
+                        allContactIds={allContactIds}
                     />
                 }
         </div>
@@ -32,6 +35,7 @@ const GroupedInvestigationsTab = (props: Props) => {
 interface Props {
     groupedInvestigationContacts: number[]; 
     setGroupedInvestigationContacts:  React.Dispatch<React.SetStateAction<number[]>>;
+    allContactIds: IdToCheck[];
 }
 
 export default GroupedInvestigationsTab;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationsTab.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationsTab.tsx
@@ -7,8 +7,7 @@ import GroupedInvestigationForm from './GroupedInvestigationForm/GroupedInvestig
 
 const notGroupedText = 'החקירה אינה מקובצת';
 
-const GroupedInvestigationsTab = (props: Props) => {
-    const { groupedInvestigationContacts, setGroupedInvestigationContacts} = props;
+const GroupedInvestigationsTab = () => {
     const classes = useStyles();
     const [groupId, setGroupId] = useState<string>("");
     useGroupedInvestigationsTab({setGroupId});
@@ -21,17 +20,10 @@ const GroupedInvestigationsTab = (props: Props) => {
                     />
                 :   <GroupedInvestigationForm 
                         groupId={groupId}
-                        groupedInvestigationContacts={groupedInvestigationContacts}
-                        setGroupedInvestigationContacts={setGroupedInvestigationContacts}
                     />
                 }
         </div>
     )
-}
-
-interface Props {
-    groupedInvestigationContacts: number[]; 
-    setGroupedInvestigationContacts:  React.Dispatch<React.SetStateAction<number[]>>;
 }
 
 export default GroupedInvestigationsTab;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationsTab.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationsTab.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react'
 
-import { IdToCheck } from 'Utils/Contacts/useDuplicateContactId';
-
 import useStyles from './groupedInvestigationFormStyles'; 
 import ErrorMessage from './ErrorMessage/ErrorMessage';
 import useGroupedInvestigationsTab from './useGroupedInvestigationsTab';
@@ -10,7 +8,7 @@ import GroupedInvestigationForm from './GroupedInvestigationForm/GroupedInvestig
 const notGroupedText = 'החקירה אינה מקובצת';
 
 const GroupedInvestigationsTab = (props: Props) => {
-    const { groupedInvestigationContacts, setGroupedInvestigationContacts , allContactIds} = props;
+    const { groupedInvestigationContacts, setGroupedInvestigationContacts} = props;
     const classes = useStyles();
     const [groupId, setGroupId] = useState<string>("");
     useGroupedInvestigationsTab({setGroupId});
@@ -25,7 +23,6 @@ const GroupedInvestigationsTab = (props: Props) => {
                         groupId={groupId}
                         groupedInvestigationContacts={groupedInvestigationContacts}
                         setGroupedInvestigationContacts={setGroupedInvestigationContacts}
-                        allContactIds={allContactIds}
                     />
                 }
         </div>
@@ -35,7 +32,6 @@ const GroupedInvestigationsTab = (props: Props) => {
 interface Props {
     groupedInvestigationContacts: number[]; 
     setGroupedInvestigationContacts:  React.Dispatch<React.SetStateAction<number[]>>;
-    allContactIds: IdToCheck[];
 }
 
 export default GroupedInvestigationsTab;

--- a/client/src/models/GroupedInvestigationContacts/ContactEvent.ts
+++ b/client/src/models/GroupedInvestigationContacts/ContactEvent.ts
@@ -4,6 +4,9 @@ type ContactEvent = {
     contactedPeopleByContactEvent : {
         nodes: {
             id: number;
+            involvedContactByInvolvedContactId?: {
+                involvementReason: number; 
+            }
             addressByIsolationAddress: {
                 cityByCity: {
                     displayName: string;

--- a/server/src/DBService/ContactEvent/Query.ts
+++ b/server/src/DBService/ContactEvent/Query.ts
@@ -162,6 +162,9 @@ query contactsByGroupId($groupId: UUID!, $epidemiologynumber: Int!) {
             contactedPeopleByContactEvent {
               nodes {
                 id
+                involvedContactByInvolvedContactId {
+                  involvementReason
+                }
                 personByPersonInfo {
                   firstName
                   identificationNumber


### PR DESCRIPTION
## Added 2 new logics to the grouped investigation form
### 1. If the contact is a family contact - don't show it
added involvement reason to the query and filtered by it in the display
### 2. If the contact already exists in the investigation - disable it
added a new class - disabled and applied it to rows containing existing Ids (using allContactIds at root level)

fixes [1431](https://dev.azure.com/spectrumFactory/CoronaI/_sprints/backlog/CoronaI%20Team/CoronaI/Sprint%2014?workitem=1431)