### PR TITLE
Admin landing page css

### DIFF
--- a/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCard.tsx
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCard.tsx
@@ -25,7 +25,7 @@ const DesksFilterCard = (props: Props): JSX.Element => {
     return (
         <LoadingCard isLoading={countyDesks.length === 0} width={cardWidth} height={cardHeight} className={classes.desksCard}>
             <CardContent>
-                <Box display='flex' flexDirection='column' className={classes.desksCardContent}>
+                <Box display='flex' flexDirection='column'>
                     <Typography variant='h6' id='desks-card-headline'>
                         <b>הדסקים בהם הינך צופה</b>
                     </Typography>

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCardStyles.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCardStyles.ts
@@ -5,11 +5,10 @@ export const cardHeight = '35vh';
 
 const useStyles = makeStyles({
     desksCard: {
-        height: '35vh',
         borderRadius: '1vw',
     },
     desksCardContent: {
-        height: '30vh',
+
     },
     desksCardActions: {
         direction: 'ltr', 
@@ -17,6 +16,8 @@ const useStyles = makeStyles({
         flip: false
     },
     desksWrapper: {
+        minHeight: '150px',
+        maxHeight: '20vh',
         overflowY: 'auto',
     }
 });

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCardStyles.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/desksFilterCard/desksFilterCardStyles.ts
@@ -7,9 +7,6 @@ const useStyles = makeStyles({
     desksCard: {
         borderRadius: '1vw',
     },
-    desksCardContent: {
-
-    },
     desksCardActions: {
         direction: 'ltr', 
         paddingLeft: '1vw',

--- a/client/src/components/App/Content/LandingPage/adminLandingPage/investigationsInfo/investigationInfoButton/investigationInfoButtonStyles.ts
+++ b/client/src/components/App/Content/LandingPage/adminLandingPage/investigationsInfo/investigationInfoButton/investigationInfoButtonStyles.ts
@@ -8,7 +8,8 @@ const useStyles = makeStyles({
         margin: '0 1vw',
         flexBasis: 0,
         flexGrow: 1,
-        height: '10vh'
+        maxHeight: '10vh',
+        minHeight: '100px',
     },
 });
 


### PR DESCRIPTION
This PR fixes admin landing page (more specificaly investigationInfo and desksFilter)cosmetic issues, the main point of resolution is replacing static 'height' with relative values (vh/vw) to a static min height (px) and a relative max height (vh/vw) - preserving the current ratios

example :
before (laptop screen size)
![image](https://user-images.githubusercontent.com/68457306/113500760-4fcd8980-9529-11eb-8da6-ee44f492bc13.png)
after
![image](https://user-images.githubusercontent.com/68457306/113500770-65db4a00-9529-11eb-9655-90bdd1577810.png)
