### PR TITLE
matched color generating method to hash

### DIFF
--- a/client/src/Utils/GroupedInvestigations/getColorByGroupId.ts
+++ b/client/src/Utils/GroupedInvestigations/getColorByGroupId.ts
@@ -18,8 +18,10 @@ const squishNumber = (number : number) => {
     return number
 }
 
-const getColorByGroupId = (groupid : string) => {
-    const seed = groupid.slice(0,6);
+const hashString = (s : string) => Math.abs(s.split('').reduce((a,b) => (((a << 5) - a) + b.charCodeAt(0))|0, 0)).toString(16)
+
+const getColorByGroupId = (groupid : string) => { 
+    const seed = hashString(groupid);
 
     // squish the color to a 'pretty' color - V.1
     const red = squishNumber(parseInt(seed.slice(0,2), 16));

--- a/client/src/Utils/GroupedInvestigations/getColorByGroupId.ts
+++ b/client/src/Utils/GroupedInvestigations/getColorByGroupId.ts
@@ -19,7 +19,7 @@ const squishNumber = (number : number) => {
 }
 
 const getColorByGroupId = (groupid : string) => {
-    const seed = groupid.slice(-6);
+    const seed = groupid.slice(0,6);
 
     // squish the color to a 'pretty' color - V.1
     const red = squishNumber(parseInt(seed.slice(0,2), 16));


### PR DESCRIPTION
This is just some random UUID's that were sent by MOH I've collected from Production : 
![image](https://user-images.githubusercontent.com/68457306/110795430-7fb5a400-827f-11eb-8e15-a60cdf8218e7.png)
from what I'm seeing the UUID that MOH sends are probably a variation ([see more](https://en.wikipedia.org/wiki/Universally_unique_identifier#Format)) of UUID 1 (which is HIGHLY insecure - because it reveals MOH's server's MAC address (00:50:56:84:25:5c probably (it's a [valid](http://sqa.fyicenter.com/1000208_MAC_Address_Validator.html) mac address))

but with UUID1 the first few digits are _farily_ random so I'm hoping that this method will prove itself somewhat effective