### PR TITLE
revert nivo

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2292,9 +2292,9 @@
       }
     },
     "postgraphile-plugin-connection-filter": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/postgraphile-plugin-connection-filter/-/postgraphile-plugin-connection-filter-2.1.1.tgz",
-      "integrity": "sha512-g2tInSqPFFKKf6jL5uL868HZm9//1L3HmOZAHc0QuRcV7jKMGuFivX1G3OXj8HBxbaSiCyxWUYjVdOYiNsJ4tQ=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/postgraphile-plugin-connection-filter/-/postgraphile-plugin-connection-filter-2.2.1.tgz",
+      "integrity": "sha512-afnINc5+7WVHL/8+nllVIyotWsUTd8m7sxp2QbtuVvC1+Kn7vteHM6//O3HIbDBU4w1gQ+/SGYRhSa2bSOQmmg=="
     },
     "postgres-array": {
       "version": "2.0.0",


### PR DESCRIPTION
…1549)

Bumps [postgraphile-plugin-connection-filter](https://github.com/graphile-contrib/postgraphile-plugin-connection-filter) from 2.1.1 to 2.2.1.
- [Release notes](https://github.com/graphile-contrib/postgraphile-plugin-connection-filter/releases)
- [Changelog](https://github.com/graphile-contrib/postgraphile-plugin-connection-filter/blob/master/CHANGELOG.md)
- [Commits](https://github.com/graphile-contrib/postgraphile-plugin-connection-filter/compare/v2.1.1...v2.2.1)

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>