### PR TITLE
Default values - tab managment

### DIFF
--- a/client/src/commons/InlineErrorText/InlineErrorText.tsx
+++ b/client/src/commons/InlineErrorText/InlineErrorText.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import {Typography} from '@material-ui/core'; 
+
+import useStyles from './inlineErrorTextStyles';
+
+const InlineErrorText = (props: Props) => {
+    const { error } = props;
+    const classes = useStyles();
+
+    return (
+        <>
+            {error && <Typography className={classes.text}>*{error.message}</Typography>}
+        </>
+    )
+}
+
+interface Props {
+    error? : {
+        type: string,
+        message: string,
+    };    
+}
+
+export default InlineErrorText;

--- a/client/src/commons/InlineErrorText/inlineErrorTextStyles.ts
+++ b/client/src/commons/InlineErrorText/inlineErrorTextStyles.ts
@@ -1,0 +1,10 @@
+import { Theme } from '@material-ui/core';
+import { makeStyles } from '@material-ui/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+    text: {
+        color: theme.palette.error.main
+    }
+}));
+
+export default useStyles;

--- a/client/src/commons/InlineErrorText/inlineErrorTextStyles.ts
+++ b/client/src/commons/InlineErrorText/inlineErrorTextStyles.ts
@@ -3,7 +3,8 @@ import { makeStyles } from '@material-ui/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
     text: {
-        color: theme.palette.error.main
+        color: theme.palette.error.main,
+        display: 'inline'
     }
 }));
 

--- a/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigationInfoBar.tsx
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigationInfoBar.tsx
@@ -71,7 +71,7 @@ const InvestigationInfoBar: React.FC<Props> = ({ currentTab }: Props) => {
             setEpidemiologyNum(lastOpenedEpidemiologyNumber);
             setLastOpenedEpidemiologyNum(defaultEpidemiologyNumber);
         } else {
-            handleInvalidEntrance();
+            //handleInvalidEntrance();
         }
     }, []);
 

--- a/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigationInfoBar.tsx
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigationInfoBar.tsx
@@ -71,7 +71,7 @@ const InvestigationInfoBar: React.FC<Props> = ({ currentTab }: Props) => {
             setEpidemiologyNum(lastOpenedEpidemiologyNumber);
             setLastOpenedEpidemiologyNum(defaultEpidemiologyNumber);
         } else {
-            //handleInvalidEntrance();
+            handleInvalidEntrance();
         }
     }, []);
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/BackgroundDiseasesFields.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/BackgroundDiseasesFields.tsx
@@ -4,6 +4,7 @@ import { Collapse, Grid, Typography } from '@material-ui/core';
 
 import Toggle from 'commons/Toggle/Toggle';
 import CustomCheckbox from 'commons/CheckBox/CustomCheckbox';
+import InlineErrorText from 'commons/InlineErrorText/InlineErrorText';
 import ClinicalDetailsFields from 'models/enums/ClinicalDetailsFields';
 import FormRowWithInput from 'commons/FormRowWithInput/FormRowWithInput';
 import AlphanumericTextField from 'commons/AlphanumericTextField/AlphanumericTextField';
@@ -40,6 +41,9 @@ const BackgroundDiseasesFields: React.FC<Props> = (props: Props): JSX.Element =>
                                 }}
                             />
                         )}
+                    />
+                    <InlineErrorText 
+                        error={errors[ClinicalDetailsFields.DOES_HAVE_BACKGROUND_DISEASES]}
                     />
                 </Grid>
             </FormRowWithInput>

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/ClinicalDetailsSchema.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/ClinicalDetailsSchema.ts
@@ -84,7 +84,7 @@ const ClinicalDetailsSchema = (validationDate: Date) => yup.object().shape({
         [ClinicalDetailsFields.ISOLATION_FLOOR]: yup.string().nullable(),
         [ClinicalDetailsFields.ISOLATION_HOUSE_NUMBER]: yup.string().nullable()
     }).required(),
-    [ClinicalDetailsFields.IS_IN_ISOLATION]: yup.boolean().nullable().required(),
+    [ClinicalDetailsFields.IS_IN_ISOLATION]: yup.boolean().nullable(),
     [ClinicalDetailsFields.ISOLATION_START_DATE]: isInIsolationStartDateSchema(validationDate),
     [ClinicalDetailsFields.ISOLATION_END_DATE]: isInIsolationEndDateSchema(validationDate),
     [ClinicalDetailsFields.ISOLATION_SOURCE]: yup.number().when(
@@ -94,14 +94,14 @@ const ClinicalDetailsSchema = (validationDate: Date) => yup.object().shape({
             otherwise: yup.number().nullable()
         }
     ),
-    [ClinicalDetailsFields.IS_ISOLATION_PROBLEM]: yup.boolean().nullable().required(),
+    [ClinicalDetailsFields.IS_ISOLATION_PROBLEM]: yup.boolean().required(requiredText).nullable(),
     [ClinicalDetailsFields.IS_ISOLATION_PROBLEM_MORE_INFO]: yup.string().when(
         ClinicalDetailsFields.IS_ISOLATION_PROBLEM, {
             is: true,
             then: yup.string().required(requiredText),
             otherwise: yup.string().nullable()
         }),
-    [ClinicalDetailsFields.DOES_HAVE_SYMPTOMS]: yup.boolean().nullable().required(),
+    [ClinicalDetailsFields.DOES_HAVE_SYMPTOMS]: yup.boolean().required(requiredText).nullable(),
     [ClinicalDetailsFields.IS_SYMPTOMS_DATE_UNKNOWN]: yup.boolean().nullable().when(ClinicalDetailsFields.DOES_HAVE_SYMPTOMS, {
         is: true,
         then: yup.boolean().nullable().required(),
@@ -124,7 +124,7 @@ const ClinicalDetailsSchema = (validationDate: Date) => yup.object().shape({
             otherwise: yup.array().of(yup.string())
         }),
     [ClinicalDetailsFields.OTHER_SYMPTOMS_MORE_INFO]: symptomsMoreInfoSchema,
-    [ClinicalDetailsFields.DOES_HAVE_BACKGROUND_DISEASES]: yup.boolean().nullable().required(),
+    [ClinicalDetailsFields.DOES_HAVE_BACKGROUND_DISEASES]: yup.boolean().required(requiredText).nullable(),
     [ClinicalDetailsFields.BACKGROUND_DESEASSES]: yup.array().of(yup.string()).when(
         ClinicalDetailsFields.DOES_HAVE_BACKGROUND_DISEASES, {
             is: true,

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/IsolationProblemFields.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/IsolationProblemFields.tsx
@@ -3,15 +3,16 @@ import { Controller, useFormContext } from 'react-hook-form';
 import { Collapse, Grid } from '@material-ui/core';
 
 import Toggle from 'commons/Toggle/Toggle';
+import InlineErrorText from 'commons/InlineErrorText/InlineErrorText';
 import ClinicalDetailsFields from 'models/enums/ClinicalDetailsFields';
+import FormRowWithInput from 'commons/FormRowWithInput/FormRowWithInput';
 import AlphanumericTextField from 'commons/AlphanumericTextField/AlphanumericTextField';
 
 import { ClinicalDetailsClasses } from './ClinicalDetailsStyles';
-import FormRowWithInput from 'commons/FormRowWithInput/FormRowWithInput';
 
 const IsolationProblemFields: React.FC<Props> = (props: Props): JSX.Element => {
     const { classes, watchIsIsolationProblem } = props;
-    const { control } = useFormContext();
+    const { control, errors } = useFormContext();
 
     return (
         <FormRowWithInput fieldName='האם בעייתי לקיים בידוד:'>
@@ -31,6 +32,9 @@ const IsolationProblemFields: React.FC<Props> = (props: Props): JSX.Element => {
                                 }}
                             />
                         )}
+                    />
+                    <InlineErrorText 
+                        error={errors[ClinicalDetailsFields.IS_ISOLATION_PROBLEM]}
                     />
                 </Grid>
                 <Grid item xs={2}>

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/SymptomsFields/SymptomsFields.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/SymptomsFields/SymptomsFields.tsx
@@ -8,6 +8,7 @@ import DatePick from 'commons/DatePick/DatePick';
 import StoreStateType from 'redux/storeStateType';
 import CustomCheckbox from 'commons/CheckBox/CustomCheckbox';
 import useStatusUtils from 'Utils/StatusUtils/useStatusUtils';
+import InlineErrorText from 'commons/InlineErrorText/InlineErrorText';
 import ClinicalDetailsFields from 'models/enums/ClinicalDetailsFields';
 import FormRowWithInput from 'commons/FormRowWithInput/FormRowWithInput';
 import { getMinimalSymptomsStartDate } from 'Utils/ClinicalDetails/symptomsUtils';
@@ -50,6 +51,9 @@ const SymptomsFields: React.FC<Props> = (props: Props): JSX.Element => {
                             />
                         )}
                     />
+                <InlineErrorText 
+                    error={errors[ClinicalDetailsFields.DOES_HAVE_SYMPTOMS]}
+                />
                 </Grid>
             </FormRowWithInput>
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/useClinicalDetails.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ClinicalDetails/useClinicalDetails.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import React, {useState} from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 
 import theme from 'styles/theme';
@@ -28,11 +28,11 @@ export const initialClinicalDetails: ClinicalDetailsData = {
     isolationSource: null,
     isolationAddress: initDBAddress,
     isInIsolation: false,
-    isIsolationProblem: false,
+    isIsolationProblem: null,
     isIsolationProblemMoreInfo: '',
     symptomsStartDate: null,
     symptoms: [],
-    doesHaveBackgroundDiseases: false,
+    doesHaveBackgroundDiseases: null,
     backgroundDeseases: [],
     hospital: '',
     hospitalizationStartDate: null,
@@ -146,12 +146,12 @@ const useClinicalDetails = (parameters: useClinicalDetailsIncome): useClinicalDe
                         ...initialClinicalDetails,
                         isPregnant: Boolean(patientClinicalDetails.isPregnant),
                         backgroundDeseases: patientClinicalDetails.backgroundDiseases,
-                        doesHaveBackgroundDiseases: Boolean(patientClinicalDetails.doesHaveBackgroundDiseases),
+                        doesHaveBackgroundDiseases: patientClinicalDetails.doesHaveBackgroundDiseases,
                         hospital: patientClinicalDetails.hospital !== null ? patientClinicalDetails.hospital : '',
                         hospitalizationStartDate: convertDate(patientClinicalDetails.hospitalizationStartTime),
                         hospitalizationEndDate: convertDate(patientClinicalDetails.hospitalizationEndTime),
                         isInIsolation: Boolean(patientClinicalDetails.isInIsolation),
-                        isIsolationProblem: Boolean(patientClinicalDetails.isIsolationProblem),
+                        isIsolationProblem: patientClinicalDetails.isIsolationProblem,
                         isIsolationProblemMoreInfo: patientClinicalDetails.isIsolationProblemMoreInfo !== null ?
                             patientClinicalDetails.isIsolationProblemMoreInfo : '',
                         isolationStartDate: convertDate(patientClinicalDetails.isolationStartTime),
@@ -160,7 +160,7 @@ const useClinicalDetails = (parameters: useClinicalDetailsIncome): useClinicalDe
                         symptoms: patientClinicalDetails.symptoms,
                         symptomsStartDate: convertDate(patientClinicalDetails.symptomsStartDate),
                         isSymptomsStartDateUnknown: patientClinicalDetails.symptomsStartTime === null,
-                        doesHaveSymptoms: Boolean(patientClinicalDetails.doesHaveSymptoms),
+                        doesHaveSymptoms: patientClinicalDetails.doesHaveSymptoms,
                         wasHospitalized: Boolean(patientClinicalDetails.wasHospitalized),
                         isolationAddress: patientAddress,
                         otherSymptomsMoreInfo: patientClinicalDetails.otherSymptomsMoreInfo !== null ?

--- a/client/src/models/Contexts/ClinicalDetailsContextData.ts
+++ b/client/src/models/Contexts/ClinicalDetailsContextData.ts
@@ -7,11 +7,11 @@ interface ClinicalDetailsData extends SymptomsExistenceInfo {
     isolationSource: number | null;
     isolationAddress: FlattenedDBAddress;
     isInIsolation: boolean;
-    isIsolationProblem: boolean;
+    isIsolationProblem: boolean | null;
     isIsolationProblemMoreInfo: string;
     isSymptomsStartDateUnknown: boolean;
     symptoms: string[];
-    doesHaveBackgroundDiseases: boolean;
+    doesHaveBackgroundDiseases: boolean | null;
     backgroundDeseases: string[];
     hospital: string;
     hospitalizationStartDate: Date | null;


### PR DESCRIPTION
**Note:** This PR currently contains only clinical details because possible exposures is still in debate..

added default 'null' values for some clinical details toggles - and 'required' validations and error messages

### New Common - `<InlineErrorText />`
The accepts nullable error field and returns inline error message with the error (if it exists)