### PR TITLE
added family filtering depending on grouping reason

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/ContactsForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/ContactsForm.tsx
@@ -9,7 +9,7 @@ import InvestigationAccordion from './InvestigationAccordion/InvestigationAccord
 const formHeadline = 'מאומתים המקובצים לחקירה :';
 
 const ContactsForm = (props: Props) => {
-    const { investigations , reason } = props;
+    const { investigations, reason, isGroupReasonFamily} = props;
     const { groupedInvestigationContacts } = useContext(groupedInvestigationsContext);
     return (
         <>
@@ -20,6 +20,7 @@ const ContactsForm = (props: Props) => {
                     return (
                         <InvestigationAccordion
                             key={index}
+                            isGroupReasonFamily={isGroupReasonFamily}
                             investigation={investigation}
                         />
                     )
@@ -32,6 +33,7 @@ const ContactsForm = (props: Props) => {
 
 interface Props {
     reason : string;
+    isGroupReasonFamily: boolean;
     investigations : ConnectedInvestigation[];
 }
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/AccordionContent.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/AccordionContent.tsx
@@ -9,7 +9,7 @@ import TableSearchBar from './TableSearchBar/TableSearchBar';
 import SelectedRowsMessage from './SelectedRowsMessage/SelectedRowsMessage';
 
 const AccordionContent = (props: Props) => {
-    const { events } = props;
+    const { events, isGroupReasonFamily} = props;
     const [query, setQuery] = useState<string>("");
     const { getCurrentSelectedRowsLength , existingIds , filteredEvents } = useAccordionContent({events , query});   
 
@@ -25,6 +25,7 @@ const AccordionContent = (props: Props) => {
                 </Grid>
                 <Grid xs={12}>
                     <ContactsTable
+                        isGroupReasonFamily={isGroupReasonFamily}
                         events={filteredEvents}
                         existingIds={existingIds}
                     />
@@ -40,6 +41,7 @@ const AccordionContent = (props: Props) => {
 }
 
 interface Props {
+    isGroupReasonFamily: boolean;
     events : ContactEvent[];
 }
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/ContactsTable.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/ContactsTable.tsx
@@ -10,7 +10,7 @@ import ErrorMessage from '../../../../../ErrorMessage/ErrorMessage';
 const noResultsMessage = 'אין תוצאות מתאימות';
 
 const ContactsTable = (props: Props) => {
-    const { events, existingIds} = props;
+    const { events, existingIds, isGroupReasonFamily} = props;
 
     return (
         <>
@@ -19,6 +19,7 @@ const ContactsTable = (props: Props) => {
             ? <Table>
                 <TableHeader />
                 <TableRows 
+                    isGroupReasonFamily={isGroupReasonFamily}
                     existingIds={existingIds}
                     events={events}
                 />
@@ -32,6 +33,7 @@ const ContactsTable = (props: Props) => {
 }
 
 interface Props {
+    isGroupReasonFamily: boolean;
     events : ContactNode[];
     existingIds: string[];
 }

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/TableRows/TableRows.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/ContactsTable/TableRows/TableRows.tsx
@@ -10,7 +10,7 @@ import useStyles from './tableRowsStyles';
 import useTableRows from './useTableRows';
 
 const TableRows = (props: Props) => {
-    const { events , existingIds } = props;
+    const { events , existingIds, isGroupReasonFamily } = props;
     const groupedInvestigationsContextState = useContext(groupedInvestigationsContext);
     const classes = useStyles();
     const { isInvolvedThroughFamily } = useInvolvedContact();
@@ -21,7 +21,7 @@ const TableRows = (props: Props) => {
             {
                 events.map((person) => {
                         const {involvedContactByInvolvedContactId} = person;
-                        const isFamily = involvedContactByInvolvedContactId && isInvolvedThroughFamily(involvedContactByInvolvedContactId.involvementReason);
+                        const isFamily = involvedContactByInvolvedContactId && isGroupReasonFamily &&  isInvolvedThroughFamily(involvedContactByInvolvedContactId.involvementReason);
                         
                         if(!isFamily) {
                             const {id} = person;
@@ -73,6 +73,7 @@ const TableRows = (props: Props) => {
 }
 
 interface Props {
+    isGroupReasonFamily: boolean;
     events : ContactNode[];
     existingIds: string[];
 }

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/InvestigationAccordion.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/InvestigationAccordion.tsx
@@ -8,7 +8,7 @@ import AccordionContent from './AccordionContent/AccordionContent';
 import AccordionHeadline from './AccordionHeadline/AccordionHeadline';
 
 const InvestigationAccordion = (props: Props) => {
-    const { investigation } = props;
+    const { investigation, isGroupReasonFamily} = props;
     const { epidemiologyNumber , contactEventsByInvestigationId , investigatedPatientByInvestigatedPatientId } = investigation;
     const { fullName , identityNumber } = investigatedPatientByInvestigatedPatientId.covidPatientByCovidPatient;
 
@@ -22,6 +22,7 @@ const InvestigationAccordion = (props: Props) => {
                 identityNumber={identityNumber}
             />
             <AccordionContent 
+                isGroupReasonFamily={isGroupReasonFamily}
                 events={contactEventsByInvestigationId.nodes}
             />
         </Accordion>
@@ -29,6 +30,7 @@ const InvestigationAccordion = (props: Props) => {
 }
 
 interface Props {
+    isGroupReasonFamily: boolean;
     investigation: ConnectedInvestigation;
 }
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/GroupedInvestigationForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/GroupedInvestigationForm.tsx
@@ -8,9 +8,11 @@ import ContactsForm from './ContactsForm/ContactsForm';
 import ErrorMessage from '../ErrorMessage/ErrorMessage';
 
 const noContactsText = 'אין מגעים לחקירות המשותפות';
+const familyReasonId = 100000000;
 
 const GroupedInvestigationForm = () => {
-    const investigations = useSelector<StoreStateType , ConnectedInvestigationContact>(state => state.groupedInvestigations.investigations)
+    const investigations = useSelector<StoreStateType , ConnectedInvestigationContact>(state => state.groupedInvestigations.investigations);
+    const isGroupReasonFamily = investigations.investigationGroupReasonByReason.id === familyReasonId;
     const nodes = investigations.investigationsByGroupId.nodes;
 
     return (
@@ -20,7 +22,8 @@ const GroupedInvestigationForm = () => {
               />
             : <ContactsForm 
                 investigations={nodes}
-                reason={investigations.otherReason||investigations.investigationGroupReasonByReason.displayName}            />
+                isGroupReasonFamily={isGroupReasonFamily}
+                reason={investigations.otherReason||investigations.investigationGroupReasonByReason.displayName} />
     )
 }
 

--- a/client/src/components/App/Content/InvestigationForm/useGroupedInvestigationContacts.ts
+++ b/client/src/components/App/Content/InvestigationForm/useGroupedInvestigationContacts.ts
@@ -35,6 +35,7 @@ const useGroupedInvestigationContacts = () => {
                 connectedInvestigationsByGroupIdLogger.error(`got errors in server result: ${error}`,Severity.HIGH);
                 return {
                     investigationGroupReasonByReason: {
+                        id: -1,
                         displayName : 'חלה שגיאה בשליפת הנתונים מהשרת'
                     },
                     investigationsByGroupId: {

--- a/client/src/models/GroupedInvestigationContacts/ConnectedInvestigationContact.ts
+++ b/client/src/models/GroupedInvestigationContacts/ConnectedInvestigationContact.ts
@@ -3,6 +3,7 @@ import ConnectedInvestigation from './ConnectedInvestigation';
 type ConnectedInvestigationContact = {
     otherReason?: string;
     investigationGroupReasonByReason: {
+        id: number;
         displayName : string;
     }
     investigationsByGroupId: {

--- a/client/src/redux/GroupedInvestigations/GroupedInvestigationsType.ts
+++ b/client/src/redux/GroupedInvestigations/GroupedInvestigationsType.ts
@@ -9,6 +9,7 @@ export const initialState : GroupedInvestigationReducerType ={
     groupId : '',
     investigations : {
         investigationGroupReasonByReason: {
+            id: -1,
             displayName : 'טוען...'
         },
         investigationsByGroupId: {

--- a/server/src/DBService/ContactEvent/Query.ts
+++ b/server/src/DBService/ContactEvent/Query.ts
@@ -146,6 +146,7 @@ query contactsByGroupId($groupId: UUID!, $epidemiologynumber: Int!) {
   investigationGroupById(id: $groupId) {
     otherReason
     investigationGroupReasonByReason {
+      id
       displayName
     }
     investigationsByGroupId(filter: {epidemiologyNumber: {notEqualTo: $epidemiologynumber}}) {
@@ -201,7 +202,6 @@ export const CONTACTS_BY_CONTACTS_IDS = gql`
           occupation
           lastUpdateTime
           isolationAddress
-          involvedContactId
           extraInfo
           doesWorkWithCrowd
           familyRelationship


### PR DESCRIPTION
by user story : [1445](https://dev.azure.com/spectrumFactory/CoronaI/_sprints/backlog/CoronaI%20Team/CoronaI/Sprint%2014?workitem=1445) added filtering of family contacts only in case that the grouping reason is family members.

the reason I've added the isGroupReasonFamily at the form level is the same reason I've added the investigations - I wanted the logic (from redux) to only be applied once at the root instead of every time in the branch level  