### PR TITLE
fix(tooltip-grouped-investigation-message)

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableFooter/InvestigationTableFooter.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableFooter/InvestigationTableFooter.tsx
@@ -114,7 +114,9 @@ const InvestigationTableFooter: React.FC<Props> = React.forwardRef((props: Props
             icon: CollectionsBookmark,
             displayTitle: 'קיבוץ חקירות',
             disabled: shouldGroupActionDisabled,
-            errorMessage: shouldGroupActionDisabled ? 'שים לב לא ניתן לקבץ חקירה שכבר מקובצת' : '',
+            errorMessage: shouldGroupActionDisabled ? 
+                checkedInvestigations.length > 1 ? 'שים לב לא ניתן לקבץ חקירה שכבר מקובצת' : 'חקירה לא מקובצת'
+                : '',
             onClick: handleOpenGroupedInvestigations
         },
         {


### PR DESCRIPTION
Fix to Bug: [1491](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1491)
Added ternary operator to control tooltip message according to the investigation/s selected.