### PR TITLE
moved minheight to px

### DIFF
--- a/client/src/commons/Forms/AddressForm/AddressFormStyles.ts
+++ b/client/src/commons/Forms/AddressForm/AddressFormStyles.ts
@@ -2,10 +2,7 @@ import { makeStyles } from '@material-ui/core';
 
 const useStyles = makeStyles({
     heightendTextField: {
-        minHeight: '3vh',
-        '@media screen and (max-height: 950px)': {
-            minHeight: '5.9vh'
-        }
+        minHeight: '42px',
     },
     fullHeight: {
         height: '100%',


### PR DESCRIPTION
fixes [1461](https://dev.azure.com/spectrumFactory/CoronaI/_sprints/backlog/CoronaI%20Team/CoronaI/Sprint%2014?workitem=1461), reason was that Material-UI's fields were getting their heights from px padding and height attributes - so to perfectly match them on empty fields I had to use static px size.