### PR TITLE
Feat(add-authority-display-name-investigators-table)

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigatorAllocation/InvestigatorsTable/InvestigatorsTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigatorAllocation/InvestigatorsTable/InvestigatorsTable.tsx
@@ -11,6 +11,7 @@ import { TableHeadersNames, TableHeaders } from './InvestigatorsTableHeaders';
 
 const pauseInvestigationsCountTitle = 'חקירות הממתינות להשלמת מידע/העברה';
 const searchBarLabel = 'הכנס שם של חוקר...';
+const authoritySourceOrganization = 'חוקר רשות';
 
 const InvestigatorsTable: React.FC<Props> = ({ investigators, selectedRow, setSelectedRow }) => {
 
@@ -36,6 +37,10 @@ const InvestigatorsTable: React.FC<Props> = ({ investigators, selectedRow, setSe
         switch(cellName) {
             case TableHeadersNames.deskName: 
                 return get(investigator, cellName) ? get(investigator, cellName) : 'לא משוייך';
+            case TableHeadersNames.sourceOrganization: 
+                const sourceOrganization: string = get(investigator, cellName);
+                const authorityName: string | null = investigator.authorityName;
+                return (sourceOrganization === authoritySourceOrganization && authorityName) ? `${get(investigator, cellName)}-${authorityName}` : get(investigator, cellName);
             case TableHeadersNames.languages: {
                  const languages: string[] = get(investigator, cellName);
                  if (languages?.length > 2) {

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -406,6 +406,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
                     countyUsers.set(user.id, {
                         ...user,
                         userName: user.username,
+                        authorityName: user.authorityname,
                         newInvestigationsCount: user.newinvestigationscount,
                         activeInvestigationsCount: user.activeinvestigationscount,
                         pauseInvestigationsCount: user.pauseinvestigationscount

--- a/client/src/models/User.ts
+++ b/client/src/models/User.ts
@@ -16,6 +16,7 @@ interface User {
     userType: UserType;
     sourceOrganization: string;
     deskName: string;
+    authorityName: string;
     countyByInvestigationGroup: CountyByInvestigationGroup;
     deskByDeskId?: Desk;
     authorityByAuthorityId?: authorityByAuthorityId;
@@ -28,6 +29,6 @@ interface CountyByInvestigationGroup {
 
 interface authorityByAuthorityId {
     authorityName: string
-}
+};
 
 export default User;

--- a/client/src/redux/User/userReducer.ts
+++ b/client/src/redux/User/userReducer.ts
@@ -7,7 +7,7 @@ export interface UserState {
     data: User;
     isLoggedIn: boolean;
     displayedCounty: number;
-}
+};
 
 export const initialUserState: UserState = {
     data: {
@@ -24,6 +24,7 @@ export const initialUserState: UserState = {
         userType: UserType.NOT_LOGGED_IN,
         sourceOrganization: '',
         deskName: '',
+        authorityName: '',
         countyByInvestigationGroup: {
             districtId: -1,
             displayName: ''
@@ -34,7 +35,7 @@ export const initialUserState: UserState = {
     },
     isLoggedIn: false,
     displayedCounty: -1
-}
+};
 
 const userReducer = (state = initialUserState, action: Actions.UserAction): UserState => {
     switch (action.type) {
@@ -54,6 +55,6 @@ const userReducer = (state = initialUserState, action: Actions.UserAction): User
         };
         default: return state;
     }
-}
+};
 
 export default userReducer;

--- a/server/src/Models/User/User.ts
+++ b/server/src/Models/User/User.ts
@@ -18,4 +18,5 @@ export default interface User {
     newInvestigationsCount: number;
     activeInvestigationsCount: number;
     authority: number;
-}
+    authorityName: string;
+};


### PR DESCRIPTION
This PR implements feature: [1502](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1502/)

Major changes:
* changed DB function get_investigator_list_by_county_function to return the new information about user authority.
* changed the text on the source organization to include authorityName.

view:
![image](https://user-images.githubusercontent.com/55889135/106865111-6a26ea80-66d3-11eb-92e7-5c90b80659ce.png)
