### PR TITLE
re-ordered allocation structure

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -150,12 +150,12 @@ const InvestigationTable: React.FC = (): JSX.Element => {
     }
 
     const allocateInvestigationToInvestigator = async (groupIds: string[], epidemiologyNumbers: number[], investigatorToAllocate: InvestigatorOption) => {
-        if (epidemiologyNumbers) {
+        if (groupIds.length && groupIds[0]) {
+            await changeGroupsInvestigator(groupIds, investigatorToAllocate, '')
+        }
+        if (epidemiologyNumbers.length > 0) {
             await changeInvestigationsInvestigator(epidemiologyNumbers, investigatorToAllocate);
-        } else {
-            if (groupIds.length && groupIds[0]) {
-            await changeGroupsInvestigator(groupIds, investigatorToAllocate)
-        }}
+        }
         groupIds[0] && groupIds.forEach((groupId: string) => fetchInvestigationsByGroupId(groupId));
         fetchTableData();
     }
@@ -455,6 +455,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                     className={classes.pagination}
                 />
             </Grid>
+            {console.log(selectedRow)}
             <InvestigatorAllocationDialog
                 isOpen={isInvestigatorAllocationDialogOpen}
                 handleCloseDialog={() => setIsInvestigatorAllocationDialogOpen(false)}

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -455,7 +455,6 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                     className={classes.pagination}
                 />
             </Grid>
-            {console.log(selectedRow)}
             <InvestigatorAllocationDialog
                 isOpen={isInvestigatorAllocationDialogOpen}
                 handleCloseDialog={() => setIsInvestigatorAllocationDialogOpen(false)}


### PR DESCRIPTION
the allocation function did not work,
2 issues here : 
1. the previous function didn't take into account that when an investigation allocation occurs through the row itself it has a group ID but also it can have an epidemiology number, so I've changed the logic to **either** instead of or so that it would work with all selections
2. the funciton (in the server side atleast) required a transfer reason , added blank reason.