### PR TITLE
fix/static investigation info - missing fields

### DIFF
--- a/server/src/ClientToDBAPI/InvestigationInfo/mainRoute.ts
+++ b/server/src/ClientToDBAPI/InvestigationInfo/mainRoute.ts
@@ -29,9 +29,11 @@ const convertInvestigationInfoFromDB = (investigationInfo: any) => {
     const investigationPatient = investigationInfo.investigatedPatientByInvestigatedPatientId;
 
     const convertedCovidPatient = {
+        ...investigationPatient,
         ...investigationPatient.covidPatientByCovidPatient,
         age: getPatientAge(investigationPatient.covidPatientByCovidPatient.birthDate)
     }
+    delete convertedCovidPatient.covidPatientByCovidPatient;
 
     const convertedInvestigation = {
         ...investigationInfo,


### PR DESCRIPTION
fixes [1507](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1507/)
# the issue
the issue stemmed from  #1222 , in mainRoute the function missed all of the fields marked in red here :
![image](https://user-images.githubusercontent.com/68457306/107141874-3991bb80-6934-11eb-923c-1027d4ba0c76.png)
because it only used spread `investigationPatient.covidPatientByCovidPatient`
# the solution
added those fields back and removed `convertedCovidPatient.covidPatientByCovidPatient`
