### PR TITLE
Fix/duplicate ids connected contacts

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/ContactsForm.test.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/ContactsForm.test.tsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 
 import MockFormProvider from 'Utils/Testing/MockFormProvider';
 import mockSelectors from 'Utils/Testing/GroupedInvestigationForm/mockSelectors';
-import { testInvestigationsNodes } from 'Utils/Testing/GroupedInvestigationForm/state'; 
+import { testInvestigationsNodes, otherContactReason, testInvestigations} from 'Utils/Testing/GroupedInvestigationForm/state';
 
 import ContactsForm from './ContactsForm';
 import InvestigationAccordion from './InvestigationAccordion/InvestigationAccordion';
@@ -17,7 +17,10 @@ const formProps = {
 }
 
 describe('<ContactsForm />', () => {
-    mockSelectors();
+    mockSelectors({
+        ...otherContactReason,
+        ...testInvestigations
+    });
     const wrapper = mount(
         <MockFormProvider>
             <ContactsForm 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/AccordionContent.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/AccordionContent/AccordionContent.tsx
@@ -9,8 +9,8 @@ import TableSearchBar from './TableSearchBar/TableSearchBar';
 import SelectedRowsMessage from './SelectedRowsMessage/SelectedRowsMessage';
 
 const AccordionContent = (props: Props) => {
-    const { events, isGroupReasonFamily} = props;
-    const [query, setQuery] = useState<string>("");
+    const { events, isGroupReasonFamily, duplicateIds } = props;
+    const [query, setQuery] = useState<string>('');
     const { getCurrentSelectedRowsLength , existingIds , filteredEvents } = useAccordionContent({events , query});   
 
     return (
@@ -28,7 +28,7 @@ const AccordionContent = (props: Props) => {
                     <ContactsTable
                         isGroupReasonFamily={isGroupReasonFamily}
                         events={filteredEvents}
-                        existingIds={existingIds}
+                        existingIds={existingIds.concat(duplicateIds)}
                     />
                 </Grid>
                 <Grid item xs={12}>
@@ -44,6 +44,7 @@ const AccordionContent = (props: Props) => {
 interface Props {
     isGroupReasonFamily: boolean;
     events : ContactEvent[];
+    duplicateIds: string[];
 }
 
 export default AccordionContent;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/InvestigationAccordion.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/InvestigationAccordion.tsx
@@ -4,6 +4,7 @@ import { Accordion } from '@material-ui/core';
 import ConnectedInvestigation from 'models/GroupedInvestigationContacts/ConnectedInvestigation';
 
 import useStyles from './accordionStyles';
+import UseDuplicateConnectedIds from './UseDuplicateConnectedIds';
 import AccordionContent from './AccordionContent/AccordionContent';
 import AccordionHeadline from './AccordionHeadline/AccordionHeadline';
 
@@ -11,6 +12,8 @@ const InvestigationAccordion = (props: Props) => {
     const { investigation, isGroupReasonFamily} = props;
     const { epidemiologyNumber , contactEventsByInvestigationId , investigatedPatientByInvestigatedPatientId } = investigation;
     const { fullName , identityNumber } = investigatedPatientByInvestigatedPatientId.covidPatientByCovidPatient;
+
+    const duplicateIds = UseDuplicateConnectedIds(epidemiologyNumber);
 
     const classes = useStyles();
 
@@ -24,6 +27,7 @@ const InvestigationAccordion = (props: Props) => {
             <AccordionContent 
                 isGroupReasonFamily={isGroupReasonFamily}
                 events={contactEventsByInvestigationId.nodes}
+                duplicateIds={duplicateIds}
             />
         </Accordion>
     )

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/UseDuplicateConnectedIds.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/UseDuplicateConnectedIds.ts
@@ -1,0 +1,28 @@
+import React from 'react'
+import { useSelector } from 'react-redux';
+
+import StoreStateType from 'redux/storeStateType';
+import ConnectedInvestigation from 'models/GroupedInvestigationContacts/ConnectedInvestigation';
+
+const UseDuplicateConnectedIds = (epiNumber : number) => {
+    const investigations = useSelector<StoreStateType , ConnectedInvestigation[]>(state => state.groupedInvestigations.investigations.investigationsByGroupId.nodes);
+
+    const indexOfCurrentInvestigation = investigations.map(investigation => investigation.epidemiologyNumber).indexOf(epiNumber);
+    const investigationsToSearch = investigations.slice(0 , indexOfCurrentInvestigation);
+    let connectedInvestigationsIds : string[] = []
+    investigationsToSearch.forEach(investigation => {
+        investigation.contactEventsByInvestigationId.nodes.forEach(event => {
+            event.contactedPeopleByContactEvent.nodes.forEach(person => {
+                const {identificationNumber , identificationType} = person.personByPersonInfo;
+            
+                if(Boolean(identificationNumber) && Boolean(identificationType)) {
+                    connectedInvestigationsIds.push(identificationNumber);
+                }
+            });
+        });
+    });
+
+    return connectedInvestigationsIds;
+}
+
+export default UseDuplicateConnectedIds

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/UseDuplicateConnectedIds.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/UseDuplicateConnectedIds.ts
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useSelector } from 'react-redux';
 
 import StoreStateType from 'redux/storeStateType';
@@ -6,10 +5,11 @@ import ConnectedInvestigation from 'models/GroupedInvestigationContacts/Connecte
 
 const UseDuplicateConnectedIds = (epiNumber : number) => {
     const investigations = useSelector<StoreStateType , ConnectedInvestigation[]>(state => state.groupedInvestigations.investigations.investigationsByGroupId.nodes);
-
     const indexOfCurrentInvestigation = investigations.map(investigation => investigation.epidemiologyNumber).indexOf(epiNumber);
     const investigationsToSearch = investigations.slice(0 , indexOfCurrentInvestigation);
+
     let connectedInvestigationsIds : string[] = []
+    
     investigationsToSearch.forEach(investigation => {
         investigation.contactEventsByInvestigationId.nodes.forEach(event => {
             event.contactedPeopleByContactEvent.nodes.forEach(person => {

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/investigationAccordion.test.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/GroupedInvestigations/GroupedInvestigationForm/ContactsForm/InvestigationAccordion/investigationAccordion.test.tsx
@@ -4,7 +4,7 @@ import { Accordion } from '@material-ui/core';
 
 import MockFormProvider from 'Utils/Testing/MockFormProvider';
 import mockSelectors from 'Utils/Testing/GroupedInvestigationForm/mockSelectors';
-import { testInvestigation } from 'Utils/Testing/GroupedInvestigationForm/state'; 
+import { testInvestigation, otherContactReason, testInvestigations} from 'Utils/Testing/GroupedInvestigationForm/state'; 
 
 import InvestigationAccordion from './InvestigationAccordion';
 import AccordionContent from './AccordionContent/AccordionContent';
@@ -16,7 +16,10 @@ const accordionProps = {
 }
 
 describe('<InvestigationAccordion />', () => {
-    mockSelectors();
+    mockSelectors({
+        ...otherContactReason,
+        ...testInvestigations
+    });
     const wrapper = mount(
         <MockFormProvider>
             <InvestigationAccordion 


### PR DESCRIPTION
Fixes [1530](https://dev.azure.com/spectrumFactory/CoronaI/_sprints/backlog/CoronaI%20Team/CoronaI/Sprint%2014?workitem=1530)
**NOTE :**  this will be erased in the next version, this is not the most optimal solution to the problem but its the most optimized that I could think of

# The problem
 the problem was that it was possible to push 2 identical contacts if those 2 contacts were on 2 connected investigation.

# The solution
added a new function `UseDuplicateConnectedIds` - it accepts the current epidemiology number as and runs through all of the investigations up to itself ( slicing from 0 to itself ) and pushes all of the exsiting ids to an array - so that if a current id already exists in another investigation before it - it would later disable it.
the accordion content later calls this function and appends all of the existing ids to all of the investigation's existing Ids. 