### PR TITLE
1762/fix/save-exposures-info

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactSection/Schemas/contactQuestioningClinical.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactSection/Schemas/contactQuestioningClinical.ts
@@ -4,7 +4,6 @@ import { requiredText } from 'commons/Schema/messages';
 import { ALPHANUMERIC_TEXT_REGEX } from 'commons/Regex/Regex';
 import ContactStatusCodes from 'models/enums/ContactStatusCodes';
 import InteractedContactFields from 'models/enums/InteractedContact';
-import { requiredText } from 'commons/Schema/messages';
 
 export const contactQuestioningClinical = {
     [InteractedContactFields.FAMILY_RELATIONSHIP]: yup.number().nullable(),

--- a/server/src/DBService/InvestigationInfo/Mutation.ts
+++ b/server/src/DBService/InvestigationInfo/Mutation.ts
@@ -41,7 +41,7 @@ export const COMMENT = gql`
 `;
 
 export const UPDATE_INVESTIGATED_PATIENT_RESORTS_DATA = gql`
-mutation updateInvestigatedPatientById ($wasInVacation: Boolean!, $wasInEvent: Boolean!, $wereConfirmedExposuresDesc: String $id: Int!) {
+mutation updateInvestigatedPatientById ($wasInVacation: Boolean, $wasInEvent: Boolean, $wereConfirmedExposuresDesc: String $id: Int!) {
     updateInvestigatedPatientById(input: {investigatedPatientPatch: {wasInVacation: $wasInVacation, wasInEvent: $wasInEvent, wereConfirmedExposuresDesc: $wereConfirmedExposuresDesc }, id: $id}) {
       clientMutationId
     }


### PR DESCRIPTION
Fix to Bug: [1762](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1762/)

Removed ! from type of variables, now supports sending only one of the values.