### PR TITLE
1744/feat/stright personal details

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/InvestigationFormStyles.ts
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationFormStyles.ts
@@ -7,7 +7,7 @@ const useStyles = makeStyles({
         backgroundColor: primaryBackgroundColor,
     },
     interactiveForm: {
-        padding: '2vh 1vw 0 1vw',
+        padding: '2vh',
     },
     buttonSection: {
         margin: '1vh 0'

--- a/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InfoItem.tsx
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InfoItem.tsx
@@ -21,8 +21,8 @@ const InfoItem = ({ name, value, testId, size = 'regular' }: InfoItemProps) => {
     const variant = sizeVariantMap[size] as Variant;
     return (
         <Typography variant={variant} className={classes.typographyElement} test-id={testId}>
-           <bdi>{name}</bdi>: 
-            {value}
+           <bdi>{name}</bdi>:
+            {` ${value}`}
         </Typography>
     );
 };


### PR DESCRIPTION
problem was that those cards didn't have the same padding value - just added a fixed value,

also fixing a cosmetic issue that was really bugging me where in the upper card the text lines will be `נפטר:לא` instead of `נפטר: לא` (with a space)