### PR TITLE
1794/fix/identification-number-field-length

### DIFF
--- a/client/src/commons/IdentificationTextField/IdentificationTextField.tsx
+++ b/client/src/commons/IdentificationTextField/IdentificationTextField.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import * as yup from 'yup';
 
 import { NUMERIC_TEXT_REGEX } from 'commons/Regex/Regex';
-import { max15LengthNumErrorMessage, numericErrorMessage } from 'commons/Schema/messages';
 import TypePreventiveTextField from 'commons/TypingPreventionTextField/TypingPreventionTextField';
+import { max15LengthNumErrorMessage, max9LengthIdErrorMessage, numericErrorMessage } from 'commons/Schema/messages';
 
 const IdentificationTextField = (props : Props) => {
-    
-    const schema = yup.string().matches(NUMERIC_TEXT_REGEX, numericErrorMessage).max(15, max15LengthNumErrorMessage);
+
+    const schema = props.isId 
+        ? yup.string().matches(NUMERIC_TEXT_REGEX, numericErrorMessage).max(9, max9LengthIdErrorMessage)
+        : yup.string().matches(NUMERIC_TEXT_REGEX, numericErrorMessage).max(15, max15LengthNumErrorMessage);
     
     return (
         <TypePreventiveTextField
@@ -27,6 +29,7 @@ interface Props{
     placeholder?: string,
     label?: string,
     className?: string,
+    isId?: boolean,
 };
 
 export default IdentificationTextField;

--- a/client/src/commons/NoContextElements/IdentificationTextField.tsx
+++ b/client/src/commons/NoContextElements/IdentificationTextField.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import * as yup from 'yup';
 
 import { NUMERIC_TEXT_REGEX } from 'commons/Regex/Regex';
-import { max15LengthNumErrorMessage, numericErrorMessage } from 'commons/Schema/messages';
-
-import TypePreventiveTextField from './TypingPreventionTextField';
+import TypePreventiveTextField from 'commons/TypingPreventionTextField/TypingPreventionTextField';
+import { max15LengthNumErrorMessage, max9LengthIdErrorMessage, numericErrorMessage } from 'commons/Schema/messages';
 
 const IdentificationTextField = (props : Props) => {
 
-    const schema = yup.string().matches(NUMERIC_TEXT_REGEX, numericErrorMessage).max(15, max15LengthNumErrorMessage);
+    const schema = props.isId 
+        ? yup.string().matches(NUMERIC_TEXT_REGEX, numericErrorMessage).max(9, max9LengthIdErrorMessage)
+        : yup.string().matches(NUMERIC_TEXT_REGEX, numericErrorMessage).max(15, max15LengthNumErrorMessage);
 
     return (
         <TypePreventiveTextField
@@ -29,7 +30,8 @@ interface Props{
     placeholder?: string,
     label?: string,
     className?: string,
-    error: string
+    error: string,
+    isId?: boolean,
 };
 
 export default IdentificationTextField;

--- a/client/src/commons/Schema/messages.ts
+++ b/client/src/commons/Schema/messages.ts
@@ -8,6 +8,7 @@ export const alphbetDashErrorMessage = 'השדה יכול להכיל אותיו�
 export const alphaNumericSpecialCharsErrorMessage = 'השדה יכול להכיל תווים חוקיים בלבד';
 export const alphaNumericWhiteSpaceErrorMessage = 'השדה יכול להכיל אותיות, מספרים, מקף ורווח בלבד';
 
+export const max9LengthIdErrorMessage = 'שדה ת.ז יכול להכיל 9 מספרים בלבד';
 export const max10LengthNumErrorMessage = 'השדה יכול להכיל 10 מספרים בלבד';
 export const max15LengthNumErrorMessage = 'השדה יכול להכיל 15 מספרים בלבד';
 export const max50LengthErrorMessage = 'השדה יכול להכיל 50 תווים בלבד';

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
@@ -41,7 +41,7 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
 
     const [shouldIdDisable, setShouldIdDisable] = useState<boolean>(false);
     const [age, setAge] = useState<string>(calcAge(interactedContact.birthDate));
-    const [isId, setIsId] =  useState<boolean>(false);
+    const [isId, setIsId] = useState<boolean>(false);
 
     const { isFieldDisabled } = useContactFields(formValues.contactStatus);
 
@@ -62,11 +62,7 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
         if (watchIdentificationType || watchIdentificationNumber){
             trigger(identificationTypeFieldName);
             trigger(identificationNumberFieldName); 
-            if (watchIdentificationType === IdentificationTypesCodes.PALESTINE_ID || watchIdentificationType === IdentificationTypesCodes.ID) {
-                setIsId(true);
-            } else {
-                setIsId(false);
-            }
+            setIsId(watchIdentificationType === IdentificationTypesCodes.PALESTINE_ID || watchIdentificationType === IdentificationTypesCodes.ID);
         }
     }, [watchIdentificationType, watchIdentificationNumber]);
         

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
@@ -15,6 +15,7 @@ import useContactFields from 'Utils/Contacts/useContactFields';
 import InteractedContactFields from 'models/enums/InteractedContact';
 import { invalidDateText, requiredText } from 'commons/Schema/messages';
 import NumericTextField from 'commons/NoContextElements/NumericTextField';
+import IdentificationTypesCodes from 'models/enums/IdentificationTypesCodes';
 import AlphanumericTextField from 'commons/NoContextElements/AlphanumericTextField';
 import IdentificationTextField from 'commons/NoContextElements/IdentificationTextField';
 import GroupedInteractedContact from 'models/ContactQuestioning/GroupedInteractedContact';
@@ -40,6 +41,7 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
 
     const [shouldIdDisable, setShouldIdDisable] = useState<boolean>(false);
     const [age, setAge] = useState<string>(calcAge(interactedContact.birthDate));
+    const [isId, setIsId] =  useState<boolean>(false);
 
     const { isFieldDisabled } = useContactFields(formValues.contactStatus);
 
@@ -60,6 +62,11 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
         if (watchIdentificationType || watchIdentificationNumber){
             trigger(identificationTypeFieldName);
             trigger(identificationNumberFieldName); 
+            if (watchIdentificationType === IdentificationTypesCodes.PALESTINE_ID || watchIdentificationType === IdentificationTypesCodes.ID) {
+                setIsId(true);
+            } else {
+                setIsId(false);
+            }
         }
     }, [watchIdentificationType, watchIdentificationNumber]);
         
@@ -143,6 +150,7 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
                                         }}
                                         placeholder='מספר תעודה'
                                         className={classes.idTextField}
+                                        isId={isId}
                                     />
                                 );
                             }}

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/ManualContactsForm/ContactForm/ContactForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/ManualContactsForm/ContactForm/ContactForm.tsx
@@ -39,7 +39,7 @@ const ContactForm: React.FC<Props> = ({ updatedContactIndex, contactStatus, pers
 
     const { shouldDisableContact } = useStatusUtils();
 
-    const [isId, setIsId] =  useState<boolean>(false);
+    const [isId, setIsId] = useState<boolean>(false);
 
     const identificationTypeFieldName = `${InteractionEventDialogFields.CONTACTS}[${updatedContactIndex}].${InteractionEventContactFields.IDENTIFICATION_TYPE}`;
 	const identificationNumberFieldName = `${InteractionEventDialogFields.CONTACTS}[${updatedContactIndex}].${InteractionEventContactFields.IDENTIFICATION_NUMBER}`;
@@ -55,11 +55,7 @@ const ContactForm: React.FC<Props> = ({ updatedContactIndex, contactStatus, pers
             trigger(identificationTypeFieldName);
             trigger(identificationNumberFieldName); 
         }
-        if (watchIdentificationType === IdentificationTypesCodes.PALESTINE_ID || watchIdentificationType === IdentificationTypesCodes.ID) {
-            setIsId(true);
-        } else {
-            setIsId(false);
-        }
+        setIsId(watchIdentificationType === IdentificationTypesCodes.PALESTINE_ID || watchIdentificationType === IdentificationTypesCodes.ID);
     }, [watchIdentificationType, watchIdentificationNumber]);
     
     useEffect(() => {

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/ManualContactsForm/ContactForm/ContactForm.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/InteractionsTab/InteractionDialog/InteractionEventForm/ContactsSection/ManualContactsForm/ContactForm/ContactForm.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from 'react-redux';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { FormControl, FormHelperText, Grid, MenuItem, Select } from '@material-ui/core';
 
@@ -13,6 +13,7 @@ import useStatusUtils from 'Utils/StatusUtils/useStatusUtils';
 import useContactFields from 'Utils/Contacts/useContactFields';
 import { get } from 'Utils/auxiliaryFunctions/auxiliaryFunctions';
 import NumericTextField from 'commons/NumericTextField/NumericTextField';
+import IdentificationTypesCodes from 'models/enums/IdentificationTypesCodes';
 import AlphanumericTextField from 'commons/AlphanumericTextField/AlphanumericTextField';
 import IdentificationTextField from 'commons/IdentificationTextField/IdentificationTextField';
 import AlphabetWithDashTextField from 'commons/AlphabetWithDashTextField/AlphabetWithDashTextField';
@@ -38,6 +39,8 @@ const ContactForm: React.FC<Props> = ({ updatedContactIndex, contactStatus, pers
 
     const { shouldDisableContact } = useStatusUtils();
 
+    const [isId, setIsId] =  useState<boolean>(false);
+
     const identificationTypeFieldName = `${InteractionEventDialogFields.CONTACTS}[${updatedContactIndex}].${InteractionEventContactFields.IDENTIFICATION_TYPE}`;
 	const identificationNumberFieldName = `${InteractionEventDialogFields.CONTACTS}[${updatedContactIndex}].${InteractionEventContactFields.IDENTIFICATION_NUMBER}`;
 
@@ -51,6 +54,11 @@ const ContactForm: React.FC<Props> = ({ updatedContactIndex, contactStatus, pers
         if (watchIdentificationType || watchIdentificationNumber){
             trigger(identificationTypeFieldName);
             trigger(identificationNumberFieldName); 
+        }
+        if (watchIdentificationType === IdentificationTypesCodes.PALESTINE_ID || watchIdentificationType === IdentificationTypesCodes.ID) {
+            setIsId(true);
+        } else {
+            setIsId(false);
         }
     }, [watchIdentificationType, watchIdentificationNumber]);
     
@@ -167,6 +175,7 @@ const ContactForm: React.FC<Props> = ({ updatedContactIndex, contactStatus, pers
                                 }}
                                 onBlur={props.onBlur}
                                 className={classes.inputForm}
+                                isId={isId}
                             />
                         )}
                     />


### PR DESCRIPTION
Fix to Bug: [1794](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1794/)

Now if chosen identificationtype is of type id, the  identificationNumber can only be 9 numbers.