### PR TITLE
Fix(symptoms-start-date-value)

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/SymptomsFields/SymptomsFields.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/SymptomsFields/SymptomsFields.tsx
@@ -99,7 +99,7 @@ const SymptomsFields: React.FC<Props> = (props: Props): JSX.Element => {
                                                 onChange={(newDate: Date) => {
                                                     if (newDate !== null) {
                                                         handleDidSymptomsDateChangeOccur();
-                                                        props.onChange(newDate)
+                                                        props.onChange(new Date(newDate.toDateString()));
                                                     }
                                                 }}
                                                 error={errors[ClinicalDetailsFields.SYMPTOMS_START_DATE] ? true : false}


### PR DESCRIPTION
Fix Bug: [1503](https://dev.azure.com/spectrumFactory/CoronaI/_sprints/backlog/CoronaI%20Team/CoronaI/Sprint%2014?workitem=1503)

##### The problem:
The symptoms start date was sent with time and not only date. And the calculation of datesToInvestigate wasn't right what caused the bug.

##### The solution:
Changed the symptoms start date to save without specific hour.
