### PR TITLE
fix(exposure-source-detail-dont-delete)

### DIFF
--- a/client/src/Utils/ControllerHooks/useExposuresSaving.ts
+++ b/client/src/Utils/ControllerHooks/useExposuresSaving.ts
@@ -110,6 +110,11 @@ const useExposuresSaving = () => {
                 [fieldsNames.airline]: '',
                 [fieldsNames.flightNumber]: ''
             }
+        } else {
+            exposureAndDataToReturn = {
+                ...exposureAndDataToReturn,
+                exposureSource: exposuresAndFlightsData.exposureSource ||  null
+            }
         }
         return (exposureAndDataToReturn as DBExposure);
     }

--- a/client/src/commons/Contexts/ExposuresAndFlights.ts
+++ b/client/src/commons/Contexts/ExposuresAndFlights.ts
@@ -12,7 +12,7 @@ export type ExposureAndFlightsDetails = {
     wereFlights: boolean,
     wasInEilat: boolean,
     wasInDeadSea: boolean,
-}
+};
 
 export interface ExposureAndFlightsDetailsAndSet {
     exposureAndFlightsData: ExposureAndFlightsDetails,

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/Forms/ExposureForm/ExposureForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/Forms/ExposureForm/ExposureForm.tsx
@@ -90,6 +90,7 @@ const ExposureForm = (props: Props) => {
 											setExposureSourceSearchString(value);
 											(!value || !value.includes(':')) &&
 												handleChangeExposureDataAndFlightsField(index, fieldsNames.exposureSource, null);
+												props.onChange(null)
 										}}
 										value={exposureSourceSearchString}
 										test-id='exposureSource'

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/Forms/ExposureForm/ExposureForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ExposuresAndFlights/Forms/ExposureForm/ExposureForm.tsx
@@ -24,7 +24,7 @@ const ExposureForm = (props: Props) => {
 
 	const classes = useStyles();
 	const formClasses = useFormStyles();
-	const { control, setValue, errors } = useFormContext();
+	const { control, setValue, errors, trigger } = useFormContext();
 
 	const [exposureSourceSearchString, setExposureSourceSearchString] = useState<string>('');
 	const [isOptionalPatientsLoading, setOptionalPatientsLoading] = useState<boolean>(false);
@@ -137,6 +137,7 @@ const ExposureForm = (props: Props) => {
 													setValue(`exposures[${index}].${fieldsNames.exposureSource}`, exposureSource);
 													setOptionalCovidPatients([]);
 													handleChangeExposureDataAndFlightsField(index, fieldsNames.exposureSource, exposureSource);
+													trigger(`exposures[${index}].${fieldsNames.exposureSource}`)
 												}}
 											>
 												<ExposureSourceOption


### PR DESCRIPTION
Fix to bug: [1453](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1453)
When saved the source was taken from the form data, and when source was deleted there wasn't a call to save the null value in the form data.