### PR TITLE
Contact Questioning Performance 

### DIFF
--- a/client/src/commons/NoContextElements/AlphanumericTextField.tsx
+++ b/client/src/commons/NoContextElements/AlphanumericTextField.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import * as yup from 'yup';
+
+import { ALPHANUMERIC_TEXT_REGEX } from 'commons/Regex/Regex';
+
+import TypePreventiveTextField from './TypingPreventionTextField';
+import AlphanumericTextFieldType from './AlphanumericTextFieldTypes';
+
+const errorMessage = 'השדה יכול להכיל רק אותיות ומספרים';
+const maxLengthErrorMessage = 'השדה יכול להכיל 50 תוים בלבד';
+
+export const stringAlphanum = yup
+  .string()
+  .matches(ALPHANUMERIC_TEXT_REGEX, errorMessage)
+  .max(50, maxLengthErrorMessage);
+
+
+const AlphanumericTextField: AlphanumericTextFieldType = (props) => {
+  return (
+    <TypePreventiveTextField
+        {...props}
+        error={'a'}
+        value={props.value || ''}
+        validationSchema={stringAlphanum}
+    />
+  );
+};
+
+export default AlphanumericTextField;

--- a/client/src/commons/NoContextElements/AlphanumericTextField.tsx
+++ b/client/src/commons/NoContextElements/AlphanumericTextField.tsx
@@ -19,7 +19,7 @@ const AlphanumericTextField: AlphanumericTextFieldType = (props) => {
   return (
     <TypePreventiveTextField
         {...props}
-        error={'a'}
+        error={props.error ?? ''}
         value={props.value || ''}
         validationSchema={stringAlphanum}
     />

--- a/client/src/commons/NoContextElements/AlphanumericTextFieldTypes.ts
+++ b/client/src/commons/NoContextElements/AlphanumericTextFieldTypes.ts
@@ -1,0 +1,20 @@
+import React from 'react';
+import { TextFieldProps } from '@material-ui/core';
+
+export interface AlphanumericTextFieldProps<T> {
+    testId?: string,
+    name: string,
+    value: T | null,
+    onChange: (value: string) => void,
+    onBlur?: (event: React.ChangeEvent<{}>) => void,
+    placeholder?: string,
+    label?: string,
+    error? : boolean,
+    className?: string,
+    disabled?: boolean,
+    InputProps?: TextFieldProps['InputProps'];
+}
+
+type AlphanumericTextFieldType = <T>(props: AlphanumericTextFieldProps<T>) => JSX.Element;
+
+export default AlphanumericTextFieldType;

--- a/client/src/commons/NoContextElements/AlphanumericTextFieldTypes.ts
+++ b/client/src/commons/NoContextElements/AlphanumericTextFieldTypes.ts
@@ -9,7 +9,7 @@ export interface AlphanumericTextFieldProps<T> {
     onBlur?: (event: React.ChangeEvent<{}>) => void,
     placeholder?: string,
     label?: string,
-    error? : boolean,
+    error? : string,
     className?: string,
     disabled?: boolean,
     InputProps?: TextFieldProps['InputProps'];

--- a/client/src/commons/NoContextElements/HebrewTextField.tsx
+++ b/client/src/commons/NoContextElements/HebrewTextField.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import * as yup from 'yup';
+
+import { HEBREW_TEXT_REGEX } from 'commons/Regex/Regex';
+
+import HebrewTextFieldType from './HebrewTextFieldTypes';
+import TypePreventiveTextField from './TypingPreventionTextField';
+
+const errorMessage = 'השדה יכול להכיל רק אותיות בעברית';
+const maxLengthErrorMessage = 'השדה יכול להכיל 50 אותיות בלבד';
+
+const stringHebrew = yup
+  .string()
+  .matches(HEBREW_TEXT_REGEX, errorMessage)
+  .max(50, maxLengthErrorMessage);
+
+
+const HebrewTextField: HebrewTextFieldType = (props) => {
+  return (
+    <TypePreventiveTextField
+        {...props}
+        error={props.error ?? ''}
+        value={props.value || ''}
+        validationSchema={stringHebrew}
+    />
+  );
+};
+
+export default HebrewTextField;

--- a/client/src/commons/NoContextElements/HebrewTextFieldTypes.tsx
+++ b/client/src/commons/NoContextElements/HebrewTextFieldTypes.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export interface HebrewTextFieldProps<T> {
+    testId?: string,
+    name: string,
+    value: T | null,
+    onChange: (value: string) => void,
+    onBlur?: (event: React.ChangeEvent<{}>) => void,
+    placeholder?: string,
+    label?: string,
+    error? : string,
+    className?: string,
+    disabled?: boolean,
+}
+
+type HebrewTextFieldType = <T>(props: HebrewTextFieldProps<T>) => JSX.Element;
+
+export default HebrewTextFieldType;

--- a/client/src/commons/NoContextElements/IdentificationTextField.tsx
+++ b/client/src/commons/NoContextElements/IdentificationTextField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {passportSchema , idSchema} from 'Utils/Schemas/identification';
-import TypePreventiveTextField from 'commons/TypingPreventionTextField/TypingPreventionTextField';
+import TypePreventiveTextField from './TypingPreventionTextField';
 
 const IdentificationTextField = (props : Props) => {
   const { isPassport } = props;
@@ -12,6 +12,7 @@ const IdentificationTextField = (props : Props) => {
   return (
     <TypePreventiveTextField
         {...props}
+        error={'e'}
         value={props.value || ''}
         validationSchema={schema}
     />

--- a/client/src/commons/NoContextElements/IdentificationTextField.tsx
+++ b/client/src/commons/NoContextElements/IdentificationTextField.tsx
@@ -12,7 +12,6 @@ const IdentificationTextField = (props : Props) => {
   return (
     <TypePreventiveTextField
         {...props}
-        error={'e'}
         value={props.value || ''}
         validationSchema={schema}
     />
@@ -29,7 +28,8 @@ interface Props{
     placeholder?: string,
     label?: string,
     className?: string,
-    isPassport: boolean
+    isPassport: boolean,
+    error: string
 }
 
 

--- a/client/src/commons/NoContextElements/NumericTextField.tsx
+++ b/client/src/commons/NoContextElements/NumericTextField.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import * as yup from 'yup';
+
+import { NUMERIC_TEXT_REGEX } from 'commons/Regex/Regex';
+
+import NumericTextFieldType from './NumericTextFieldTypes';
+import TypePreventiveTextField from './TypingPreventionTextField';
+
+const maxLengthErrorMessage = 'השדה יכול להכיל 10 מספרים בלבד';
+const alphabeticErrorMessage = 'השדה יכול להכיל מספרים בלבד';
+
+const stringAlphabet = yup.string().matches(NUMERIC_TEXT_REGEX, alphabeticErrorMessage).max(10, maxLengthErrorMessage);
+
+const NumericTextField: NumericTextFieldType = (props) => {
+
+  const { value } = props;
+
+  return (
+    <TypePreventiveTextField
+      {...props}
+      error={'o'}
+      value={value || ''}
+      validationSchema={stringAlphabet}
+    />
+  );
+};
+
+export default NumericTextField;

--- a/client/src/commons/NoContextElements/NumericTextField.tsx
+++ b/client/src/commons/NoContextElements/NumericTextField.tsx
@@ -13,12 +13,12 @@ const stringAlphabet = yup.string().matches(NUMERIC_TEXT_REGEX, alphabeticErrorM
 
 const NumericTextField: NumericTextFieldType = (props) => {
 
-  const { value } = props;
+  const { value, error } = props;
 
   return (
     <TypePreventiveTextField
       {...props}
-      error={'o'}
+      error={error ?? ''}
       value={value || ''}
       validationSchema={stringAlphabet}
     />

--- a/client/src/commons/NoContextElements/NumericTextFieldTypes.ts
+++ b/client/src/commons/NoContextElements/NumericTextFieldTypes.ts
@@ -7,7 +7,7 @@ export interface NumericTextFieldProps<T> {
     value: T | null,
     onChange: (value: string) => void,
     onBlur?: (event: React.ChangeEvent<{}>) => void,
-    error? : boolean,
+    error? : string,
     placeholder?: string,
     label?: string,
     className?: string,

--- a/client/src/commons/NoContextElements/NumericTextFieldTypes.ts
+++ b/client/src/commons/NoContextElements/NumericTextFieldTypes.ts
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export interface NumericTextFieldProps<T> {
+    disabled?: boolean,
+    testId?: string,
+    name: string,
+    value: T | null,
+    onChange: (value: string) => void,
+    onBlur?: (event: React.ChangeEvent<{}>) => void,
+    error? : boolean,
+    placeholder?: string,
+    label?: string,
+    className?: string,
+}
+
+type NumericTextFieldType = <T>(props: NumericTextFieldProps<T>) => JSX.Element;
+
+export default NumericTextFieldType;

--- a/client/src/commons/NoContextElements/TypingPreventionTextField.tsx
+++ b/client/src/commons/NoContextElements/TypingPreventionTextField.tsx
@@ -1,15 +1,10 @@
 import React, { useMemo } from 'react';
-import { ValidationError } from 'yup';
 import { TextField } from '@material-ui/core';
-import { useFormContext } from 'react-hook-form';
-
-import { get } from 'Utils/auxiliaryFunctions/auxiliaryFunctions';
 
 import TypePreventiveTextFieldType from './TypingPreventionTextFieldTypes';
 
 const TypePreventiveTextField: TypePreventiveTextFieldType = (props) => {
     const {  error, testId, name, onChange,  validationSchema,  label,...textFieldProps } = props;
-    //const { errors, setError, clearErrors } = useFormContext(); 
 
     const value = !props.value ? '' : props.value;
     
@@ -17,18 +12,12 @@ const TypePreventiveTextField: TypePreventiveTextFieldType = (props) => {
         const newValue = event.target.value;
         try {
             validationSchema.validateSync(newValue);
-            //learErrors(name);
+            
             onChange(newValue);
         } catch (error) {
-            //if (error instanceof ValidationError)
-            // setError(name, {
-            //     type: 'manual',
-            //     message: error.message,
-            // });
+
         }
     };
-
-    //const errorObject = get(errors, name);
 
     const getTextField = useMemo(() => {
         return (

--- a/client/src/commons/NoContextElements/TypingPreventionTextField.tsx
+++ b/client/src/commons/NoContextElements/TypingPreventionTextField.tsx
@@ -1,0 +1,53 @@
+import React, { useMemo } from 'react';
+import { ValidationError } from 'yup';
+import { TextField } from '@material-ui/core';
+import { useFormContext } from 'react-hook-form';
+
+import { get } from 'Utils/auxiliaryFunctions/auxiliaryFunctions';
+
+import TypePreventiveTextFieldType from './TypingPreventionTextFieldTypes';
+
+const TypePreventiveTextField: TypePreventiveTextFieldType = (props) => {
+    const {  error, testId, name, onChange,  validationSchema,  label,...textFieldProps } = props;
+    //const { errors, setError, clearErrors } = useFormContext(); 
+
+    const value = !props.value ? '' : props.value;
+    
+    const conditionalyTriggerOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const newValue = event.target.value;
+        try {
+            validationSchema.validateSync(newValue);
+            //learErrors(name);
+            onChange(newValue);
+        } catch (error) {
+            //if (error instanceof ValidationError)
+            // setError(name, {
+            //     type: 'manual',
+            //     message: error.message,
+            // });
+        }
+    };
+
+    //const errorObject = get(errors, name);
+
+    const getTextField = useMemo(() => {
+        return (
+            <TextField
+                test-id={testId}
+                name={name}
+                value={value}
+                onChange={conditionalyTriggerOnChange}
+                error={Boolean(error)}
+                label={error || label}
+                {...textFieldProps}
+            />
+        )
+
+    } , [value , name , error])
+    
+    return (
+        getTextField
+    );
+};
+
+export default TypePreventiveTextField;

--- a/client/src/commons/NoContextElements/TypingPreventionTextField.tsx
+++ b/client/src/commons/NoContextElements/TypingPreventionTextField.tsx
@@ -6,13 +6,12 @@ import TypePreventiveTextFieldType from './TypingPreventionTextFieldTypes';
 const TypePreventiveTextField: TypePreventiveTextFieldType = (props) => {
     const {  error, testId, name, onChange,  validationSchema,  label,...textFieldProps } = props;
 
-    const value = !props.value ? '' : props.value;
+    const value = props.value ?? '';
     
     const conditionalyTriggerOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         const newValue = event.target.value;
         try {
             validationSchema.validateSync(newValue);
-            
             onChange(newValue);
         } catch (error) {
 

--- a/client/src/commons/NoContextElements/TypingPreventionTextFieldTypes.ts
+++ b/client/src/commons/NoContextElements/TypingPreventionTextFieldTypes.ts
@@ -1,0 +1,26 @@
+import React from 'react';
+import * as yup from 'yup';
+import {TextFieldProps} from '@material-ui/core';
+
+export interface TypePreventiveTextFieldProps<T> {
+    disabled?: boolean,
+    testId?: string,
+    name: string,
+    value: T | null,
+    onChange: (value: string) => void,
+    onBlur?: (event: React.ChangeEvent<{}>) => void,
+    validationSchema: yup.StringSchema<string | undefined, object>
+    placeholder?: string,
+    label?: string,
+    className?: string,
+    multiline?: TextFieldProps['multiline'];
+    fullWidth?: TextFieldProps['fullWidth'];
+    inputProps?: TextFieldProps['inputProps'];
+    InputProps?: TextFieldProps['InputProps'];
+    onKeyDown? : (e : React.KeyboardEvent) => void;
+    InputLabelProps?: TextFieldProps['InputLabelProps'];
+    error: string;
+}
+
+type TypePreventiveTextFieldType = <T>(props: TypePreventiveTextFieldProps<T>) => JSX.Element;
+export default TypePreventiveTextFieldType;

--- a/client/src/commons/TypingPreventionTextField/TypingPreventionTextField.tsx
+++ b/client/src/commons/TypingPreventionTextField/TypingPreventionTextField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { ValidationError } from 'yup';
 import { TextField } from '@material-ui/core';
 import { useFormContext } from 'react-hook-form';
@@ -30,16 +30,23 @@ const TypePreventiveTextField: TypePreventiveTextFieldType = (props) => {
 
     const errorObject = get(errors, name);
 
+    const getTextField = useMemo(() => {
+        return (
+            <TextField
+                test-id={testId}
+                name={name}
+                value={value}
+                onChange={conditionalyTriggerOnChange}
+                error={errorObject ? true : false}
+                label={errorObject ? errorObject.message : label}
+                {...textFieldProps}
+            />
+        )
+
+    } , [value , name , errorObject])
+    
     return (
-        <TextField
-            test-id={testId}
-            name={name}
-            value={value}
-            onChange={conditionalyTriggerOnChange}
-            error={errorObject ? true : false}
-            label={errorObject ? errorObject.message : label}
-            {...textFieldProps}
-        />
+        getTextField
     );
 };
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningCheck.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningCheck.tsx
@@ -23,7 +23,7 @@ import { OCCUPATION_LABEL, RELEVANT_OCCUPATION_LABEL } from '../PersonalInfoTab/
 
 const ContactQuestioningCheck: React.FC<Props> = (props: Props): JSX.Element => {
     const {formErrors , contactStatus , control} = props;
-    console.log('cqc rerendered', formErrors);
+
     const classes = useStyles();
 
     const occupations = useSelector<StoreStateType , string[]>(state => state.occupations);

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningCheck.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningCheck.tsx
@@ -22,15 +22,14 @@ import useStyles from './ContactQuestioningStyles';
 import { OCCUPATION_LABEL, RELEVANT_OCCUPATION_LABEL } from '../PersonalInfoTab/PersonalInfoTab';
 
 const ContactQuestioningCheck: React.FC<Props> = (props: Props): JSX.Element => {
-    const {control , getValues} = useFormContext();
-
+    const {formErrors , contactStatus , control} = props;
+    console.log('cqc rerendered', formErrors);
     const classes = useStyles();
 
     const occupations = useSelector<StoreStateType , string[]>(state => state.occupations);
     const { index , interactedContact } = props;
 
-    const formValues = getValues().form ? getValues().form[index] : interactedContact
-    const { isFieldDisabled } = useContactFields(formValues.contactStatus);
+    const { isFieldDisabled } = useContactFields(contactStatus);
 
     return (
         <Grid item xs={4}>
@@ -210,4 +209,7 @@ export default ContactQuestioningCheck;
 interface Props {
     index: number,
     interactedContact: InteractedContact;
+    formErrors: any;
+    control: any;
+    contactStatus: number;
 };

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningClinical.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningClinical.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { addDays, format } from 'date-fns';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller, DeepMap, FieldError } from 'react-hook-form';
 import { Avatar, FormControl, Grid, MenuItem, Select, Typography } from '@material-ui/core';
 
 import theme from 'styles/theme';
@@ -11,7 +11,7 @@ import FamilyRelationship from 'models/FamilyRelationship';
 import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
 import useStatusUtils from 'Utils/StatusUtils/useStatusUtils';
 import InteractedContactFields from 'models/enums/InteractedContact';
-import HebrewTextField from 'commons/HebrewTextField/HebrewTextField';
+import HebrewTextField from 'commons/NoContextElements/HebrewTextField';
 import AddressForm, { AddressFormFields } from 'commons/Forms/AddressForm/AddressForm';
 import useContactFields, { ValidationReason } from 'Utils/Contacts/useContactFields';
 import AlphanumericTextField from 'commons/AlphanumericTextField/AlphanumericTextField';
@@ -24,8 +24,8 @@ const emptyFamilyRelationship: FamilyRelationship = {
 };
 
 const ContactQuestioningClinical: React.FC<Props> = (props: Props): JSX.Element => {
-    const { control , getValues , errors, setValue } = useFormContext();
-    const { index, familyRelationships, interactedContact, isFamilyContact } = props;
+    const { index, familyRelationships, interactedContact, isFamilyContact, 
+            control, formValues, formErrors } = props;
 
     const classes = useStyles();
 
@@ -35,7 +35,7 @@ const ContactQuestioningClinical: React.FC<Props> = (props: Props): JSX.Element 
 
     const { alertError, alertWarning } = useCustomSwal();
 
-    const formValues = getValues().form ? getValues().form[index] : interactedContact;
+    //const formValues = getValues().form ? getValues().form[index] : interactedContact;
     const { isFieldDisabled, validateContact } = useContactFields(formValues.contactStatus);
     
     const daysToIsolate = 14;
@@ -75,11 +75,9 @@ const ContactQuestioningClinical: React.FC<Props> = (props: Props): JSX.Element 
     }
 
     const isIdAndPhoneNumValid = (): boolean => {
-        const formErrors = errors.form;
         if (formErrors) {
-            const currentFormErrors = formErrors[index];
-            if (currentFormErrors) {
-                return Boolean(formErrors[index].id) || Boolean(formErrors[index].phoneNumber)
+            if (formErrors) {
+                return Boolean(formErrors.id) || Boolean(formErrors.phoneNumber)
             }
         }
         return true;
@@ -164,6 +162,7 @@ const ContactQuestioningClinical: React.FC<Props> = (props: Props): JSX.Element 
                                 return (
                                     <HebrewTextField
                                         {...props}
+                                        error={formErrors && formErrors[InteractedContactFields.ADDITIONAL_PHONE_NUMBER]?.message}
                                         disabled={isFieldDisabled}
                                         testId='relationship'
                                         onChange={(newValue: string) => {
@@ -258,6 +257,10 @@ export default ContactQuestioningClinical;
 interface Props {
     index: number;
     familyRelationships: FamilyRelationship[];
+    //TODO : figure out why InteractedContact exists in the first place
     interactedContact: InteractedContact;
     isFamilyContact: boolean;
+    control: any;
+    formValues: InteractedContact;
+    formErrors?: DeepMap<InteractedContact, FieldError>;
 };

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningClinical.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningClinical.tsx
@@ -35,7 +35,6 @@ const ContactQuestioningClinical: React.FC<Props> = (props: Props): JSX.Element 
 
     const { alertError, alertWarning } = useCustomSwal();
 
-    //const formValues = getValues().form ? getValues().form[index] : interactedContact;
     const { isFieldDisabled, validateContact } = useContactFields(formValues.contactStatus);
     
     const daysToIsolate = 14;
@@ -257,7 +256,6 @@ export default ContactQuestioningClinical;
 interface Props {
     index: number;
     familyRelationships: FamilyRelationship[];
-    //TODO : figure out why InteractedContact exists in the first place
     interactedContact: InteractedContact;
     isFamilyContact: boolean;
     control: any;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningClinical.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningClinical.tsx
@@ -205,7 +205,7 @@ const ContactQuestioningClinical: React.FC<Props> = (props: Props): JSX.Element 
                                                 props.onChange(booleanValue);
                                             }
                                         }
-                                        } />
+                                    } />
                                 )
                             }}
                         />

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
@@ -27,6 +27,7 @@ const idInfoMessage = 'ניתן להזין בשדה תז עד 9 תווים'
 const ContactQuestioningPersonal: React.FC<Props> = (
     props: Props
 ): JSX.Element => {
+    // TODO : find a way to seperate those fields outward to Accordion - so we can selectivly render them
     const { control, getValues , errors, trigger} = useFormContext();
     const { index, interactedContact } = props;
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
@@ -28,10 +28,10 @@ const ContactQuestioningPersonal: React.FC<Props> = (
     props: Props
 ): JSX.Element => {
     // TODO : find a way to seperate those fields outward to Accordion - so we can selectivly render them
-    const { control, getValues , errors, trigger} = useFormContext();
-    const { index, interactedContact } = props;
+    //const { control, getValues , errors, trigger} = useFormContext();
+    const { index, interactedContact, currentFormErrors, formValues, control, trigger } = props;
 
-    const currentFormErrors = errors?.form && errors?.form[index];
+    //const currentFormErrors = errors?.form && errors?.form[index];
     
     const calcAge = (birthDate: Date) => {
         const newAge: number = differenceInYears(new Date(),new Date(birthDate));
@@ -45,9 +45,9 @@ const ContactQuestioningPersonal: React.FC<Props> = (
     const [shouldIdDisable, setShouldIdDisable] = useState<boolean>(false);
     const [age, setAge] = useState<string>(calcAge(interactedContact.birthDate));
 
-    const formValues = getValues().form
-        ? getValues().form[index]
-        : interactedContact;
+    // const formValues = getValues().form
+    //     ? getValues().form[index]
+    //     : interactedContact;
     const { isFieldDisabled } = useContactFields(formValues.contactStatus);
     const [isPassport, setIsPassport] = useState<boolean>(
         formValues.identificationType === IdentificationTypes.PASSPORT
@@ -266,4 +266,8 @@ export default ContactQuestioningPersonal;
 interface Props {
     index: number;
     interactedContact: GroupedInteractedContact;
+    control: any;
+    formValues: any;
+    trigger: (fieldname : string) => {};
+    currentFormErrors: any;
 }

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
@@ -13,8 +13,8 @@ import useContactFields from 'Utils/Contacts/useContactFields';
 import useStatusUtils from 'Utils/StatusUtils/useStatusUtils';
 import IdentificationTypes from 'models/enums/IdentificationTypes';
 import InteractedContactFields from 'models/enums/InteractedContact';
-import NumericTextField from 'commons/NumericTextField/NumericTextField';
-import AlphanumericTextField from 'commons/AlphanumericTextField/AlphanumericTextField';
+import NumericTextField from 'commons/NoContextElements/NumericTextField';
+import AlphanumericTextField from 'commons/NoContextElements/AlphanumericTextField';
 import IdentificationTextField from 'commons/NoContextElements/IdentificationTextField';
 
 import useStyles from './ContactQuestioningStyles';

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
@@ -15,7 +15,7 @@ import IdentificationTypes from 'models/enums/IdentificationTypes';
 import InteractedContactFields from 'models/enums/InteractedContact';
 import NumericTextField from 'commons/NumericTextField/NumericTextField';
 import AlphanumericTextField from 'commons/AlphanumericTextField/AlphanumericTextField';
-import IdentificationTextField from 'commons/IdentificationTextField/IdentificationTextField';
+import IdentificationTextField from 'commons/NoContextElements/IdentificationTextField';
 
 import useStyles from './ContactQuestioningStyles';
 import { ADDITIONAL_PHONE_LABEL } from '../PersonalInfoTab/PersonalInfoTab';

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
@@ -136,6 +136,7 @@ const ContactQuestioningPersonal: React.FC<Props> = (
                                 return (
                                     <IdentificationTextField
                                         {...props}
+                                        error={currentFormErrors && currentFormErrors[InteractedContactFields.IDENTIFICATION_NUMBER]?.message}
                                         isPassport={isPassport}
                                         disabled={shouldIdDisable}
                                         testId='identificationNumber'
@@ -198,6 +199,7 @@ const ContactQuestioningPersonal: React.FC<Props> = (
                             return (
                                 <NumericTextField
                                     {...props}
+                                    error={currentFormErrors && currentFormErrors[InteractedContactFields.PHONE_NUMBER]?.message}
                                     disabled={isFieldDisabled}
                                     testId='phoneNumber'
                                     placeholder='הכנס טלפון:'
@@ -217,6 +219,7 @@ const ContactQuestioningPersonal: React.FC<Props> = (
                                 <NumericTextField
                                     {...props}
                                     disabled={isFieldDisabled}
+                                    error={currentFormErrors && currentFormErrors[InteractedContactFields.ADDITIONAL_PHONE_NUMBER]?.message}
                                     testId='additionalPhoneNumber'
                                     onChange={(newValue: string) => {
                                         props.onChange(newValue);

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
@@ -1,7 +1,7 @@
 import { differenceInYears } from 'date-fns';
 import React, { useState, useEffect } from 'react';
-import { Controller, useFormContext } from 'react-hook-form';
 import { Avatar, Grid, Typography } from '@material-ui/core';
+import { Controller, DeepMap, FieldError } from 'react-hook-form';
 
 import Toggle from 'commons/Toggle/Toggle';
 import DatePick from 'commons/DatePick/DatePick';
@@ -27,11 +27,7 @@ const idInfoMessage = 'ניתן להזין בשדה תז עד 9 תווים'
 const ContactQuestioningPersonal: React.FC<Props> = (
     props: Props
 ): JSX.Element => {
-    // TODO : find a way to seperate those fields outward to Accordion - so we can selectivly render them
-    //const { control, getValues , errors, trigger} = useFormContext();
     const { index, interactedContact, currentFormErrors, formValues, control, trigger } = props;
-
-    //const currentFormErrors = errors?.form && errors?.form[index];
     
     const calcAge = (birthDate: Date) => {
         const newAge: number = differenceInYears(new Date(),new Date(birthDate));
@@ -45,9 +41,6 @@ const ContactQuestioningPersonal: React.FC<Props> = (
     const [shouldIdDisable, setShouldIdDisable] = useState<boolean>(false);
     const [age, setAge] = useState<string>(calcAge(interactedContact.birthDate));
 
-    // const formValues = getValues().form
-    //     ? getValues().form[index]
-    //     : interactedContact;
     const { isFieldDisabled } = useContactFields(formValues.contactStatus);
     const [isPassport, setIsPassport] = useState<boolean>(
         formValues.identificationType === IdentificationTypes.PASSPORT
@@ -120,7 +113,7 @@ const ContactQuestioningPersonal: React.FC<Props> = (
                             <HelpIcon 
                                 title={idTooltipText} 
                                 isWarning={
-                                    currentFormErrors && currentFormErrors[InteractedContactFields.IDENTIFICATION_NUMBER]
+                                    Boolean(currentFormErrors && currentFormErrors[InteractedContactFields.IDENTIFICATION_NUMBER])
                                 } 
                             />
                         }
@@ -137,7 +130,7 @@ const ContactQuestioningPersonal: React.FC<Props> = (
                                 return (
                                     <IdentificationTextField
                                         {...props}
-                                        error={currentFormErrors && currentFormErrors[InteractedContactFields.IDENTIFICATION_NUMBER]?.message}
+                                        error={(currentFormErrors && currentFormErrors[InteractedContactFields.IDENTIFICATION_NUMBER]?.message ) || ''}
                                         isPassport={isPassport}
                                         disabled={shouldIdDisable}
                                         testId='identificationNumber'
@@ -267,7 +260,7 @@ interface Props {
     index: number;
     interactedContact: GroupedInteractedContact;
     control: any;
-    formValues: any;
+    formValues: InteractedContact;
     trigger: (fieldname : string) => {};
-    currentFormErrors: any;
+    currentFormErrors?: DeepMap<InteractedContact, FieldError>;
 }

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/InteractedContactAccordion.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/InteractedContactAccordion.tsx
@@ -17,6 +17,7 @@ import PrimaryButton from 'commons/Buttons/PrimaryButton/PrimaryButton';
 import GroupedInteractedContact from 'models/ContactQuestioning/GroupedInteractedContact';
 
 import useStyles from './ContactQuestioningStyles';
+import { FormInputs } from './ContactQuestioningInterfaces';
 import ContactQuestioningInfo from './ContactQuestioningInfo';
 import ContactQuestioningCheck from './ContactQuestioningCheck';
 import ContactQuestioningPersonal from './ContactQuestioningPersonal';
@@ -24,7 +25,7 @@ import ContactQuestioningClinical from './ContactQuestioningClinical';
 import InteractedContactFields from 'models/enums/InteractedContact';
 
 const InteractedContactAccordion = (props: Props) => {
-    const {errors, watch, ...methods} = useFormContext();
+    const {errors, watch, ...methods} = useFormContext<FormInputs>();
 
     const classes = useStyles();
 
@@ -39,23 +40,23 @@ const InteractedContactAccordion = (props: Props) => {
         shouldDisable,
     } = props;
 
-    const watchCurrentStatus = watch(`form[${index}].${InteractedContactFields.CONTACT_STATUS}`)
+    const watchCurrentStatus: number = watch(`form[${index}].${InteractedContactFields.CONTACT_STATUS}`)
 
-    const formErrors = errors.form ? (errors.form[index] ? errors.form[index] : {}) : {};
+    const formErrors = errors?.form && errors?.form[index];
 
     const getAccordionClasses = () : string => {
         let classesList : string[] = [];
         classesList.push(classes.accordion);
 
-        const formHasErrors = Object.entries(formErrors)
+        const formHasErrors = Object.entries(formErrors || {})
             .some(([key, value]) => (
                 value !== undefined
             ));
     
         if(formHasErrors) {
-            classesList.push(classes.errorAccordion)
+            classesList.push(classes.errorAccordion);
         }
-        return classesList.join(" ")
+        return classesList.join(" ");
     }
 
     const formValues = methods.getValues().form
@@ -127,7 +128,7 @@ const InteractedContactAccordion = (props: Props) => {
                             test-id='saveContact'
                             onClick={() => {
                                 const currentParsedPerson = parsePerson(
-                                    methods.getValues().form[index],
+                                    methods.getValues().form[index] as GroupedInteractedContact,
                                     index
                                 );
                                 saveContact(currentParsedPerson);

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/InteractedContactAccordion.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/InteractedContactAccordion.tsx
@@ -56,75 +56,84 @@ const InteractedContactAccordion = (props: Props) => {
         return classesList.join(" ")
     }
 
+    const formValues = methods.getValues().form
+        ? JSON.stringify(methods.getValues().form[index])
+        : interactedContact;
+
+    const getAccordion = React.useMemo(() => {
+        return (
+            <div key={interactedContact.id}>
+                <Accordion
+                    className={getAccordionClasses()}
+                    style={{ borderRadius: '3vw' }}
+                >
+                    <AccordionSummary
+                        test-id='contactLocation'
+                        expandIcon={<ExpandMore />}
+                        aria-controls='panel1a-content'
+                        id='panel1a-header'
+                        dir='ltr'
+                    >
+                        <ContactQuestioningInfo
+                            index={index}
+                            interactedContact={interactedContact}
+                            contactStatuses={contactStatuses}
+                            saveContact={saveContact}
+                            parsePerson={parsePerson}
+                        />
+                    </AccordionSummary>
+                    <AccordionDetails>
+                        <Grid container justify='space-evenly'>
+                            <ContactQuestioningPersonal
+                                index={index}
+                                interactedContact={interactedContact}
+                            />
+                            <Divider
+                                orientation='vertical'
+                                variant='middle'
+                                light={true}
+                            />
+                            <ContactQuestioningClinical
+                                index={index}
+                                familyRelationships={
+                                    familyRelationships as FamilyRelationship[]
+                                }
+                                interactedContact={interactedContact}
+                                isFamilyContact={isFamilyContact}
+                            />
+                            <Divider
+                                orientation='vertical'
+                                variant='middle'
+                                light={true}
+                            />
+                            <ContactQuestioningCheck
+                                index={index}
+                                interactedContact={interactedContact}
+                            />
+                        </Grid>
+                    </AccordionDetails>
+                    <AccordionActions className={classes.accordionActions}>
+                        <PrimaryButton
+                            disabled={shouldDisable(watchCurrentStatus)}
+                            test-id='saveContact'
+                            onClick={() => {
+                                const currentParsedPerson = parsePerson(
+                                    methods.getValues().form[index],
+                                    index
+                                );
+                                saveContact(currentParsedPerson);
+                            }}
+                        >
+                            שמור מגע
+                        </PrimaryButton>
+                    </AccordionActions>
+                </Accordion>
+            </div>
+        )    
+    } , [formValues]);
 
     return (
-        <div key={interactedContact.id}>
-            <Accordion
-                className={getAccordionClasses()}
-                style={{ borderRadius: '3vw' }}
-            >
-                <AccordionSummary
-                    test-id='contactLocation'
-                    expandIcon={<ExpandMore />}
-                    aria-controls='panel1a-content'
-                    id='panel1a-header'
-                    dir='ltr'
-                >
-                    <ContactQuestioningInfo
-                        index={index}
-                        interactedContact={interactedContact}
-                        contactStatuses={contactStatuses}
-                        saveContact={saveContact}
-                        parsePerson={parsePerson}
-                    />
-                </AccordionSummary>
-                <AccordionDetails>
-                    <Grid container justify='space-evenly'>
-                        <ContactQuestioningPersonal
-                            index={index}
-                            interactedContact={interactedContact}
-                        />
-                        <Divider
-                            orientation='vertical'
-                            variant='middle'
-                            light={true}
-                        />
-                        <ContactQuestioningClinical
-                            index={index}
-                            familyRelationships={
-                                familyRelationships as FamilyRelationship[]
-                            }
-                            interactedContact={interactedContact}
-                            isFamilyContact={isFamilyContact}
-                        />
-                        <Divider
-                            orientation='vertical'
-                            variant='middle'
-                            light={true}
-                        />
-                        <ContactQuestioningCheck
-                            index={index}
-                            interactedContact={interactedContact}
-                        />
-                    </Grid>
-                </AccordionDetails>
-                <AccordionActions className={classes.accordionActions}>
-                    <PrimaryButton
-                        disabled={shouldDisable(watchCurrentStatus)}
-                        test-id='saveContact'
-                        onClick={() => {
-                            const currentParsedPerson = parsePerson(
-                                methods.getValues().form[index],
-                                index
-                            );
-                            saveContact(currentParsedPerson);
-                        }}
-                    >
-                        שמור מגע
-                    </PrimaryButton>
-                </AccordionActions>
-            </Accordion>
-        </div>
+        getAccordion
     );
 };
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/InteractedContactAccordion.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/InteractedContactAccordion.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { ExpandMore } from '@material-ui/icons';
 import { useFormContext } from 'react-hook-form';
 import {
@@ -25,6 +25,7 @@ import InteractedContactFields from 'models/enums/InteractedContact';
 
 const InteractedContactAccordion = (props: Props) => {
     const {errors, watch, ...methods} = useFormContext();
+
     const classes = useStyles();
 
     const {
@@ -40,11 +41,12 @@ const InteractedContactAccordion = (props: Props) => {
 
     const watchCurrentStatus = watch(`form[${index}].${InteractedContactFields.CONTACT_STATUS}`)
 
+    const formErrors = errors.form ? (errors.form[index] ? errors.form[index] : {}) : {};
+
     const getAccordionClasses = () : string => {
         let classesList : string[] = [];
         classesList.push(classes.accordion);
 
-        const formErrors = errors.form ? (errors.form[index] ? errors.form[index] : {}) : {};
         const formHasErrors = Object.entries(formErrors)
             .some(([key, value]) => (
                 value !== undefined
@@ -109,6 +111,9 @@ const InteractedContactAccordion = (props: Props) => {
                             <ContactQuestioningCheck
                                 index={index}
                                 interactedContact={interactedContact}
+                                formErrors={formErrors}
+                                control={methods.control}
+                                contactStatus={watchCurrentStatus}
                             />
                         </Grid>
                     </AccordionDetails>
@@ -129,7 +134,7 @@ const InteractedContactAccordion = (props: Props) => {
                     </AccordionActions>
                 </Accordion>
             </div>
-        )    
+        )
     } , [formValues]);
 
     return (

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/InteractedContactAccordion.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/InteractedContactAccordion.tsx
@@ -59,7 +59,7 @@ const InteractedContactAccordion = (props: Props) => {
     }
 
     const formValues = methods.getValues().form
-        ? JSON.stringify(methods.getValues().form[index])
+        ? methods.getValues().form[index]
         : interactedContact;
 
     const getAccordion = React.useMemo(() => {
@@ -89,6 +89,10 @@ const InteractedContactAccordion = (props: Props) => {
                             <ContactQuestioningPersonal
                                 index={index}
                                 interactedContact={interactedContact}
+                                control={methods.control}
+                                formValues={formValues}
+                                trigger={methods.trigger}
+                                currentFormErrors={formErrors}
                             />
                             <Divider
                                 orientation='vertical'
@@ -135,7 +139,7 @@ const InteractedContactAccordion = (props: Props) => {
                 </Accordion>
             </div>
         )
-    } , [formValues]);
+    } , [JSON.stringify(formValues)]);
 
     return (
         getAccordion

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/InteractedContactAccordion.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/InteractedContactAccordion.tsx
@@ -47,11 +47,13 @@ const InteractedContactAccordion = (props: Props) => {
     const getAccordionClasses = () : string => {
         let classesList : string[] = [];
         classesList.push(classes.accordion);
-
-        const formHasErrors = Object.entries(formErrors || {})
-            .some(([key, value]) => (
-                value !== undefined
-            ));
+        
+        const formHasErrors = formErrors 
+            ? Object.entries(formErrors)
+                .some(([key, value]) => (
+                    value !== undefined
+                ))
+            : false
     
         if(formHasErrors) {
             classesList.push(classes.errorAccordion);
@@ -107,6 +109,9 @@ const InteractedContactAccordion = (props: Props) => {
                                 }
                                 interactedContact={interactedContact}
                                 isFamilyContact={isFamilyContact}
+                                control={methods.control}
+                                formValues={formValues}
+                                formErrors={formErrors}
                             />
                             <Divider
                                 orientation='vertical'


### PR DESCRIPTION
This PR includes HUGE (10x from ~600ms/character to ~60ms!) performance boosts to ContactQuestioning.tsx

# The problem
So the problem was rooted within the context - more specifically within `TypePreventiveTextField` and other uses of it
When a member is subscribed to the form context - it will always re-render whenever the context will change - **even if the item is wrapped inside a memorized field** - from what I can see - I think that that there are 2 major problems in  `TypePreventiveTextField` :
1. The `get` function -  to get the current field's appropriate error it takes all existing errors from the state and filters them until it gets the current fields one - this happends every time every field changed (formProvider)
2. The `setError/clearErrors` functions - these functions edited the 'error' fieid and caused the provider to change (triggering a re-render the the entire dependent tree)

# The solution
In order to maintain the rest of the project's usability I've decided to create new versions of  `TypePreventiveTextField` and variations of it that do not use form context but instead get the error as a prop.
Also I've memoized each accordion ( by if the accordion's values have changed ) - and removed context use from each accordion's sub-category.

note : it seemed that AddressForm still uses context but it does not hurt the performance (prob beacuse it doesn't use textfield) so I've decided to keep it as is