### PR TITLE
added isnamedlocation refrence in the name

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionDialog.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionDialog.tsx
@@ -125,10 +125,8 @@ const InteractionDialog = (props: Props) => {
             [InteractionEventDialogFields.UNKNOWN_TIME]: Boolean(data[InteractionEventDialogFields.UNKNOWN_TIME]),
             [InteractionEventDialogFields.ID]: methods.watch(InteractionEventDialogFields.ID),
             [InteractionEventDialogFields.PLACE_NAME]: 
-                isNamedLocation 
-                    ? Boolean(data[InteractionEventDialogFields.PLACE_NAME])
-                        ? data[InteractionEventDialogFields.PLACE_NAME]
-                        : generatePlacenameByPlaceSubType(placeSubtypeName)
+                isNamedLocation && Boolean(data[InteractionEventDialogFields.PLACE_NAME])
+                    ? data[InteractionEventDialogFields.PLACE_NAME]
                     : generatePlacenameByPlaceSubType(placeSubtypeName),
             [InteractionEventDialogFields.EXTERNALIZATION_APPROVAL]: Boolean(data[InteractionEventDialogFields.EXTERNALIZATION_APPROVAL]),
             [InteractionEventDialogFields.ADDITIONAL_OCCURRENCES]:

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionDialog.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionDialog.tsx
@@ -11,6 +11,7 @@ import InvolvedContact from 'models/InvolvedContact';
 import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
 import PrimaryButton from 'commons/Buttons/PrimaryButton/PrimaryButton';
 import useDuplicateContactId, {IdToCheck} from 'Utils/Contacts/useDuplicateContactId';
+import {getOptionsByPlaceAndSubplaceType} from 'Utils/ContactEvent/placeTypesCodesHierarchy';
 import {ContactBankContextProvider , ContactBankOption} from 'commons/Contexts/ContactBankContext';
 import {GroupedInvestigationsContextProvider} from 'commons/Contexts/GroupedInvestigationFormContext';
 import {familyMembersContext, FamilyMembersDataContextProvider} from 'commons/Contexts/FamilyMembersContext';
@@ -112,6 +113,7 @@ const InteractionDialog = (props: Props) => {
     });
 
     const convertData = (data: InteractionEventDialogData) => {
+        const { isNamedLocation } = getOptionsByPlaceAndSubplaceType(data.placeType, data.placeSubType);
         initialInteractionDate.current.setHours(0, 0, 0, 0);
         const startTimeToSave = isUnknownTime ? initialInteractionDate.current : data.startTime;
         const endTimeToSave = isUnknownTime ? initialInteractionDate.current : data.endTime;
@@ -122,8 +124,12 @@ const InteractionDialog = (props: Props) => {
             [InteractionEventDialogFields.END_TIME]: endTimeToSave,
             [InteractionEventDialogFields.UNKNOWN_TIME]: Boolean(data[InteractionEventDialogFields.UNKNOWN_TIME]),
             [InteractionEventDialogFields.ID]: methods.watch(InteractionEventDialogFields.ID),
-            [InteractionEventDialogFields.PLACE_NAME]: Boolean(data[InteractionEventDialogFields.PLACE_NAME]) ?
-                data[InteractionEventDialogFields.PLACE_NAME] : generatePlacenameByPlaceSubType(placeSubtypeName),
+            [InteractionEventDialogFields.PLACE_NAME]: 
+                isNamedLocation 
+                    ? Boolean(data[InteractionEventDialogFields.PLACE_NAME])
+                        ? data[InteractionEventDialogFields.PLACE_NAME]
+                        : generatePlacenameByPlaceSubType(placeSubtypeName)
+                    : generatePlacenameByPlaceSubType(placeSubtypeName),
             [InteractionEventDialogFields.EXTERNALIZATION_APPROVAL]: Boolean(data[InteractionEventDialogFields.EXTERNALIZATION_APPROVAL]),
             [InteractionEventDialogFields.ADDITIONAL_OCCURRENCES]:
             data[InteractionEventDialogFields.ADDITIONAL_OCCURRENCES]?.map(convertAdditionalOccurances) || [],


### PR DESCRIPTION
This is a weird case, which signifies how inherently flawed this whole page really is -
turns out there are place and sub-places codes, and also the places actual names (like the codes can mean education - school and the place name will be 'Gan Nahum high school')
it is important to know that some places do not have a placename (like private house) so in that case the name is determined by a function called generatePlacenameByPlaceSubType.
the problem itself stemmed from the fact that once a place already have a place name ( in the private house case with no way of editing it) then generatePlacenameByPlaceSubType will not run again because it already has a name.

to fix this i've changed the way the name is calculated to the following logic:
if the place is a named location ( if the 'placename' field appears ) use the place name from the textfield - if it's empty - generate one.
if the place is unnamed - generate one always
