### PR TITLE
changed delete contact to only delete contacted_person instead of person

### DIFF
--- a/server/src/ScriptRunner/Scripts/index/delete_public_contacted_person.sql
+++ b/server/src/ScriptRunner/Scripts/index/delete_public_contacted_person.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION public.delete_contacted_person_function(
+	contacted_person_id integer,
+	involved_contact_id integer,
+	investigation_id integer)
+    RETURNS void
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+AS $BODY$
+begin		
+    -- I'm leaving this as a function in case einat changes her mind about deletion :P
+	
+	delete from public.contacted_person
+   	where id = contacted_person_id;
+							
+END;
+$BODY$;
+


### PR DESCRIPTION
Problem was that `delete_contacted_person_funciton` was deleting public.contacted_person (by contacted_person(id)) and then deleting public.person - issue is that now contacted_person can contain multiple instances of person so deleting person violates FK constraint.

moved into just not deleting public.person at all.