### PR TITLE
1785/fix/complexity-icon-appearance

### DIFF
--- a/server/src/ScriptRunner/Scripts/index/update_investigation_reasons_id.sql
+++ b/server/src/ScriptRunner/Scripts/index/update_investigation_reasons_id.sql
@@ -1,0 +1,20 @@
+-- FUNCTION: public.update_investigation_reasons_id(integer, integer)
+
+DROP FUNCTION IF EXISTS public.update_investigation_reasons_id(integer, integer);
+
+CREATE OR REPLACE FUNCTION public.update_investigation_reasons_id(
+	new_complexity_reason_id integer,
+	epidemiology_number_input integer)
+    RETURNS void
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+AS $BODY$
+declare
+BEGIN
+UPDATE public.investigation
+SET complexity_reasons_id = array_append(complexity_reasons_id, new_complexity_reason_id), 
+	complexity_code = 1
+WHERE epidemiology_number = epidemiology_number_input;
+END;
+$BODY$;


### PR DESCRIPTION
### The Bug: [1785](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1785/)

#### The problem:
when investigation is not complex and we add flight it call update_investigation_reasons_id function which add the complex_reason_id to the array of reasons_id but it wo'nt change the field that tells if the investigation is complex or not.

#### The solution:
Now when updating the reasons array, also makes sure the investigation declared as complex by changing the investigation complexity_code to 1.