### PR TITLE
1545/fix/group-reason-tooltip

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableRow/InvestigationTableRow.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableRow/InvestigationTableRow.tsx
@@ -120,7 +120,7 @@ const InvestigationTableRow = ({
             case TableHeadersNames.color:
                 return (
                     Boolean(indexedRow.groupId) ?
-                        <Tooltip arrow placement='top' title={indexedRow.otherReason !== '' ? indexedRow.otherReason : indexedRow.groupReason}>
+                        <Tooltip arrow placement='top' title={indexedRow.otherReason !== '' && indexedRow.otherReason !== ' ' ? indexedRow.otherReason : indexedRow.groupReason}>
                             <div className={classes.groupColor}
                                 style={{ backgroundColor: groupColor }}
                             />


### PR DESCRIPTION
### The problem:

Some of the grouped investigations have a space value (" ") in their "other reason" field.
### The solution:

Added another check to the tooltip title so that we won't display space.