### PR TITLE
Fix/grouped contact family

### DIFF
--- a/db scripts/duplicate_person_by_id.sql
+++ b/db scripts/duplicate_person_by_id.sql
@@ -1,0 +1,42 @@
+-- FUNCTION: public.duplicate_person_by_id()
+
+-- DROP FUNCTION public.duplicate_person_by_id(personId bigint);
+
+CREATE OR REPLACE FUNCTION public.duplicate_person_by_id(
+	personId bigint
+	)
+    RETURNS bigint
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+AS $BODY$
+DECLARE 
+	new_person_id bigint;
+BEGIN
+	INSERT INTO public.person (
+		first_name,
+		last_name,
+		identification_type,
+		identification_number,
+		phone_number,
+		additional_phone_number,
+		gender,
+		birth_date
+	) SELECT 
+		first_name,
+		last_name,
+		identification_type,
+		identification_number,
+		phone_number,
+		additional_phone_number,
+		gender,
+		birth_date
+	FROM public.person
+	WHERE id = personId
+	RETURNING id INTO new_person_id;
+	RETURN new_person_id;
+END
+$BODY$;
+
+ALTER FUNCTION public.duplicate_person_by_id(personId bigint)
+    OWNER TO coronai;

--- a/server/src/ClientToDBAPI/IntersectionsRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/IntersectionsRoute/mainRoute.ts
@@ -199,21 +199,16 @@ intersectionsRoute.post('/groupedInvestigationContacts' , async (request : Reque
                 response.status(errorStatusCode).send(error);
             });
         return {
-            node : {
                 ...contact.node,
-                personInfo : parseInt(newPersonInfo)
-            }
+                personInfo : parseInt(newPersonInfo),
+                contactStatus: 1,
+                contactEvent: eventId,
+                creationTime: new Date()
         }
     }));
 
     await fullContacts.map(async (contact : any) => {
-        const params = {
-            ...contact.node,
-            contactStatus: 1,
-            contactEvent: eventId,
-            creationTime: new Date()
-        }
-        await graphqlRequest(CREATE_CONTACTED_PERSON , response.locals , {params})
+        await graphqlRequest(CREATE_CONTACTED_PERSON , response.locals , {params : contact})
             .then(result => {
                 createGroupedContactLogger.info(validDBResponseLog, Severity.LOW);
                 return;

--- a/server/src/ClientToDBAPI/IntersectionsRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/IntersectionsRoute/mainRoute.ts
@@ -209,8 +209,9 @@ intersectionsRoute.post('/groupedInvestigationContacts' , async (request : Reque
     await fullContacts.map(async (contact : any) => {
         const params = {
             ...contact.node,
-            contactStatus : 1,
-            contactEvent : eventId
+            contactStatus: 1,
+            contactEvent: eventId,
+            creationTime: new Date()
         }
         await graphqlRequest(CREATE_CONTACTED_PERSON , response.locals , {params})
             .then(result => {

--- a/server/src/DBService/ContactEvent/Mutation.ts
+++ b/server/src/DBService/ContactEvent/Mutation.ts
@@ -39,3 +39,11 @@ export const CREATE_CONTACTED_PERSON = gql`
         }
     }
 `;
+
+export const DUPLICATE_PERSON = gql`
+    mutation duplicatePersonById($personId: BigInt!) {
+        duplicatePersonById(input: {personid: $personId}) {
+            bigInt
+        }
+    }
+`;

--- a/server/src/DBService/ContactEvent/Query.ts
+++ b/server/src/DBService/ContactEvent/Query.ts
@@ -211,7 +211,6 @@ export const CONTACTS_BY_CONTACTS_IDS = gql`
           doesLiveWithConfirmed
           doesHaveBackgroundDiseases
           doesFeelGood
-          creationTime
           contactType
           completionTime
         }

--- a/server/src/DBService/ContactEvent/Query.ts
+++ b/server/src/DBService/ContactEvent/Query.ts
@@ -211,8 +211,6 @@ export const CONTACTS_BY_CONTACTS_IDS = gql`
           doesLiveWithConfirmed
           doesHaveBackgroundDiseases
           doesFeelGood
-          contactType
-          completionTime
         }
       }
     }


### PR DESCRIPTION
fixes [1540](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1540)

# The Issue
The issue was that in the creation of a connected contact relied on the existing personInfo from public.person, the problem with that approach was that the table public.involved_contact has a FK constriction on public.person (which means that if a person existed on that table he cannot be deleted unless he was deleted from that table)
# The Solution
added a new function - duplicate_contact - that takes a personId - 'duplicates' it and then returns the new persons id, so that now - before creating a new contacted_person, a new pesron will be duplicated.
also this will pair nicely with the new 'Contact bank' story.