### PR TITLE
Fix/users middleware

### DIFF
--- a/client/src/components/App/Content/LandingPage/adminLandingPage/useAdminLandingPage.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/useAdminLandingPage.ts
@@ -9,6 +9,7 @@ import StoreStateType from 'redux/storeStateType';
 import { landingPageRoute } from 'Utils/Routes/Routes';
 import { defaultTimeRange } from 'models/enums/timeRanges'
 import { TimeRange, TimeRangeDates } from 'models/TimeRange';
+import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
 import FilterRulesVariables from 'models/FilterRulesVariables';
 import InvesitgationStatistics from 'models/InvestigationStatistics';
 import FilterRulesDescription from 'models/enums/FilterRulesDescription';
@@ -18,6 +19,7 @@ import { HistoryState } from '../InvestigationTable/InvestigationTableInterfaces
 export const allTimeRangeId = 10;
 
 const useAdminLandingPage = (parameters: Parameters) => {
+    const { alertError } = useCustomSwal();
 
     const history = useHistory<HistoryState>();
     const displayedCounty = useSelector<StoreStateType, number>(state => state.user.displayedCounty);
@@ -86,6 +88,7 @@ const useAdminLandingPage = (parameters: Parameters) => {
         })
         .catch(error => {
             unallocatedCountLogger.error(`got error ${error}`, Severity.HIGH);
+            alertError('לא ניתן היה לקבל את הנתונים');
         })
         .finally(() => {
             setIsLoading(false)

--- a/server/src/ClientToDBAPI/LandingPageRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/LandingPageRoute/mainRoute.ts
@@ -157,7 +157,7 @@ landingPageRoute.post('/changeDesk', adminMiddleWare, (request: Request, respons
         });
 })
 
-landingPageRoute.post('/changeGroupDesk', adminMiddleWare, (request: Request, response: Response) => {
+landingPageRoute.post('/changeGroupDesk', handleCountyRequest, (request: Request, response: Response) => {
     const changeGroupDeskLogger = logger.setup({
         workflow: 'change desk for grouped investigatios',
         user: response.locals.user.id,
@@ -182,7 +182,7 @@ landingPageRoute.post('/changeGroupDesk', adminMiddleWare, (request: Request, re
         });
 });
 
-landingPageRoute.post('/investigationStatistics', adminMiddleWare ,(request: Request, response: Response) => {
+landingPageRoute.post('/investigationStatistics', handleCountyRequest, (request: Request, response: Response) => {
     const investigationsStatisticsLogger = logger.setup({
         workflow: 'query investigations statistics',
         user: response.locals.user.id,

--- a/server/src/ClientToDBAPI/LandingPageRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/LandingPageRoute/mainRoute.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 
 import { Severity } from '../../Models/Logger/types';
 import { adminMiddleWare } from '../../middlewares/Authentication';
+import handleCountyRequest from '../../middlewares/HandleCountyRequest';
 import { graphqlRequest, errorStatusCode } from '../../GraphqlHTTPRequest';
 import { convertUserInvestigationsData, convertGroupInvestigationsData } from './utils';
 import { CHANGE_DESK_ID, UPDATE_DESK_BY_GROUP_ID } from '../../DBService/LandingPage/Mutation';
@@ -53,7 +54,7 @@ landingPageRoute.post('/investigations', (request: Request, response: Response) 
         });
 })
 
-landingPageRoute.post('/groupInvestigations', adminMiddleWare, (request: Request, response: Response) => {
+landingPageRoute.post('/groupInvestigations', handleCountyRequest, (request: Request, response: Response) => {
     const groupInvestigationsLogger = logger.setup({
         workflow: `query group's Investigations`,
         user: response.locals.user.id,

--- a/server/src/ClientToDBAPI/UsersRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/UsersRoute/mainRoute.ts
@@ -5,6 +5,7 @@ import UserPatch from '../../Models/User/UserPatch';
 import { Severity } from '../../Models/Logger/types';
 import { adminMiddleWare } from '../../middlewares/Authentication';
 import handleUsersRequest from '../../middlewares/HandleUsersRequest';
+import handleCountyRequest from '../../middlewares/handleCountyRequest';
 import CreateUserResponse from '../../Models/User/CreateUserResponse';
 import UpdateUserResponse from '../../Models/User/UpdateUserResponse';
 import { graphqlRequest, errorStatusCode } from '../../GraphqlHTTPRequest';
@@ -388,7 +389,7 @@ usersRoute.put('', (request: Request, response: Response) => {
         });
 });
 
-usersRoute.post('/county', adminMiddleWare, (request: Request, response: Response) => {
+usersRoute.post('/county', handleCountyRequest, (request: Request, response: Response) => {
     const countyLogger = logger.setup({
         workflow: 'query users by current user\'s county id',
         user: response.locals.user.id

--- a/server/src/ClientToDBAPI/UsersRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/UsersRoute/mainRoute.ts
@@ -4,6 +4,7 @@ import User from '../../Models/User/User';
 import UserPatch from '../../Models/User/UserPatch';
 import { Severity } from '../../Models/Logger/types';
 import { adminMiddleWare } from '../../middlewares/Authentication';
+import handleUsersRequest from '../../middlewares/HandleUsersRequest';
 import CreateUserResponse from '../../Models/User/CreateUserResponse';
 import UpdateUserResponse from '../../Models/User/UpdateUserResponse';
 import { graphqlRequest, errorStatusCode } from '../../GraphqlHTTPRequest';
@@ -136,7 +137,7 @@ usersRoute.post('/updateIsUserActive', (request: Request, response: Response) =>
     updateIsUserActive(response, response.locals.user.id, request.body.isActive);
 })
 
-usersRoute.post('/updateIsUserActiveById', adminMiddleWare, (request: Request, response: Response) => {
+usersRoute.post('/updateIsUserActiveById', handleUsersRequest, (request: Request, response: Response) => {
     updateIsUserActive(response, request.body.userId, request.body.isActive);
 })
 

--- a/server/src/ClientToDBAPI/UsersRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/UsersRoute/mainRoute.ts
@@ -43,7 +43,7 @@ usersRoute.get('/userActivityStatus', (request: Request, response: Response) => 
         })
 })
 
-usersRoute.post('/updateSourceOrganizationById', adminMiddleWare, (request: Request, response: Response) => {
+usersRoute.post('/updateSourceOrganizationById', handleUsersRequest, (request: Request, response: Response) => {
     const updateSourceOrganizationLogger = logger.setup({
         workflow: 'update user source organization',
         user: response.locals.user.id,
@@ -65,7 +65,7 @@ usersRoute.post('/updateSourceOrganizationById', adminMiddleWare, (request: Requ
         })
 })
 
-usersRoute.post('/updateDesk', adminMiddleWare, (request: Request, response: Response) => {
+usersRoute.post('/updateDesk', handleUsersRequest, (request: Request, response: Response) => {
     const updateDeskLogger = logger.setup({
         workflow: 'update user desk',
         user: response.locals.user.id,
@@ -87,7 +87,7 @@ usersRoute.post('/updateDesk', adminMiddleWare, (request: Request, response: Res
         })
 })
 
-usersRoute.post('/updateCounty', adminMiddleWare, (request: Request, response: Response) => {
+usersRoute.post('/updateCounty', handleUsersRequest, (request: Request, response: Response) => {
     const updateCountyLogger = logger.setup({
         workflow: 'update user county',
         user: response.locals.user.id,

--- a/server/src/DBService/Counties/Query.ts
+++ b/server/src/DBService/Counties/Query.ts
@@ -14,3 +14,11 @@ query allCounties {
   }
 }
 `;
+
+export const DISTRICT_BY_COUNTY = gql`
+query DistrictByCounty($id : Int!) {
+  countyById(id: $id){
+    districtId
+  }
+}
+`;

--- a/server/src/DBService/Users/Query.ts
+++ b/server/src/DBService/Users/Query.ts
@@ -1,5 +1,4 @@
 import { gql } from 'postgraphile';
-import InvestigationMainStatusCodes from '../../Models/InvestigationStatus/InvestigationMainStatusCodes';
 
 export const GET_IS_USER_ACTIVE = gql`
     query isUserActive($id: String!){
@@ -118,4 +117,15 @@ query allUserTypes {
     }
   }
 }
+`;
+
+export const DISTRICT_COUNTY_BY_USER = gql`
+query GetUser($id: String!) {
+    userById(id: $id) {
+      investigationGroup
+      countyByInvestigationGroup {
+        districtId
+      }
+    }
+  }   
 `;

--- a/server/src/middlewares/HandleCountyRequest.ts
+++ b/server/src/middlewares/HandleCountyRequest.ts
@@ -1,0 +1,74 @@
+import { NextFunction, Request, Response } from 'express';
+
+import UserType from '../Models/User/UserType';
+import { DISTRICT_BY_COUNTY } from '../DBService/Counties/Query';
+import logger, { invalidDBResponseLog, launchingDBRequestLog, validDBResponseLog } from '../Logger/Logger';
+import { graphqlRequest, unauthorizedStatusCode } from '../GraphqlHTTPRequest';
+import { Severity } from '../Models/Logger/types';
+
+const handleCountyRequest = async (request: Request, response: Response, next: NextFunction) => {
+    const currentUser = response.locals.user;
+    const county = parseInt(request.body.county);
+    console.log(county , currentUser);
+    const countyMiddlewareLogger = logger.setup({
+        workflow: 'countyMiddleware',
+        investigation: currentUser.epidemiologynumber,
+    });
+
+    if (currentUser.userType === UserType.SUPER_ADMIN) {
+        const district = await getUserDistrict(county , response.locals);
+
+        if(currentUser.countyByInvestigationGroup.districtId === district) {
+            countyMiddlewareLogger.info(
+                'user is super admin and county is in user district, redirecting',
+                Severity.LOW
+            )
+            return next();
+        }
+        countyMiddlewareLogger.warn(
+            'user is super admin but county is not in user district, returning auth error',
+            Severity.HIGH
+        )
+        return response.sendStatus(unauthorizedStatusCode);
+    } else if (currentUser.userType === UserType.ADMIN) {
+        if (currentUser.investigationGroup === county) {
+            countyMiddlewareLogger.info(
+                'user is admin and county is users, redirecting',
+                Severity.LOW
+            )
+            return next()
+        }
+        countyMiddlewareLogger.warn(
+            'user is admin but county is not users county, returning auth error',
+            Severity.HIGH
+        )
+        return response.sendStatus(unauthorizedStatusCode);
+    } else {
+        countyMiddlewareLogger.info(
+            'user is not admin nor super admin and requested county permitted action, returning auth error',
+            Severity.HIGH
+        );
+        return response.sendStatus(unauthorizedStatusCode);
+    }
+};
+
+const getUserDistrict = async (countyId: number, locals: any) => {
+    const districtByUserLogger = logger.setup({
+        workflow: 'districtByUser',
+        user: locals.user.id,
+    });
+
+    districtByUserLogger.info(launchingDBRequestLog(countyId), Severity.LOW);
+    const userDetails = await graphqlRequest(DISTRICT_BY_COUNTY, locals, { id : countyId })
+        .then((result: any) => {
+            districtByUserLogger.info(validDBResponseLog, Severity.LOW);
+            return result.data.countyById.districtId;
+        })
+        .catch((error) => {
+            districtByUserLogger.error(invalidDBResponseLog(error), Severity.HIGH);
+            return {};
+        });
+    return userDetails;
+};
+
+export default handleCountyRequest;

--- a/server/src/middlewares/HandleCountyRequest.ts
+++ b/server/src/middlewares/HandleCountyRequest.ts
@@ -9,7 +9,7 @@ import { Severity } from '../Models/Logger/types';
 const handleCountyRequest = async (request: Request, response: Response, next: NextFunction) => {
     const currentUser = response.locals.user;
     const county = parseInt(request.body.county);
-    console.log(county , currentUser);
+
     const countyMiddlewareLogger = logger.setup({
         workflow: 'countyMiddleware',
         investigation: currentUser.epidemiologynumber,

--- a/server/src/middlewares/HandleUsersRequest.ts
+++ b/server/src/middlewares/HandleUsersRequest.ts
@@ -1,30 +1,71 @@
 import { NextFunction, Request, Response } from 'express';
 
 import UserType from '../Models/User/UserType';
-import { GET_USER_BY_ID } from '../DBService/Users/Query';
+import { DISTRICT_COUNTY_BY_USER } from '../DBService/Users/Query';
 import logger, { invalidDBResponseLog, launchingDBRequestLog, validDBResponseLog } from '../Logger/Logger';
-import { errorStatusCode, graphqlRequest, unauthorizedStatusCode } from '../GraphqlHTTPRequest';
+import { graphqlRequest, unauthorizedStatusCode } from '../GraphqlHTTPRequest';
+import { Severity } from '../Models/Logger/types';
 
 const handleUsersRequest = async (request: Request, response: Response, next: NextFunction) => {
-    const { user } = response.locals;
-    console.log(user);
-    graphqlRequest(GET_USER_BY_ID, response.locals, {id :String(request.body.userId)})
-            .then((result: any) => {
-                console.log(result.data.userById.countyByInvestigationGroup);
-            })
-    const investigationMiddlewareLogger = logger.setup({
+    const currentUser = response.locals.user;
+    const { userId } = request.body;
+
+    const usersMiddlewareLogger = logger.setup({
         workflow: 'InvestigationMiddleware',
-        investigation: user.epidemiologynumber,
+        investigation: currentUser.epidemiologynumber,
     });
 
-    if(user.userType === UserType.SUPER_ADMIN) {
-        return next();
-    } else if(user.userType === UserType.ADMIN) {
-        return next();
+    const questionedUser = await getUserDistrictCounty(userId, response.locals);
+    console.log(currentUser , questionedUser);
+    if (currentUser.userType === UserType.SUPER_ADMIN) {
+        if (currentUser.countyByInvestigationGroup.districtId === questionedUser.countyByInvestigationGroup.districtId) {
+            usersMiddlewareLogger.info(
+                'requesting user is super admin and questioned user is in user district , redirecting',
+                Severity.LOW
+            );
+            return next();
+        }
+        usersMiddlewareLogger.info(
+            'requesting user is super admin and questioned user is not in user district , returning auth error',
+            Severity.HIGH
+        );
+        return response.sendStatus(unauthorizedStatusCode);
+    } else if (currentUser.userType === UserType.ADMIN) {
+        if (currentUser.investigationGroup === questionedUser.investigationGroup) {
+            usersMiddlewareLogger.info('requesting user is admin and questioned user is in user group, redirecting', Severity.HIGH);
+            return next();
+        }
+        usersMiddlewareLogger.info(
+            'requesting user is admin and questioned user is not in user group, returning auth error',
+            Severity.HIGH
+        );
+        return response.sendStatus(unauthorizedStatusCode);
     } else {
-        return response.sendStatus(401);
+        usersMiddlewareLogger.info(
+            'user is not admin nor super admin and requested user permitted action, returning auth error',
+            Severity.HIGH
+        );
+        return response.sendStatus(unauthorizedStatusCode);
     }
+};
 
+const getUserDistrictCounty = async (id: number, locals: any) => {
+    const districtByUserLogger = logger.setup({
+        workflow: 'districtByUser',
+        user: locals.user.id,
+    });
+
+    districtByUserLogger.info(launchingDBRequestLog(id), Severity.LOW);
+    const userDetails = await graphqlRequest(DISTRICT_COUNTY_BY_USER, locals, { id })
+        .then((result: any) => {
+            districtByUserLogger.info(validDBResponseLog, Severity.LOW);
+            return result.data.userById;
+        })
+        .catch((error) => {
+            districtByUserLogger.error(invalidDBResponseLog(error), Severity.HIGH);
+            return {};
+        });
+    return userDetails;
 };
 
 export default handleUsersRequest;

--- a/server/src/middlewares/HandleUsersRequest.ts
+++ b/server/src/middlewares/HandleUsersRequest.ts
@@ -1,0 +1,30 @@
+import { NextFunction, Request, Response } from 'express';
+
+import UserType from '../Models/User/UserType';
+import { GET_USER_BY_ID } from '../DBService/Users/Query';
+import logger, { invalidDBResponseLog, launchingDBRequestLog, validDBResponseLog } from '../Logger/Logger';
+import { errorStatusCode, graphqlRequest, unauthorizedStatusCode } from '../GraphqlHTTPRequest';
+
+const handleUsersRequest = async (request: Request, response: Response, next: NextFunction) => {
+    const { user } = response.locals;
+    console.log(user);
+    graphqlRequest(GET_USER_BY_ID, response.locals, {id :String(request.body.userId)})
+            .then((result: any) => {
+                console.log(result.data.userById.countyByInvestigationGroup);
+            })
+    const investigationMiddlewareLogger = logger.setup({
+        workflow: 'InvestigationMiddleware',
+        investigation: user.epidemiologynumber,
+    });
+
+    if(user.userType === UserType.SUPER_ADMIN) {
+        return next();
+    } else if(user.userType === UserType.ADMIN) {
+        return next();
+    } else {
+        return response.sendStatus(401);
+    }
+
+};
+
+export default handleUsersRequest;

--- a/server/src/middlewares/HandleUsersRequest.ts
+++ b/server/src/middlewares/HandleUsersRequest.ts
@@ -16,7 +16,6 @@ const handleUsersRequest = async (request: Request, response: Response, next: Ne
     });
 
     const questionedUser = await getUserDistrictCounty(userId, response.locals);
-    console.log(currentUser , questionedUser);
     if (currentUser.userType === UserType.SUPER_ADMIN) {
         if (currentUser.countyByInvestigationGroup.districtId === questionedUser.countyByInvestigationGroup.districtId) {
             usersMiddlewareLogger.info(

--- a/server/src/middlewares/HandleUsersRequest.ts
+++ b/server/src/middlewares/HandleUsersRequest.ts
@@ -24,23 +24,23 @@ const handleUsersRequest = async (request: Request, response: Response, next: Ne
             );
             return next();
         }
-        usersMiddlewareLogger.info(
+        usersMiddlewareLogger.warn(
             'requesting user is super admin and questioned user is not in user district , returning auth error',
             Severity.HIGH
         );
         return response.sendStatus(unauthorizedStatusCode);
     } else if (currentUser.userType === UserType.ADMIN) {
         if (currentUser.investigationGroup === questionedUser.investigationGroup) {
-            usersMiddlewareLogger.info('requesting user is admin and questioned user is in user group, redirecting', Severity.HIGH);
+            usersMiddlewareLogger.info('requesting user is admin and questioned user is in user group, redirecting', Severity.LOW);
             return next();
         }
-        usersMiddlewareLogger.info(
+        usersMiddlewareLogger.warn(
             'requesting user is admin and questioned user is not in user group, returning auth error',
             Severity.HIGH
         );
         return response.sendStatus(unauthorizedStatusCode);
     } else {
-        usersMiddlewareLogger.info(
+        usersMiddlewareLogger.warn(
             'user is not admin nor super admin and requested user permitted action, returning auth error',
             Severity.HIGH
         );

--- a/server/src/middlewares/HandleUsersRequest.ts
+++ b/server/src/middlewares/HandleUsersRequest.ts
@@ -1,13 +1,14 @@
 import { NextFunction, Request, Response } from 'express';
 
 import UserType from '../Models/User/UserType';
-import { DISTRICT_COUNTY_BY_USER } from '../DBService/Users/Query';
-import logger, { invalidDBResponseLog, launchingDBRequestLog, validDBResponseLog } from '../Logger/Logger';
-import { graphqlRequest, unauthorizedStatusCode } from '../GraphqlHTTPRequest';
 import { Severity } from '../Models/Logger/types';
+import { DISTRICT_COUNTY_BY_USER } from '../DBService/Users/Query';
+import { graphqlRequest, unauthorizedStatusCode } from '../GraphqlHTTPRequest';
+import logger, { invalidDBResponseLog, launchingDBRequestLog, validDBResponseLog } from '../Logger/Logger';
 
 const handleUsersRequest = async (request: Request, response: Response, next: NextFunction) => {
     const currentUser = response.locals.user;
+    const { userType } = currentUser;
     const { userId } = request.body;
 
     const usersMiddlewareLogger = logger.setup({
@@ -16,7 +17,7 @@ const handleUsersRequest = async (request: Request, response: Response, next: Ne
     });
 
     const questionedUser = await getUserDistrictCounty(userId, response.locals);
-    if (currentUser.userType === UserType.SUPER_ADMIN) {
+    if (userType === UserType.SUPER_ADMIN) {
         if (currentUser.countyByInvestigationGroup.districtId === questionedUser.countyByInvestigationGroup.districtId) {
             usersMiddlewareLogger.info(
                 'requesting user is super admin and questioned user is in user district , redirecting',
@@ -29,7 +30,7 @@ const handleUsersRequest = async (request: Request, response: Response, next: Ne
             Severity.HIGH
         );
         return response.sendStatus(unauthorizedStatusCode);
-    } else if (currentUser.userType === UserType.ADMIN) {
+    } else if (userType === UserType.ADMIN) {
         if (currentUser.investigationGroup === questionedUser.investigationGroup) {
             usersMiddlewareLogger.info('requesting user is admin and questioned user is in user group, redirecting', Severity.LOW);
             return next();


### PR DESCRIPTION
Added 2 new middlewares 

### Users middleware
handles any request regarding users ( where a user preforms the action on another user ) using the following logic : 
if the user is a super-admin: allow the request if the requested user is in the asking user's district
if the user is an admin: allow the request if the requested user is in the asking user's county
if the user is a normal investigator:  deny the request

### counties middleware
handles requests regarding counties (see counties users/investigations) using the following logic : 
if the user is a super-admin: allow the request if the county is in the asking user's district
if the user is an admin: allow the request if the county is the asking user's county
if the user is a normal investigator: deny the request

added an alert for errored requests in adminLandingPage