### PR TITLE
moved loading of groupedinv order to sync

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -368,7 +368,6 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                 const indexedRow = convertToIndexedRow(row);
                                 const isRowClickable = isInvestigationRowClickable(row.mainStatus);
                                 const isGroupShown = checkGroupedInvestigationOpen.includes(indexedRow.epidemiologyNumber);
-                                
                                 return (
                                     <>
                                         <InvestigationTableRow
@@ -415,8 +414,6 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                                 const currentGroupedInvestigationsLength = allGroupedInvestigations.get(indexedRow.groupId)?.length! - 1; // not including row head
                                                 const indexedGroupedInvestigationRow = convertToIndexedRow(row);
                                                 const isGroupedRowClickable = isInvestigationRowClickable(row.mainStatus);
-
-                                                console.log(row.investigationDesk);
                                                 return (
                                                     <InvestigationTableRow
                                                         columns={(user.userType === userType.ADMIN || user.userType === userType.SUPER_ADMIN) ? adminCols : userCols}

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -235,10 +235,6 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                     groupId ?
                         await changeGroupsDesk([groupId], newSelectedDesk) :
                         await changeInvestigationsDesk([epidemiologyNumber], newSelectedDesk);
-                    fetchTableData();
-                    if(groupId){
-                        fetchInvestigationsByGroupId(groupId);
-                    }
                 }
 
                 setSelectedRow(DEFAULT_SELECTED_ROW);
@@ -372,7 +368,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                 const indexedRow = convertToIndexedRow(row);
                                 const isRowClickable = isInvestigationRowClickable(row.mainStatus);
                                 const isGroupShown = checkGroupedInvestigationOpen.includes(indexedRow.epidemiologyNumber);
-
+                                
                                 return (
                                     <>
                                         <InvestigationTableRow
@@ -419,6 +415,8 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                                                 const currentGroupedInvestigationsLength = allGroupedInvestigations.get(indexedRow.groupId)?.length! - 1; // not including row head
                                                 const indexedGroupedInvestigationRow = convertToIndexedRow(row);
                                                 const isGroupedRowClickable = isInvestigationRowClickable(row.mainStatus);
+
+                                                console.log(row.investigationDesk);
                                                 return (
                                                     <InvestigationTableRow
                                                         columns={(user.userType === userType.ADMIN || user.userType === userType.SUPER_ADMIN) ? adminCols : userCols}

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -725,10 +725,19 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             });
             changeDeskLogger.info(logGroupTransfer(groupIds, TableHeadersNames.investigationDesk, newSelectedDesk?.deskName || '', transferReason), Severity.LOW);
             setSelectedRow(DEFAULT_SELECTED_ROW);
-            fetchTableData();
         } catch (error) {
             changeDeskLogger.error(`couldn't change the desk for group ${joinedGroupIds} due to ${error}`, Severity.HIGH);
             alertError(UPDATE_ERROR_TITLE);
+        } finally {
+            if (groupIds[0]) {
+                await Promise.all(
+                    groupIds.map(async (groupId: string) => {
+                        await fetchInvestigationsByGroupId(groupId);
+                    })
+                );
+            }
+
+            fetchTableData();
         }
     };
 
@@ -930,7 +939,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             investigationsByGroupIdLogger.error(err, Severity.HIGH);
             return [];
         } finally {
-            setIsLoading(false)
+            setIsLoading(false);
         }
     }
 


### PR DESCRIPTION
fixes [1484](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1484/)

#1272 solved half of the problem - what was happening is that when the investigation was being transferred `fetchTableData()` and `fetchInvestigationsByGroupId()` were running in parallel - both using global 'isLoading' - meaning that if both started at the same time - the one that was the quickest would have caused the loading to stop (even though the other one was still on-going)

so I changed the order of those actions to sync - first of all  `fetchInvestigationsByGroupId` runs in parallel on all of the group ids and when its done `fetchTableData` is run.

this also solved the problem of changing multiple grouped investigations loading (by the footer).