### PR TITLE
1576/fix/undisable-family-contacts

### DIFF
--- a/client/src/commons/Contexts/FamilyMembersContext.ts
+++ b/client/src/commons/Contexts/FamilyMembersContext.ts
@@ -4,10 +4,12 @@ import InvolvedContact from 'models/InvolvedContact';
 
 export interface FamilyMembersContext {
     familyMembers: InvolvedContact[];
+    eventFamilyMembersIds?: (string | undefined)[];
 };
 
 const initialFamilyMembers: FamilyMembersContext = {
-    familyMembers: []
+    familyMembers: [],
+    eventFamilyMembersIds: []
 };
 
 export const familyMembersContext = createContext<FamilyMembersContext>(initialFamilyMembers);

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionDialog.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionDialog.tsx
@@ -4,28 +4,27 @@ import React, {useContext, useMemo, useState} from 'react';
 import {FormProvider, useForm,} from 'react-hook-form';
 import {Dialog, DialogTitle, DialogContent, DialogActions, Button, Tooltip} from '@material-ui/core';
 
+import theme from 'styles/theme';
 import Contact from 'models/Contact';
-import InvolvedContact from 'models/InvolvedContact';
 import PlaceSubType from 'models/PlaceSubType';
+import InvolvedContact from 'models/InvolvedContact';
+import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
+import PrimaryButton from 'commons/Buttons/PrimaryButton/PrimaryButton';
 import {ContactBankContextProvider , ContactBankOption} from 'commons/Contexts/ContactBankContext';
 import {GroupedInvestigationsContextProvider} from 'commons/Contexts/GroupedInvestigationFormContext';
+import {familyMembersContext, FamilyMembersDataContextProvider} from 'commons/Contexts/FamilyMembersContext';
 import InteractionEventDialogData, {DateData, OccuranceData} from 'models/Contexts/InteractionEventDialogData';
 import InteractionEventDialogFields from 'models/enums/InteractionsEventDialogContext/InteractionEventDialogFields';
 import InteractionEventContactFields from 'models/enums/InteractionsEventDialogContext/InteractionEventContactFields';
-import PrimaryButton from 'commons/Buttons/PrimaryButton/PrimaryButton';
-import {familyMembersContext} from 'commons/Contexts/FamilyMembersContext';
 
 import useStyles from './InteractionDialogStyles';
 import useInteractionsForm from './InteractionEventForm/useInteractionsForm';
+import InteractionFormTabSwitchButton from './InteractionFormTabSwitchButton';
 import ContactsTabs from './InteractionEventForm/ContactsSection/ContactsTabs';
 import InteractionEventSchema from './InteractionEventForm/InteractionSection/InteractionEventSchema';
 import ContactTypeKeys from './InteractionEventForm/ContactsSection/ManualContactsForm/ContactForm/ContactTypeKeys';
+import repetitiveFieldTools from './InteractionEventForm/InteractionSection/RepetitiveEventForm/hooks/repetitiveFieldTools';
 import InteractionEventForm, {InteractionEventFormProps} from './InteractionEventForm/InteractionSection/InteractionEventForm';
-import InteractionFormTabSwitchButton from './InteractionFormTabSwitchButton';
-import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
-import repetitiveFieldTools
-    from './InteractionEventForm/InteractionSection/RepetitiveEventForm/hooks/repetitiveFieldTools';
-import theme from 'styles/theme';
 
 const filTimeValidationMessage = 'יש למלא שעה';
 const repetitiveWithoutDatesSelectedErrorMessage = 'שים לב שלא ניתן לשמור אירוע מחזורי עם תאריך אחד בלבד';
@@ -213,20 +212,32 @@ const InteractionDialog = (props: Props) => {
 
     const getExistingPersonInfos = () => {
         return interactionData?.contacts.map(contact => contact.personInfo);
-    }
+    };
+
     const contactBankProviderState = {
         contactBank, 
         setContactBank, 
         existingEventPersonInfos : getExistingPersonInfos()
-    }
+    };
+
     const getEventContactIds = () => {
         return interactionData?.contacts.map(contact => contact.identificationNumber);
-    }
+    };
+
     const groupedInvestigationProviderState = {
         groupedInvestigationContacts, 
         setGroupedInvestigationContacts,
         eventContactIds : getEventContactIds()
-    }
+    };
+
+    const getEventFamilyMembersIds = () => {
+        return interactionData?.contacts.map(contact => contact.identificationNumber);
+    };
+
+    const familyMembersDataProviderState = {
+        familyMembers, 
+        eventFamilyMembersIds : getEventFamilyMembersIds()
+    };
 
     const validateAndHandleSubmit = methods.handleSubmit(
         () => {
@@ -260,12 +271,14 @@ const InteractionDialog = (props: Props) => {
                             onPlaceSubTypeChange={onPlaceSubtypeChange}
                         />
                         <GroupedInvestigationsContextProvider value={groupedInvestigationProviderState}>
-                            <ContactBankContextProvider value={contactBankProviderState}>
-                                <ContactsTabs
-                                    isVisible={isAddingContacts}
-                                    existingPersons={getPersonMap()}
-                                />
-                            </ContactBankContextProvider>
+                            <FamilyMembersDataContextProvider value={familyMembersDataProviderState}>
+                                <ContactBankContextProvider value={contactBankProviderState}>
+                                    <ContactsTabs
+                                        isVisible={isAddingContacts}
+                                        existingPersons={getPersonMap()}
+                                    />
+                                </ContactBankContextProvider>
+                            </FamilyMembersDataContextProvider>
                         </GroupedInvestigationsContextProvider>
                     </form>
                 </DialogContent>

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersForm.tsx
@@ -1,20 +1,20 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { Typography } from '@material-ui/core';
 
-import { familyMembersContext } from 'commons/Contexts/FamilyMembersContext';
-
+import useFamilyMemebersForm from './useFamilyMembersForm';
 import FamilyMembersTable from './FamilyMembersTable/FamilyMembersTable';
 
 const noFamilyMembers = 'לא קיימים נתונים ממרשם האוכלוסין';
 
 const FamilyMembersForm: React.FC = () => {
 
-    const { familyMembers } = useContext(familyMembersContext);
+    const { familyMembers, existingFamilyMembers } = useFamilyMemebersForm();
 
     return (
         familyMembers.length > 0 ?
             <FamilyMembersTable
                 familyMembers={familyMembers}
+                existingFamilyMembers={existingFamilyMembers}
             />
             :
             <Typography variant='h5'>{noFamilyMembers}</Typography>

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersTable/FamilyMembersTable.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersTable/FamilyMembersTable.tsx
@@ -1,5 +1,5 @@
+import React, { useEffect } from 'react';
 import { Home } from '@material-ui/icons';
-import React, { useEffect, useMemo, useState } from 'react';
 import { TableContainer, Paper, Table, TableHead, TableRow, TableCell, TableBody, Checkbox, Typography, Tooltip } from '@material-ui/core';
 
 import InvolvedContact from 'models/InvolvedContact';
@@ -13,8 +13,8 @@ const houseMember = 'בן בית';
 const cityCellName = 'isolationCity';
 
 const FamilyMembersTable: React.FC<Props> = (props: Props) => {
+    const { familyMembers, existingFamilyMembers } = props;
 
-    const { familyMembers } = props;
     const classes = useStyles();
 
     const { convertToIndexedRow, getTableCell } = useFamilyContactsUtils();
@@ -27,8 +27,9 @@ const FamilyMembersTable: React.FC<Props> = (props: Props) => {
         });
     }, []);
 
-    const { selectRow, counterDescription, 
-            isRowSelected, isHouseMember } = useFamilyMemebersTable({ familyMembers });
+    const { selectRow, counterDescription, isRowSelected, 
+            isHouseMember, isRowDisabled, getRowClass 
+    } = useFamilyMemebersTable({ familyMembers, existingFamilyMembers });
 
     return (
         <>
@@ -49,10 +50,10 @@ const FamilyMembersTable: React.FC<Props> = (props: Props) => {
                         {
                             familyMembers.map((familyMember: InvolvedContact) => (
                                 <>
-                                    <TableRow className={isRowSelected(familyMember) ? classes.checkedRow  : ''}>
+                                    <TableRow className={getRowClass(familyMember)}>
                                         {
                                             <Checkbox
-                                                //disabled={familyMember.isContactedPerson}
+                                                disabled={isRowDisabled(familyMember.identificationNumber)}
                                                 onClick={() => selectRow(familyMember)}
                                                 color='primary'
                                                 checked={isRowSelected(familyMember)}
@@ -84,6 +85,7 @@ const FamilyMembersTable: React.FC<Props> = (props: Props) => {
 
 interface Props {
     familyMembers: InvolvedContact[];
+    existingFamilyMembers: string[];
 };
 
 export default FamilyMembersTable;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersTable/FamilyMembersTable.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersTable/FamilyMembersTable.tsx
@@ -1,11 +1,8 @@
 import { Home } from '@material-ui/icons';
-import { useSelector } from 'react-redux';
-import StoreStateType from 'redux/storeStateType';
 import React, { useEffect, useMemo, useState } from 'react';
 import { TableContainer, Paper, Table, TableHead, TableRow, TableCell, TableBody, Checkbox, Typography, Tooltip } from '@material-ui/core';
 
 import InvolvedContact from 'models/InvolvedContact';
-import FlattenedDBAddress, { DBAddress } from 'models/DBAddress';
 import useFamilyContactsUtils from 'Utils/FamilyContactsUtils/useFamilyContactsUtils';
 import { FamilyContactsTableHeaders } from 'Utils/FamilyContactsUtils/FamilyContactsTableHeaders';
 
@@ -30,11 +27,8 @@ const FamilyMembersTable: React.FC<Props> = (props: Props) => {
         });
     }, []);
 
-    const {selectRow,
-        counterDescription,
-        isRowSelected,
-        isHouseMember } = useFamilyMemebersTable({ familyMembers });
-
+    const { selectRow, counterDescription, 
+            isRowSelected, isHouseMember } = useFamilyMemebersTable({ familyMembers });
 
     return (
         <>

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersTable/FamilyMembersTable.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersTable/FamilyMembersTable.tsx
@@ -10,6 +10,7 @@ import useFamilyContactsUtils from 'Utils/FamilyContactsUtils/useFamilyContactsU
 import { FamilyContactsTableHeaders } from 'Utils/FamilyContactsUtils/FamilyContactsTableHeaders';
 
 import useStyles from './FamilyMembersTableStyles';
+import useFamilyMemebersTable from './useFamilyMembersTable';
 
 const houseMember = 'בן בית';
 const cityCellName = 'isolationCity';
@@ -21,10 +22,6 @@ const FamilyMembersTable: React.FC<Props> = (props: Props) => {
 
     const { convertToIndexedRow, getTableCell } = useFamilyContactsUtils();
 
-    const investigatedPatientAddress = useSelector<StoreStateType, FlattenedDBAddress>(state => state.address);
-
-    const [selectedFamilyMembers, setSelectedFamilyMembers] = useState<InvolvedContact[]>([]);
-
     const FamilyTableHeadersWithCheckbox = [''].concat(Object.values(FamilyContactsTableHeaders));
 
     useEffect(() => {
@@ -33,31 +30,11 @@ const FamilyMembersTable: React.FC<Props> = (props: Props) => {
         });
     }, []);
 
-    const selectRow = (selectedFamilyMember: InvolvedContact) => {
-        const familyMemberIndex = selectedFamilyMembers.findIndex(checkedRow => selectedFamilyMember === checkedRow);
-        if (familyMemberIndex !== -1) {
-            setSelectedFamilyMembers(selectedFamilyMembers.filter(member => member !== selectedFamilyMember));
-            selectedFamilyMember.selected = false;
-        } else {
-            setSelectedFamilyMembers([...selectedFamilyMembers, selectedFamilyMember]);
-            selectedFamilyMember.selected = true;
-        }
-    };
+    const {selectRow,
+        counterDescription,
+        isRowSelected,
+        isHouseMember } = useFamilyMemebersTable({ familyMembers });
 
-    const counterDescription: string = useMemo(() => {
-        return selectedFamilyMembers.length > 0 ?
-            selectedFamilyMembers.length === 1 ?
-                'נבחר מגע משפחה אחד' :
-                'בסה"כ נבחרו ' + selectedFamilyMembers.length + ' מגעי משפחה'
-            : ''
-    }, [selectedFamilyMembers]);
-
-    const isRowSelected = (selectedFamilyMember: InvolvedContact) => selectedFamilyMembers?.includes(selectedFamilyMember);
-
-    const isHouseMember = (familyMemberAddress: DBAddress) => (
-        familyMemberAddress?.city?.id === investigatedPatientAddress.city &&
-        familyMemberAddress?.street?.id === investigatedPatientAddress.street
-    );
 
     return (
         <>

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersTable/FamilyMembersTable.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersTable/FamilyMembersTable.tsx
@@ -78,10 +78,10 @@ const FamilyMembersTable: React.FC<Props> = (props: Props) => {
                         {
                             familyMembers.map((familyMember: InvolvedContact) => (
                                 <>
-                                    <TableRow className={isRowSelected(familyMember) ? classes.checkedRow : familyMember.isContactedPerson ? classes.disabledRow : ''}>
+                                    <TableRow className={isRowSelected(familyMember) ? classes.checkedRow  : ''}>
                                         {
                                             <Checkbox
-                                                disabled={familyMember.isContactedPerson}
+                                                //disabled={familyMember.isContactedPerson}
                                                 onClick={() => selectRow(familyMember)}
                                                 color='primary'
                                                 checked={isRowSelected(familyMember)}

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersTable/FamilyMembersTableStyles.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersTable/FamilyMembersTableStyles.ts
@@ -8,7 +8,7 @@ const useStyles = makeStyles({
         backgroundColor: 'rgb(202, 222, 234)',
     },
     disabledRow: {
-        backgroundColor: 'lightgray',
+        backgroundColor: 'rgb(0, 0, 0, 0.15)'
     },
     homeIcon: {
         marginBottom: '-0.8vh',

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersTable/useFamilyMembersTable.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersTable/useFamilyMembersTable.ts
@@ -5,8 +5,8 @@ import StoreStateType from 'redux/storeStateType';
 import InvolvedContact from 'models/InvolvedContact';
 import FlattenedDBAddress, { DBAddress } from 'models/DBAddress';
 
-const useFamilyMemebersTable = (props: any): any => {
-    const { familyMembers } = props;
+const useFamilyMemebersTable = (parameters: Parameters) => {
+    const { familyMembers } = parameters;
 
 
     const investigatedPatientAddress = useSelector<StoreStateType, FlattenedDBAddress>(state => state.address);
@@ -52,6 +52,10 @@ const useFamilyMemebersTable = (props: any): any => {
         isRowSelected,
         isHouseMember
     }
+};
+
+interface Parameters {
+    familyMembers: InvolvedContact[];
 };
 
 export default useFamilyMemebersTable;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersTable/useFamilyMembersTable.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersTable/useFamilyMembersTable.ts
@@ -1,0 +1,57 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import StoreStateType from 'redux/storeStateType';
+import InvolvedContact from 'models/InvolvedContact';
+import FlattenedDBAddress, { DBAddress } from 'models/DBAddress';
+
+const useFamilyMemebersTable = (props: any): any => {
+    const { familyMembers } = props;
+
+
+    const investigatedPatientAddress = useSelector<StoreStateType, FlattenedDBAddress>(state => state.address);
+
+    const [selectedFamilyMembers, setSelectedFamilyMembers] = useState<InvolvedContact[]>([]);
+
+    useEffect(() => {
+        familyMembers.forEach((familyMember: InvolvedContact) => {
+            familyMember.selected = false;
+        });
+    }, []);
+
+    const selectRow = (selectedFamilyMember: InvolvedContact) => {
+        const familyMemberIndex = selectedFamilyMembers.findIndex(checkedRow => selectedFamilyMember === checkedRow);
+        if (familyMemberIndex !== -1) {
+            setSelectedFamilyMembers(selectedFamilyMembers.filter(member => member !== selectedFamilyMember));
+            selectedFamilyMember.selected = false;
+        } else {
+            setSelectedFamilyMembers([...selectedFamilyMembers, selectedFamilyMember]);
+            selectedFamilyMember.selected = true;
+        }
+    };
+
+    const counterDescription: string = useMemo(() => {
+        return selectedFamilyMembers.length > 0 ?
+            selectedFamilyMembers.length === 1 ?
+                'נבחר מגע משפחה אחד' :
+                'בסה"כ נבחרו ' + selectedFamilyMembers.length + ' מגעי משפחה'
+            : ''
+    }, [selectedFamilyMembers]);
+
+    const isRowSelected = (selectedFamilyMember: InvolvedContact) => selectedFamilyMembers?.includes(selectedFamilyMember);
+
+    const isHouseMember = (familyMemberAddress: DBAddress) => (
+        familyMemberAddress?.city?.id === investigatedPatientAddress.city &&
+        familyMemberAddress?.street?.id === investigatedPatientAddress.street
+    );
+
+
+    return {
+        selectRow,
+        counterDescription,
+        isRowSelected,
+        isHouseMember
+    }
+};
+
+export default useFamilyMemebersTable;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersTable/useFamilyMembersTable.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/FamilyMembersTable/useFamilyMembersTable.ts
@@ -1,13 +1,16 @@
-import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useEffect, useMemo, useState } from 'react';
 
 import StoreStateType from 'redux/storeStateType';
 import InvolvedContact from 'models/InvolvedContact';
 import FlattenedDBAddress, { DBAddress } from 'models/DBAddress';
 
-const useFamilyMemebersTable = (parameters: Parameters) => {
-    const { familyMembers } = parameters;
+import useStyles from './FamilyMembersTableStyles';
 
+const useFamilyMemebersTable = (parameters: Parameters) => {
+    const { familyMembers, existingFamilyMembers } = parameters;
+
+    const classes = useStyles();
 
     const investigatedPatientAddress = useSelector<StoreStateType, FlattenedDBAddress>(state => state.address);
 
@@ -45,17 +48,32 @@ const useFamilyMemebersTable = (parameters: Parameters) => {
         familyMemberAddress?.street?.id === investigatedPatientAddress.street
     );
 
+    const isRowDisabled = (identificationNumber: string) => {
+       return existingFamilyMembers.indexOf(identificationNumber) !== -1; 
+    };
+
+    const getRowClass = (familyMember: InvolvedContact) => {
+        if(isRowDisabled(familyMember.identificationNumber)) {
+            return classes.disabledRow;
+        } else if (isRowSelected(familyMember)) {
+            return classes.checkedRow;
+        }
+        return '';
+    };
 
     return {
         selectRow,
         counterDescription,
         isRowSelected,
-        isHouseMember
-    }
+        isHouseMember,
+        isRowDisabled,
+        getRowClass
+    };
 };
 
 interface Parameters {
     familyMembers: InvolvedContact[];
+    existingFamilyMembers: string[];
 };
 
 export default useFamilyMemebersTable;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/useFamilyMembersForm.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/FamilyMembers/useFamilyMembersForm.ts
@@ -1,0 +1,24 @@
+import { useContext } from 'react';
+
+import { familyMembersContext } from 'commons/Contexts/FamilyMembersContext';
+
+const useFamilyMemebersForm = () => {
+
+    const { familyMembers, eventFamilyMembersIds } = useContext(familyMembersContext);
+
+    const existingFamilyMembers = eventFamilyMembersIds 
+        ? eventFamilyMembersIds.map(identificationNumber => {
+            if(identificationNumber) { 
+                return identificationNumber;
+            }
+            return '';
+        })
+        : [];
+
+    return {
+        familyMembers,
+        existingFamilyMembers
+    };
+};
+
+export default useFamilyMemebersForm;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionsTab.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionsTab.tsx
@@ -90,11 +90,6 @@ const InteractionsTab: React.FC<Props> = (props: Props): JSX.Element => {
 
     const closeFamilyDialog = () => setUncontactedFamilyMembers([]);
 
-    const filteredInteractionUnInvolved = (interaction: Interaction) => ({
-        ...interaction,
-        contacts: interaction.contacts.filter(contact => !isInvolved(contact.involvedContact?.involvementReason))
-    });
-
     const generateContactCard = (interactionDate: Date) => {
         return (
             <ContactDateCard
@@ -102,7 +97,7 @@ const InteractionsTab: React.FC<Props> = (props: Props): JSX.Element => {
                 loadInteractions={loadInteractions}
                 loadInvolvedContacts={loadInvolvedContacts}
                 contactDate={interactionDate}
-                onEditClick={(interaction: InteractionEventDialogData) => setInteractionToEdit(filteredInteractionUnInvolved(interaction))}
+                onEditClick={(interaction: InteractionEventDialogData) => setInteractionToEdit(interaction)}
                 onDeleteClick={handleDeleteContactEvent}
                 onDeleteContactClick={handleDeleteContactedPerson}
                 createNewInteractionEvent={() => setNewInteractionEventDate(interactionDate)}

--- a/server/src/ClientToDBAPI/IntersectionsRoute/mainRoute.ts
+++ b/server/src/ClientToDBAPI/IntersectionsRoute/mainRoute.ts
@@ -365,7 +365,6 @@ intersectionsRoute.post('/addContactsFromBank', handleInvestigationRequest, (req
     };
 
     addContactsFromBankLogger.info(launchingDBRequestLog(parameters), Severity.LOW);
-    console.log('BANK', parameters);
     graphqlRequest(ADD_CONTACTS_FROM_BANK, response.locals, parameters)
         .then(result => {
             addContactsFromBankLogger.info(validDBResponseLog, Severity.LOW);

--- a/server/src/middlewares/ConvertToObject.ts
+++ b/server/src/middlewares/ConvertToObject.ts
@@ -3,7 +3,6 @@ import { Request, Response, NextFunction } from 'express';
 const convertToJson = (req: Request, res: Response, next: NextFunction) => {
     if (req.body && Object.keys(req.body).length > 0) {
         req.body = JSON.parse(req.body);
-        console.log(req.body)
     }
     next();
 }


### PR DESCRIPTION
Fix to bug: [1576](https://dev.azure.com/spectrumFactory/CoronaI/_sprints/backlog/CoronaI%20Team/CoronaI/Sprint%2015?workitem=1576)

### The problem:
Once you added a family member as a contact in one event you could not add it in another event.

### The solution: 
Now you can add Family member as a contact in several events.
If you already added Family member as a contact in event when you edit the events contacts this family member will be disabled.

### Also in this PR:
*  Deleted console.log() calls.
*  Edit of DB function update_contact_person.sql so it will allow to add update_contact_person.