### PR TITLE
removed setloading(false) on success of deleteIrrelevantContactEvents

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/useClinicalDetails.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/useClinicalDetails.ts
@@ -198,7 +198,6 @@ const useClinicalDetails = (parameters: useClinicalDetailsIncome): useClinicalDe
                 deleteIrrelevantEventsLogger.error(`Failed to delete irrelevant contact events: ${err}`, Severity.LOW);
                 alertError(deletingContactEventsErrorMsg);
                 setDidDeletingContactEventsSucceed(false);
-            }).finally(() => {
                 setIsLoading(false);
             })
         }


### PR DESCRIPTION
fixes [1490](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1490/)

problem was that isLoading was set to false on deleteIrrelevantContacts success and then immediately set to true in saveClinicalDetailsToDB.
something about the speed of the action probably caused the page to not show the loading sign the second time

made isLoading(false) only occur on failure (the function doesn't have any other uses)