### PR TITLE
fix(static-fields-tool-tip-message)

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigatedPersonInfo/InvestigatedPersonInfo.tsx
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigatedPersonInfo/InvestigatedPersonInfo.tsx
@@ -327,7 +327,7 @@ const InvestigatedPersonInfo = (props: Props) => {
                         isInClosedInstitution && <ComplexityIcon tooltipText='המאומת שוהה במוסד' />
                     }
                     <Divider />
-                    <Tooltip title={vaccinationEffectiveFrom ? formatDate(vaccinationEffectiveFrom) : noInfo}>
+                    <Tooltip title={isVaccinated ? vaccinationEffectiveFrom ? formatDate(vaccinationEffectiveFrom) : noInfo : ''}>
                         <div>
                             <InfoItemWithIcon testId='isVaccinated' name='האם מחוסן' value={isVaccinated ? yes : noInfo}
                                 icon={VaccinationIcon}
@@ -339,7 +339,7 @@ const InvestigatedPersonInfo = (props: Props) => {
                         isVaccinated && <ComplexityIcon tooltipText={formatDate(vaccinationEffectiveFrom)} />
                     }
                     <Divider />
-                    <Tooltip title={mutationName ? mutationName : noInfo}>
+                    <Tooltip title={isSuspicionOfMutation ? mutationName ? mutationName : noInfo : ''}>
                         <div>
                             <InfoItemWithIcon testId='isSuspicionOfMutation' name='חשד למוטציה' value={isSuspicionOfMutation ? yes : noInfo}
                                 icon={MutationIcon}
@@ -351,7 +351,7 @@ const InvestigatedPersonInfo = (props: Props) => {
                         isSuspicionOfMutation && <ComplexityIcon tooltipText={mutationName ? mutationName : noInfo} />
                     }
                     <Divider />
-                    <Tooltip title={previousDiseaseStartDate ? formatDate(previousDiseaseStartDate) : noInfo}>
+                    <Tooltip title={isReturnSick ? previousDiseaseStartDate ? formatDate(previousDiseaseStartDate) : noInfo : ''}>
                         <div>
                             <InfoItemWithIcon testId='isReturnSick' name='חולה חוזר' value={isReturnSick ? yes : noInfo}
                                 icon={ReturnSickIcon}


### PR DESCRIPTION
Fix to bug: [1543](https://dev.azure.com/spectrumFactory/CoronaI/_sprints/backlog/CoronaI%20Team/CoronaI/Sprint%2014?workitem=1543)

Now ToolTip message works like this:
* Case 1: true value of (isVaccinated, isReturnSick or isSuspicionOfMutation) && value in (vaccinationEffectiveFrom, previousDiseaseStartDate, mutationName) -> ToolTip with the value
* Case 2: true value of (isVaccinated, isReturnSick or isSuspicionOfMutation) &&  no value in (vaccinationEffectiveFrom, previousDiseaseStartDate, mutationName) -> ToolTip with the noInfo value
* Case 3: false value of (isVaccinated, isReturnSick or isSuspicionOfMutation) &&  no value in (vaccinationEffectiveFrom, previousDiseaseStartDate, mutationName) -> no ToolTip value at all