### PR TITLE
Fix/tracking recommendation other

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigationInfoBar.tsx
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigationInfoBar.tsx
@@ -105,7 +105,7 @@ const InvestigationInfoBar: React.FC<Props> = ({ currentTab }: Props) => {
                     setEndTime(investigationInfo.endTime);
                     setInvestigationStaticInfo(formattedInvestigationInfo);
                     setTrackingRecommendation({
-                        reason: investigationInfo.trackingSubReasonByTrackingSubReason?.reasonId ?? null,
+                        reason: investigationInfo.trackingSubReasonByTrackingSubReason?.reasonId ?? 0,
                         subReason: investigationInfo.trackingSubReasonByTrackingSubReason?.subReasonId,
                         extraInfo: investigationInfo.trackingExtraInfo 
                     })

--- a/client/src/components/App/Content/InvestigationForm/TrackingRecommendation/TrackingRecommendationForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TrackingRecommendation/TrackingRecommendationForm.tsx
@@ -82,6 +82,7 @@ const TrackingRecommendationForm = (props: Props) => {
                     <FormControl variant='outlined'>
                         <AlphanumericTextField
                             name='trackingExtraInfo'
+                            key={reason || ''}
                             value={extraInfo || ''}
                             onChange={(value) => {
                                 setTrackingRecommendation({


### PR DESCRIPTION
This is a weird one, covers 2 main issues : 
# Issues
## Sub-reason dropdown shows when theres no reason
### Why does it happen
This happened because we recive `null` from the server when there's no main reason - this is then not caught in the collapse which compares it to 0 (default value),
### How was it fixed
fixed it by moving the value to 0 instead of null on receiving it
## On picking other (for the first time only ! ) It resets the values of the rest of the row
### Why does it happen
I'm still uncertain how exactly this is happening, but it appears that when onClick is performed on the TextField - the values for reason and sub-reason are not the updated values, this seemed to disappear only when those fields were related to the element (which is a whole other level of weird because sub-type doesn't seem to be having this issue). 
### How was it fixed
fixed it by relating the textfield to the value of reason (by assigning the 'key' prop to it), **please note that this is a patch and I would love any help figuring out why it happens in the first place**