### PR TITLE
added break-word for long words in comment

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableRow/CommentCell/commentCellStyles.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableRow/CommentCell/commentCellStyles.ts
@@ -4,6 +4,7 @@ import theme from 'styles/theme';
 
 const useStyles = makeStyles(() => ({
     comment : {
+        overflowWrap: 'break-word',
         fontSize: '0.9rem',
         whiteSpace: 'normal',
         overflow: 'hidden',


### PR DESCRIPTION
# The Issue
if a SINGLE 45+ CHARECTER LONG WORD were to appear as the comment then it would be cut out,
by the way , the ONLY word that ever exist that is anywhere near this length is the 45 letter word [Pneumonoultramicroscopicsilicovolcanoconiosis ](https://en.wikipedia.org/wiki/Pneumonoultramicroscopicsilicovolcanoconiosis), and I doubt any one will ever use it as it is a synonym for scoliosis,
by the way the longest word in Hebrew is only 19 characters long (וכשלאנציקלופדיותינו) so I'm glad to know were safe on this side
# The solution
added `overflow-wrap : break word` to the comment field


EDIT: if the investigator is Icelandic he can write Vaðlaheiðarvegavinnuverkfærageymsluskúraútidyralyklakippuhringur which is 64 character long 