### PR TITLE
added global install of ts-node

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,6 +8,7 @@ COPY * ./
 
 # Run the command inside your image filesystem.
 RUN npm install
+RUN npm install -g ts-node
 
 # Add metadata to the image to describe which port the container is listening on at runtime.
 EXPOSE 8080


### PR DESCRIPTION
look, I have no idea how it worked until now. 
ts-node existed as a DEV dep for 9 months now, but apparently Docker (maybe node:slim distro - ill look into that) doesn't natively support ts-node anymore, (that's my guess at least)
this is support to at the very least make the server execute