### PR TITLE
1563/feat/post-intersections-bank

### DIFF
--- a/db scripts/add_contacts_from_bank.sql
+++ b/db scripts/add_contacts_from_bank.sql
@@ -1,0 +1,37 @@
+ DROP FUNCTION public.add_contacts_from_bank(integer, json);
+
+CREATE OR REPLACE FUNCTION public.add_contacts_from_bank(IN contact_event_id integer, IN contacts json)
+    RETURNS void
+    LANGUAGE 'plpgsql'
+    VOLATILE
+    PARALLEL UNSAFE
+    COST 100
+AS $BODY$
+declare
+/*adds contacted persons assigned to specified contacted_event*/
+--Variables:
+
+contacts_arr json[];
+contact json;
+extraInfo varchar;
+personId int4;
+contactType int4;
+
+begin 
+	contacts_arr :=(
+					select array_agg(contacts_data)
+					from json_array_elements(contacts->'contacts') contacts_data
+				  );
+	foreach contact in array contacts_arr 
+	loop
+		select trim(nullif((contact->'extraInfo')::text,'null'),'"') into extraInfo;
+ 		select trim(nullif((contact->'contactType')::text,'null'),'"')::int4 into contactType;
+		select trim(nullif((contact->'personInfo')::text,'null'),'"')::int4 into personId;
+
+		INSERT INTO public.contacted_person
+			(person_info, contact_event,extra_info, contact_type, contact_status, creation_time)
+			VALUES(personId, contact_event_id,extraInfo, contactType, 1, now());
+			
+	end loop;
+end;
+$BODY$;

--- a/db scripts/add_contacts_from_bank.sql
+++ b/db scripts/add_contacts_from_bank.sql
@@ -1,4 +1,4 @@
- DROP FUNCTION public.add_contacts_from_bank(integer, json);
+-- DROP FUNCTION public.add_contacts_from_bank(integer, json);
 
 CREATE OR REPLACE FUNCTION public.add_contacts_from_bank(IN contact_event_id integer, IN contacts json)
     RETURNS void
@@ -8,8 +8,8 @@ CREATE OR REPLACE FUNCTION public.add_contacts_from_bank(IN contact_event_id int
     COST 100
 AS $BODY$
 declare
-/*adds contacted persons assigned to specified contacted_event*/
---Variables:
+-- Adds contacted persons assigned to specified contacted_eventט
+-- Variables:
 
 contacts_arr json[];
 contact json;

--- a/server/src/ClientToDBAPI/IntersectionsRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/IntersectionsRoute/mainRoute.ts
@@ -354,7 +354,7 @@ intersectionsRoute.delete('/deleteContactEventsByDate', (request: Request, respo
 intersectionsRoute.post('/addContactsFromBank', handleInvestigationRequest, (request: Request, response: Response) => {
     const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
     const addContactsFromBankLogger = logger.setup({
-        workflow: 'adds contacts to event from contacts bank',
+        workflow: 'add contacts to event from contacts bank',
         user: response.locals.user.id,
         investigation: epidemiologyNumber
     });

--- a/server/src/ClientToDBAPI/IntersectionsRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/IntersectionsRoute/mainRoute.ts
@@ -9,12 +9,16 @@ import { GetInvolvedContactsResponse, InvolvedContactDB} from '../../Models/Cont
 import logger, { invalidDBResponseLog, launchingDBRequestLog, validDBResponseLog } from '../../Logger/Logger';
 import { GetPlaceSubTypesByTypesResposne, PlacesSubTypesByTypes } from '../../Models/ContactEvent/GetPlacesSubTypesByTypes';
 import {
-    CREATE_OR_EDIT_CONTACT_EVENT, DELETE_CONTACT_EVENT, DELETE_CONTACT_EVENTS_BY_DATE, DELETE_CONTACTED_PERSON, 
-    CREATE_CONTACTED_PERSON, DUPLICATE_PERSON
+    CREATE_OR_EDIT_CONTACT_EVENT, DELETE_CONTACT_EVENT, 
+    DELETE_CONTACT_EVENTS_BY_DATE, DELETE_CONTACTED_PERSON, 
+    CREATE_CONTACTED_PERSON, DUPLICATE_PERSON, 
+    ADD_CONTACTS_FROM_BANK
 } from '../../DBService/ContactEvent/Mutation';
 import {
-    GET_FULL_CONTACT_EVENT_BY_INVESTIGATION_ID, GET_LOACTIONS_SUB_TYPES_BY_TYPES, GET_ALL_CONTACT_TYPES,
-    GET_ALL_INVOLVED_CONTACTS, CONTACTS_BY_GROUP_ID, CONTACTS_BY_CONTACTS_IDS
+    GET_FULL_CONTACT_EVENT_BY_INVESTIGATION_ID, 
+    GET_LOACTIONS_SUB_TYPES_BY_TYPES, GET_ALL_CONTACT_TYPES,
+    GET_ALL_INVOLVED_CONTACTS, CONTACTS_BY_GROUP_ID, 
+    CONTACTS_BY_CONTACTS_IDS
 } from '../../DBService/ContactEvent/Query';
 
 const intersectionsRoute = Router();
@@ -123,14 +127,12 @@ intersectionsRoute.post('/createContactEvent', handleInvestigationRequest, (requ
         user: response.locals.user.id,
         investigation: epidemiologyNumber
     });
-
     const parameters = {
         event: JSON.stringify({
             contactEvents: extractInteractions(request.body),
             investigationId: epidemiologyNumber
         })
     };
-
     createContactEventLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
     graphqlRequest(CREATE_OR_EDIT_CONTACT_EVENT, response.locals, parameters)
         .then(result => {
@@ -357,12 +359,10 @@ intersectionsRoute.post('/addContactsFromBank', handleInvestigationRequest, (req
         investigation: epidemiologyNumber
     });
 
-    // const parameters = {
-    //     event: JSON.stringify({
-    //         contactEvents: extractInteractions(request.body),
-    //         investigationId: epidemiologyNumber
-    //     })
-    // };
+    const parameters = {
+        contactEventId: request.body.contactEventId,
+        contacts: JSON.stringify({contactEvents: request.body.contacts})
+    };
 
     addContactsFromBankLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
     graphqlRequest(ADD_CONTACTS_FROM_BANK, response.locals, parameters)

--- a/server/src/ClientToDBAPI/IntersectionsRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/IntersectionsRoute/mainRoute.ts
@@ -349,4 +349,31 @@ intersectionsRoute.delete('/deleteContactEventsByDate', (request: Request, respo
     });
 });
 
+intersectionsRoute.post('/addContactsFromBank', handleInvestigationRequest, (request: Request, response: Response) => {
+    const epidemiologyNumber = parseInt(response.locals.epidemiologynumber);
+    const addContactsFromBankLogger = logger.setup({
+        workflow: 'adds contacts to event from contacts bank',
+        user: response.locals.user.id,
+        investigation: epidemiologyNumber
+    });
+
+    // const parameters = {
+    //     event: JSON.stringify({
+    //         contactEvents: extractInteractions(request.body),
+    //         investigationId: epidemiologyNumber
+    //     })
+    // };
+
+    addContactsFromBankLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
+    graphqlRequest(ADD_CONTACTS_FROM_BANK, response.locals, parameters)
+        .then(result => {
+            addContactsFromBankLogger.info(validDBResponseLog, Severity.LOW);
+            response.send(result);
+        })
+        .catch(error => {
+            addContactsFromBankLogger.error(invalidDBResponseLog(error), Severity.HIGH);
+            response.status(errorStatusCode).send(error);
+        });
+});
+
 export default intersectionsRoute;

--- a/server/src/DBService/ContactEvent/Mutation.ts
+++ b/server/src/DBService/ContactEvent/Mutation.ts
@@ -47,3 +47,11 @@ export const DUPLICATE_PERSON = gql`
         }
     }
 `;
+
+export const ADD_CONTACTS_FROM_BANK = gql`
+    mutation addContactsFromBank() {
+        addContactsFromBank(input: {}) {
+            clientMutationId
+        }
+    }
+`;

--- a/server/src/DBService/ContactEvent/Mutation.ts
+++ b/server/src/DBService/ContactEvent/Mutation.ts
@@ -49,8 +49,8 @@ export const DUPLICATE_PERSON = gql`
 `;
 
 export const ADD_CONTACTS_FROM_BANK = gql`
-    mutation addContactsFromBank() {
-        addContactsFromBank(input: {}) {
+    mutation addContactsFromBank($contactEventId: Int!, $contacts: JSON!) {
+        addContactsFromBank(input: {contactsEventId: $contactEventId, contacts: $contacts}) {
             clientMutationId
         }
     }


### PR DESCRIPTION
Part of feat: [1563](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1563)
 ### What's in?:
* New route:  post to /intersections/addContactsFromBank
* New mutation: ADD_CONTACTS_FROM_BANK
* New DB function: add_contacts_from_bank.sql

All this will be used when saving the contacts from the contact bank when creating new event.
From the client side we will need to send 2 parameters to the new route: 
1. contactEventId - int
2. contacts - objects array (each object with: person_info, contact_type, extra_info)