### PR TITLE
1571/fix/other investigations details

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,2 +1,2 @@
 feature : ['*/feat*' , '*/feature*' , 'feat/*' , 'feature/*']
-fix : ['*/fix' , 'fix/*']
+fix : ['*/fix*' , 'fix/*']

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -25,10 +25,10 @@ import InvestigationMainStatus from 'models/InvestigationMainStatus';
 import { setIsLoading } from 'redux/IsLoading/isLoadingActionCreators';
 import InvestigationsFilterByFields from 'models/enums/InvestigationsFilterByFields';
 import InvestigationMainStatusCodes from 'models/enums/InvestigationMainStatusCodes';
-import { setAxiosInterceptorId } from 'redux/Investigation/investigationActionCreators';
 import { setLastOpenedEpidemiologyNum } from 'redux/Investigation/investigationActionCreators';
 import { setInvestigationStatus, setCreator } from 'redux/Investigation/investigationActionCreators';
 import AllocatedInvestigator from 'models/InvestigationTable/AllocateInvestigatorDialog/AllocatedInvestigator';
+import { resetInvestigationState, setAxiosInterceptorId } from 'redux/Investigation/investigationActionCreators';
 
 import useStyle from './InvestigationTableStyles';
 import { filterCreators } from './FilterCreators';
@@ -337,6 +337,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
 
 
     useEffect(() => {
+        resetInvestigationState();
         fetchAllInvestigationStatuses();
         fetchAllInvestigationSubStatuses();
         startWaiting();

--- a/client/src/redux/Investigation/investigationActionCreators.ts
+++ b/client/src/redux/Investigation/investigationActionCreators.ts
@@ -80,3 +80,9 @@ export const setDatesToInvestigateParams = (symptomsExistenceInfo?: SymptomsExis
         payload: { symptomsExistenceInfo, validationDate }
     })
 };
+
+export const resetInvestigationState = () => {
+    store.dispatch({
+        type: actionTypes.RESET_STATE,
+    })
+};

--- a/client/src/redux/Investigation/investigationActionTypes.ts
+++ b/client/src/redux/Investigation/investigationActionTypes.ts
@@ -12,6 +12,7 @@ export const SET_INVESTIGATION_STATUS = 'SET_INVESTIGATION_STATUS';
 export const SET_END_TIME = 'SET_END_TIME';
 export const SET_CREATOR = 'SET_CREATOR';
 export const SET_DATES_TO_INVESTIGATE_PARAMS = 'SET_DATES_TO_INVESTIGATE_PARAMS';
+export const RESET_STATE = 'RESET_STATE';
 
 interface SetEpidemiologyNum {
     type: typeof SET_EPIDEMIOLOGY_NUM,
@@ -68,6 +69,10 @@ interface SetDatesToInvestigateParams {
     payload: {symptomsExistenceInfo?: SymptomsExistenceInfo, validationDate?: Date}
 }
 
+interface ResetStateParams {
+    type: typeof RESET_STATE,
+}
+
 export type InvestigationAction = SetEpidemiologyNum | SetInvestigationStatus | SetInvestigatedPatientId | SetAxiosInterceptorId
  | SetLastOpenedEpidemiologyNum | SetIsCurrentlyLoading | SetIsDeceased | SetIsCurrentlyHospitialized | SetEndTime 
- | SetCreator | SetDatesToInvestigateParams;
+ | SetCreator | SetDatesToInvestigateParams |  ResetStateParams;

--- a/client/src/redux/Investigation/investigationReducer.ts
+++ b/client/src/redux/Investigation/investigationReducer.ts
@@ -53,6 +53,7 @@ const investigationReducer = (state = initialState, action: Actions.Investigatio
         }
         case Actions.SET_END_TIME: return { ...state, endTime: action.payload.endTime }
         case Actions.SET_CREATOR: return  { ...state, creator: action.payload.creator }
+        case Actions.RESET_STATE: return  initialState
         default: return state;
     }
 }


### PR DESCRIPTION
# The problem
for a long time some investigators were getting other investigations details when they were trying to open one.
In a conversation with simon and moshe we've found a reported way to recreate it ( which didn't work for me at least :/) , but from that way It seems that maybe the cache is not updated correctly, you can read about it in the comment below
# The solution
**NOTE** : This may not necceceraly solve the problem but if the problem keeps occurring we'll know that the cause is not the cache.
added a manual reset of the redux investigation state on /landing (when the user left an investigation)

note2 - this also solves bad definition of pr-labeler