### PR TITLE
loading bar redo

### DIFF
--- a/server/src/ScriptRunner/src/LoadingBar/generateLoadingBar.ts
+++ b/server/src/ScriptRunner/src/LoadingBar/generateLoadingBar.ts
@@ -1,13 +1,13 @@
 const RUNNER = '🏃';
-const GUST = '💨';
-const DOT = '➖󠀠'
-const BAR_LENGTH = 18;
+const COMPLETED = '█';
+const UNCOMPLETED = '░'
+const BAR_LENGTH = Math.min(50 , process.stdout.columns - 1) // account for runner;
 
 const generateLoadingBar = (fraction : number) => {
     const gustCount = Math.floor(fraction * BAR_LENGTH) - 1;
     const dotCount = BAR_LENGTH - gustCount - 1; // account for runner
 
-    return  repeatString(DOT,dotCount) + RUNNER + repeatString(GUST,gustCount) ; 
+    return  repeatString(UNCOMPLETED,dotCount) + RUNNER + repeatString(COMPLETED,gustCount) ; 
 }
 
 const repeatString = (string : string, times : number) => {


### PR DESCRIPTION
2 major changes
1. changed the loading bar from emoji to ascii (turns out that the emojis can overflow (see those �))
2. changed the loading bar's length to the terminal's width (to a maximum of 50)
