### PR TITLE
added duplicate id check for form values

### DIFF
--- a/client/src/Utils/GroupedInvestigationsContacts/getGroupedInvestigationIds.ts
+++ b/client/src/Utils/GroupedInvestigationsContacts/getGroupedInvestigationIds.ts
@@ -24,8 +24,34 @@ const GetGroupedInvestigationsIds = () => {
         return id && groupedInvestigationsIds.indexOf(id) !== -1;
     }
 
+    const connectedContactsMap = () => {
+        let ids = new Map();
+        investigations.forEach(investigation => 
+            investigation.contactEventsByInvestigationId.nodes.forEach(event => 
+                event.contactedPeopleByContactEvent.nodes.forEach(person => {
+                    const {identificationType, identificationNumber} = person.personByPersonInfo;
+                    if(identificationType && identificationNumber) {
+                        ids.set(person.id ,identificationType + identificationNumber);
+                    }
+                }
+            )
+        ));
+
+        return ids;
+    }
+
+    const connectedInvestigationsIds = (contactsIds : number[]) => {
+        const connectedMap = connectedContactsMap();
+        let ids: string[] = [];
+        contactsIds.forEach(contactId => 
+            ids.push(connectedMap.get(contactId))    
+        )
+        return ids;
+    }
+
     return {
-        isGroupedContact
+        isGroupedContact,
+        connectedInvestigationsIds
     }
 
 }


### PR DESCRIPTION
fixes [1506](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1506/)
the bug says that a user inserted 2 identical ids for the same event - after checking with @MagusM It looks like this was done on purpose as the log are looking reasonable (timestamp is normal - no close api calls)
## the problem
the problem was that when the form was created it was possible to insert 2 identical IDs ( because the duplicate ID check was referring to the investigation's _existing_ ids)
with the addition of grouped investigations contacts this was becoming more of an issue ( as they could choose one grouped id and also add it manualy)

## the solution
added a check in the form's state before sending - if the form/the connectedInvestigationForm already exists - alert the user and prevent him from sending the form