### PR TITLE
1733/fix/overflow tabs

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/TabManagement/TabManagement.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/TabManagement.tsx
@@ -101,28 +101,16 @@ const TabManagement: React.FC<Props> = (tabManagementProps: Props): JSX.Element 
                         }}
                         textColor='primary'
                         className={classes.tabs}
-                        variant="scrollable"
-                        scrollButtons="auto"
+                        variant='scrollable'
+                        scrollButtons='auto'
                         ScrollButtonComponent={(props) => {
-                            if (
-                                props.direction === "right"
-                            ) {
-                                return (
-                                    <IconButton {...props}
-                                        disabled={false}
-                                    >
-                                        <ChevronLeft />
-                                    </IconButton>
-                                );
-                            } else {
-                                return (
-                                    <IconButton {...props}
-                                        disabled={false}
-                                    >
-                                        <ChevronRight />
-                                    </IconButton>
-                                );
-                            }
+                            return (
+                                <IconButton {...props}
+                                    disabled={false}
+                                >
+                                    {props.direction === 'left' ? <ChevronRight /> : <ChevronLeft />}
+                                </IconButton>
+                            )
                         }}
                     >
                         {

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/TabManagement.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/TabManagement.tsx
@@ -15,7 +15,7 @@ import InteractionsTab from './InteractionsTab/InteractionsTab';
 import PersonalInfoTab from './PersonalInfoTab/PersonalInfoTab';
 import ContactQuestioning from './ContactQuestioning/ContactQuestioning';
 import ExposuresAndFlights from './ExposuresAndFlights/ExposuresAndFlights';
-import { ChevronLeft, ChevronRight } from '@material-ui/icons';
+import { ArrowLeft, ChevronLeft, ChevronRight } from '@material-ui/icons';
 
 const END_INVESTIGATION = 'סיים חקירה';
 const CONTINUE_TO_NEXT_TAB = 'המשך לשלב הבא';
@@ -96,20 +96,44 @@ const TabManagement: React.FC<Props> = (tabManagementProps: Props): JSX.Element 
                     <Tabs
                         value={currentTab}
                         classes={{
-                            indicator: classes.indicator
+                            root: classes.tabRoot,
+                            indicator: classes.indicator,
                         }}
                         textColor='primary'
                         className={classes.tabs}
+                        variant="scrollable"
+                        scrollButtons="auto"
+                        ScrollButtonComponent={(props) => {
+                            if (
+                                props.direction === "right"
+                            ) {
+                                return (
+                                    <IconButton {...props}
+                                        disabled={false}
+                                    >
+                                        <ChevronLeft />
+                                    </IconButton>
+                                );
+                            } else {
+                                return (
+                                    <IconButton {...props}
+                                        disabled={false}
+                                    >
+                                        <ChevronRight />
+                                    </IconButton>
+                                );
+                            }
+                        }}
                     >
                         {
-                            tabs.map((tab: TabObj) =>
+                            tabs.map((tab: TabObj , index : number) =>
                             !(tab.id === TabId.CONTACTS_QUESTIONING && !areThereContacts) &&
                             <StyledTab
                                     // @ts-ignore
                                     type='submit'
                                     form={`form-${currentTab}`}
                                     onClick={() => { setNextTab(tab.id) }}
-                                    key={tab.id}
+                                    key={index}
                                     label={tab.name}
                                     icon={isTabValid(tab.id) ? <ErrorOutlineIcon className={classes.icon} fontSize={'small'}/> : undefined}
                                     className={isTabValid(tab.id) ? classes.errorIcon : undefined}

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/TabManagementStyles.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/TabManagementStyles.ts
@@ -31,6 +31,9 @@ const useStyles = makeStyles({
             borderBottom: `3px solid ${theme.palette.primary.main}`
         }
     },
+    tabRoot: {
+        flexDirection: 'row-reverse'
+    },
     indicator: {
         display: 'none'
     }


### PR DESCRIPTION
urghhhhhhhhhhh, this bug is a mess.

there's an issue with material UI's RTLs version of scrollable tabs. so I rendered the component myself - switched the flex direction to reverse (so that the right arrow will be at the left and vice versa) , flipped the arrow's icon direction and removed 'disabled' functionality (because the RTL value of where the indicator is is really really messed up (flex-direction: 'row-reverse' really doesn't help it here))