### PR TITLE
Group color revision

### DIFF
--- a/client/src/Utils/GroupedInvestigations/getColorByGroupId.ts
+++ b/client/src/Utils/GroupedInvestigations/getColorByGroupId.ts
@@ -1,0 +1,31 @@
+const squishNumber = (number : number) => {
+    // we want the color not to be really bright nor really dark
+    const minColorValue = 50;
+    const maxColorValue = 200;
+
+    /* 
+     * if the number's rgb value is too large or too small - 
+     * move it over to a normal value by adding or subtracting its diffrence from the allowed normal
+     * note that is does mean that the values 50-99 and 199-154 are more likely to appear than others (2 more times actually)
+     * I'll figure a way to address this inbalance in a next revision
+     */
+
+    if(number > maxColorValue) {
+        return maxColorValue - (255 - number);
+    } else if (number < minColorValue ) {
+        return minColorValue + (50 - number);
+    }
+    return number
+}
+
+const getColorByGroupId = (groupid : string) => {
+    const rnd = groupid.slice(-6);
+
+    // squish the color to a 'pretty' color - V.1
+    const red = squishNumber(parseInt(rnd.slice(0,2), 16));
+    const green = squishNumber(parseInt(rnd.slice(2,4), 16));
+    const blue = squishNumber(parseInt(rnd.slice(4,6), 16));
+    return (`rgb(${red}, ${green}, ${blue})`);
+}
+
+export default  getColorByGroupId;

--- a/client/src/Utils/GroupedInvestigations/getColorByGroupId.ts
+++ b/client/src/Utils/GroupedInvestigations/getColorByGroupId.ts
@@ -19,12 +19,12 @@ const squishNumber = (number : number) => {
 }
 
 const getColorByGroupId = (groupid : string) => {
-    const rnd = groupid.slice(-6);
+    const seed = groupid.slice(-6);
 
     // squish the color to a 'pretty' color - V.1
-    const red = squishNumber(parseInt(rnd.slice(0,2), 16));
-    const green = squishNumber(parseInt(rnd.slice(2,4), 16));
-    const blue = squishNumber(parseInt(rnd.slice(4,6), 16));
+    const red = squishNumber(parseInt(seed.slice(0,2), 16));
+    const green = squishNumber(parseInt(seed.slice(2,4), 16));
+    const blue = squishNumber(parseInt(seed.slice(4,6), 16));
     return (`rgb(${red}, ${green}, ${blue})`);
 }
 

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -23,6 +23,7 @@ import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
 import InvestigationTableRow from 'models/InvestigationTableRow';
 import InvestigationMainStatus from 'models/InvestigationMainStatus';
 import { setIsLoading } from 'redux/IsLoading/isLoadingActionCreators';
+import getColorByGroupId from 'Utils/GroupedInvestigations/getColorByGroupId';
 import InvestigationsFilterByFields from 'models/enums/InvestigationsFilterByFields';
 import InvestigationMainStatusCodes from 'models/enums/InvestigationMainStatusCodes';
 import { setLastOpenedEpidemiologyNum } from 'redux/Investigation/investigationActionCreators';
@@ -515,13 +516,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
                         investigationRows
                             .filter((row) => row.groupId !== null && !investigationColor.current.has(row.groupId))
                             .forEach((row) => {
-                                // We have this color range so the group colors aren't too dark nor bright
-                                const minColorValue = 50;
-                                const maxColorValue = 200;
-                                const red = getFlooredRandomNumber(minColorValue, maxColorValue);
-                                const green = getFlooredRandomNumber(minColorValue, maxColorValue);
-                                const blue = getFlooredRandomNumber(minColorValue, maxColorValue);
-                                investigationColor.current.set(row.groupId, `rgb(${red}, ${green}, ${blue})`);
+                                investigationColor.current.set(row.groupId, getColorByGroupId(row.groupId));
                             });
                         setRows(investigationRows);
                         setIsLoading(false);


### PR DESCRIPTION
this is the first version of the UUID to color function `getColorByGroupId`,
the function relies on the 6 last digits of the UUID (3 hex codes) and 'squishes' them to not be to dark or light while still maintaining a _fairly_ balanced color distribution