### PR TITLE
1784/feat/set-table-scrollbar-to-top

### DIFF
--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -414,7 +414,11 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                 <Pagination
                     page={currentPage}
                     count={totalPageCount}
-                    onChange={(event, value) => setCurrentPage(value)}
+                    onChange={(event, value) => {
+                        setCurrentPage(value);
+                        window.scrollTo(0, 0);
+                        tableContainerRef.current?.scrollTo(0, 0);
+                    }}
                     size='large'
                     className={classes.pagination}
                 />


### PR DESCRIPTION
This PR implements feature: [1784](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1784)

when moving page sets page and table scrollbar to (0, 0) position.