### PR TITLE
1847/fix/contact-questioning-styles

### DIFF
--- a/client/src/commons/NoContextElements/AddressForm.tsx
+++ b/client/src/commons/NoContextElements/AddressForm.tsx
@@ -1,8 +1,8 @@
 import { useSelector } from 'react-redux';
 import { Autocomplete } from '@material-ui/lab';
 import React, { useEffect, useState } from 'react';
+import { FormControl, Grid, TextField } from '@material-ui/core';
 import { Controller ,DeepMap, FieldError } from 'react-hook-form';
-import { Grid, TextField } from '@material-ui/core';
 
 import City from 'models/City';
 import Street from 'models/Street';
@@ -48,11 +48,11 @@ const AddressForm: React.FC<Props> = ({
     }, [cityWatcher]);
 
     const apartmentFieldNameSplitted = apartmentField?.name.split('.');
-    const smallFieldsClass = unsized ? [classes.fullHeight , classes.heightendTextField].join(" ") : classes.fullHeight;
+    const smallFieldsClass = unsized ? [classes.fullHeight , classes.heightendTextField].join(' ') : classes.fullHeight;
 
     return (
-        <Grid item xs={unsized ? 12 : 8} container alignItems='stretch' spacing={2}>
-            <Grid item xs={unsized ? 12 : 3} className={cityField.className}>
+        <Grid item container alignItems='stretch' spacing={2}>
+            <Grid item className={cityField.className}>
                 {
                     disabled ?
                     <Controller
@@ -60,14 +60,16 @@ const AddressForm: React.FC<Props> = ({
                         control={control}
                         defaultValue={cityField.defaultValue}
                         render={(props) => (
-                            <TextField 
-                                className={smallFieldsClass}
-                                InputProps={{className: smallFieldsClass}}
-                                value={cities.get(props.value)?.displayName} 
-                                label={CITY_LABEL}
-                                InputLabelProps={{ shrink: true }}
-                                disabled 
-                            />
+                            <FormControl variant='outlined' fullWidth>
+                                <TextField 
+                                    className={smallFieldsClass}
+                                    InputProps={{className: smallFieldsClass}}
+                                    value={cities.get(props.value)?.displayName} 
+                                    label={CITY_LABEL}
+                                    InputLabelProps={{ shrink: true }}
+                                    disabled 
+                                />
+                            </FormControl>
                         )}
                     />
                     :
@@ -76,24 +78,27 @@ const AddressForm: React.FC<Props> = ({
                         control={control}
                         defaultValue={cityField.defaultValue}
                         render={(props) => (
-                            <Autocomplete
-                                options={Array.from(cities, ([id, value]) => ({ id, value }))}
-                                getOptionLabel={(option) => option ? option.value?.displayName : option}
-                                value={props.value ? {id: props.value as string, value: cities.get(props.value) as City} : {id: '', value: {id: '', displayName: ''}}}
-                                onChange={(event, selectedCity) => props.onChange(selectedCity ? selectedCity.id : null)}
-                                renderInput={(params) => <TextField
-                                        error={Boolean(errors?.city)}
-                                        test-id={cityField.testId || ''}
-                                        label={errors?.city?.message || `${CITY_LABEL}`}
-                                        {...params}
-                                        placeholder={CITY_LABEL}
-                                    />}
-                            />
+                            <FormControl variant='outlined' fullWidth>
+                                <Autocomplete
+                                    options={Array.from(cities, ([id, value]) => ({ id, value }))}
+                                    getOptionLabel={(option) => option ? option.value?.displayName : option}
+                                    value={props.value ? {id: props.value as string, value: cities.get(props.value) as City} : {id: '', value: {id: '', displayName: ''}}}
+                                    onChange={(event, selectedCity) => props.onChange(selectedCity ? selectedCity.id : null)}
+                                    renderInput={(params) => 
+                                        <TextField
+                                            error={Boolean(errors?.city)}
+                                            test-id={cityField.testId || ''}
+                                            label={errors?.city?.message || `${CITY_LABEL}`}
+                                            {...params}
+                                            placeholder={CITY_LABEL}
+                                        />}
+                                />
+                            </FormControl>
                         )}
                     />
                 }
             </Grid>
-            <Grid item xs={unsized ? 12 : 3} className={streetField.className}>
+            <Grid item className={streetField.className}>
                 {
                     disabled ?
                     <Controller
@@ -101,15 +106,17 @@ const AddressForm: React.FC<Props> = ({
                         control={control}
                         defaultValue={streetField.defaultValue}
                         render={(props) => (
-                            <TextField 
-                                className={smallFieldsClass}
-                                InputProps={{className: smallFieldsClass}}
-                                test-id={streetField.testId || ''} 
-                                value={streetsInCity.get(props.value)?.displayName} 
-                                label={STREET_LABEL} 
-                                InputLabelProps={{ shrink: true }}
-                                disabled 
-                            />
+                            <FormControl variant='outlined' fullWidth>
+                                <TextField 
+                                    className={smallFieldsClass}
+                                    InputProps={{className: smallFieldsClass}}
+                                    test-id={streetField.testId || ''} 
+                                    value={streetsInCity.get(props.value)?.displayName} 
+                                    label={STREET_LABEL} 
+                                    InputLabelProps={{ shrink: true }}
+                                    disabled 
+                                />
+                            </FormControl>
                         )}
                     />
                     :
@@ -118,33 +125,36 @@ const AddressForm: React.FC<Props> = ({
                         control={control}
                         defaultValue={streetField.defaultValue}
                         render={(props) => (
-                            <Autocomplete
-                                options={Array.from(streetsInCity, ([id, value]) => ({ id, value }))}
-                                getOptionLabel={(option) => {
-                                    if (option) {
-                                        if (option?.value) return option.value?.displayName
-                                        else return '';
-                                    } else return option
-                                }}
-                                value={props.value ? {id: props.value as string, value: streetsInCity.get(props.value) as Street} : {id: '', value: {id: '', displayName: ''}}}
-                                onChange={(event, selectedStreet) => 
-                                    props.onChange(selectedStreet ? selectedStreet.id : '')
-                                }
-                                renderInput={(params) =>
-                                    <TextField
-                                        {...params}
-                                        error={Boolean(errors?.street)}
-                                        test-id={streetField.testId || ''}
-                                        label={errors?.street?.message || `${STREET_LABEL}`}
-                                        placeholder={STREET_LABEL}
-                                    />
-                                }
-                            />
+                            <FormControl variant='outlined' fullWidth>
+                                <Autocomplete
+                                    options={Array.from(streetsInCity, ([id, value]) => ({ id, value }))}
+                                    getOptionLabel={(option) => {
+                                        if (option) {
+                                            if (option?.value) return option.value?.displayName
+                                            else return '';
+                                        } else return option
+                                    }}
+                                    value={props.value ? {id: props.value as string, value: streetsInCity.get(props.value) as Street} : {id: '', value: {id: '', displayName: ''}}}
+                                    onChange={(event, selectedStreet) => 
+                                        props.onChange(selectedStreet ? selectedStreet.id : '')
+                                    }
+                                    renderInput={(params) =>
+                                        <TextField
+                                            {...params}
+                                            error={Boolean(errors?.street)}
+                                            test-id={streetField.testId || ''}
+                                            label={errors?.street?.message || `${STREET_LABEL}`}
+                                            placeholder={STREET_LABEL}
+                                        />
+                                    }
+                                />
+                            </FormControl>
                         )}
                     />
                 }
             </Grid>
-            <Grid item xs={unsized ? 12 : 2} className={houseNumberField.className}>
+
+            <Grid item className={houseNumberField.className}>
                 {
                     disabled ?
                     <Controller
@@ -152,15 +162,17 @@ const AddressForm: React.FC<Props> = ({
                         control={control}
                         defaultValue={houseNumberField.defaultValue}
                         render={(props) => (
-                            <TextField 
-                                className={smallFieldsClass}
-                                InputProps={{className: smallFieldsClass}}
-                                test-id={houseNumberField.testId || UNKNOWN} 
-                                value={props.value} 
-                                label={HOUSE_NUM_LABEL} 
-                                InputLabelProps={{ shrink: true }}
-                                disabled
-                            />
+                            <FormControl variant='outlined' fullWidth>
+                                <TextField 
+                                    className={smallFieldsClass}
+                                    InputProps={{className: smallFieldsClass}}
+                                    test-id={houseNumberField.testId || UNKNOWN} 
+                                    value={props.value} 
+                                    label={HOUSE_NUM_LABEL} 
+                                    InputLabelProps={{ shrink: true }}
+                                    disabled
+                                />
+                            </FormControl>
                         )}
                     />
                     :
@@ -169,25 +181,28 @@ const AddressForm: React.FC<Props> = ({
                         control={control}
                         defaultValue={houseNumberField.defaultValue}
                         render={(props) => (
-                            <AlphanumericTextField
-                                name={props.name}
-                                error={errors?.houseNum?.message}
-                                className={smallFieldsClass}
-                                InputProps={{className: smallFieldsClass}}
-                                testId={houseNumberField.testId || ''}
-                                value={props.value}
-                                onChange={props.onChange}
-                                onBlur={props.onBlur}
-                                label={HOUSE_NUM_LABEL} 
-                                placeholder={HOUSE_NUM_LABEL}
-                            />
+                            <FormControl variant='outlined' fullWidth>
+                                <AlphanumericTextField
+                                    name={props.name}
+                                    error={errors?.houseNum?.message}
+                                    className={smallFieldsClass}
+                                    InputProps={{className: smallFieldsClass}}
+                                    testId={houseNumberField.testId || ''}
+                                    value={props.value}
+                                    onChange={props.onChange}
+                                    onBlur={props.onBlur}
+                                    label={HOUSE_NUM_LABEL} 
+                                    placeholder={HOUSE_NUM_LABEL}
+                                />
+                            </FormControl>
                         )}
                     />
                 }
             </Grid>
+
             {
                 apartmentField &&
-                <Grid item xs={unsized ? 12 : 2} className={apartmentField?.className}>
+                <Grid item className={apartmentField?.className}>
                     {
                         disabled ?
                         <Controller
@@ -195,15 +210,17 @@ const AddressForm: React.FC<Props> = ({
                             control={control}
                             defaultValue={apartmentField?.defaultValue}
                             render={(props) => (
-                                <TextField 
-                                    className={smallFieldsClass}
-                                    InputProps={{className: smallFieldsClass}}
-                                    test-id={apartmentField?.testId || ''} 
-                                    value={props.value} 
-                                    label={APARTMENT_LABEL} 
-                                    InputLabelProps={{ shrink: true }}
-                                    disabled={true} 
-                                />
+                                <FormControl variant='outlined' fullWidth>
+                                    <TextField 
+                                        className={smallFieldsClass}
+                                        InputProps={{className: smallFieldsClass}}
+                                        test-id={apartmentField?.testId || ''} 
+                                        value={props.value} 
+                                        label={APARTMENT_LABEL} 
+                                        InputLabelProps={{ shrink: true }}
+                                        disabled={true} 
+                                    />
+                                </FormControl>
                             )}
                         />
                         :
@@ -212,18 +229,20 @@ const AddressForm: React.FC<Props> = ({
                             control={control}
                             defaultValue={apartmentField?.defaultValue}
                             render={(props) => (
-                                <AlphanumericTextField
-                                    className={smallFieldsClass}
-                                    error={errors?.apartment?.message}
-                                    InputProps={{className: smallFieldsClass}}
-                                    testId={apartmentField?.testId || ''}
-                                    name={apartmentFieldNameSplitted ? apartmentFieldNameSplitted[apartmentFieldNameSplitted.length - 1] : ''}
-                                    value={props.value}
-                                    onChange={props.onChange}
-                                    onBlur={props.onBlur}
-                                    placeholder={APARTMENT_LABEL}
-                                    label={APARTMENT_LABEL}
-                                />
+                                <FormControl variant='outlined' fullWidth>
+                                    <AlphanumericTextField
+                                        className={smallFieldsClass}
+                                        error={errors?.apartment?.message}
+                                        InputProps={{className: smallFieldsClass}}
+                                        testId={apartmentField?.testId || ''}
+                                        name={apartmentFieldNameSplitted ? apartmentFieldNameSplitted[apartmentFieldNameSplitted.length - 1] : ''}
+                                        value={props.value}
+                                        onChange={props.onChange}
+                                        onBlur={props.onBlur}
+                                        placeholder={APARTMENT_LABEL}
+                                        label={APARTMENT_LABEL}
+                                    />
+                                </FormControl>
                             )}
                         />
                     }
@@ -238,7 +257,7 @@ interface FormField {
     className?: string;
     testId?: string;
     defaultValue?: any;
-}
+};
 
 interface Props {
     disabled?: boolean;
@@ -251,7 +270,7 @@ interface Props {
     control: any;
     watch: any;
     errors?: DeepMap<FlattenedDBAddress , FieldError>;
-}
+};
 
 export type AddressFormFields = Pick<Props, 'cityField' | 'streetField' | 'houseNumberField'> & Partial<Pick<Props, 'floorField' | 'apartmentField'>>;
 

--- a/client/src/commons/NoContextElements/AddressForm.tsx
+++ b/client/src/commons/NoContextElements/AddressForm.tsx
@@ -8,16 +8,13 @@ import City from 'models/City';
 import Street from 'models/Street';
 import FlattenedDBAddress from 'models/DBAddress';
 import StoreStateType from 'redux/storeStateType';
-import InteractedContact from 'models/InteractedContact';
 import { getStreetByCity } from 'Utils/Address/AddressUtils';
-import { get } from 'Utils/auxiliaryFunctions/auxiliaryFunctions';
 
 import useStyles from './AddressFormStyles';
 import AlphanumericTextField from './AlphanumericTextField';
 
 const CITY_LABEL = 'עיר';
 const STREET_LABEL = 'רחוב';
-const FLOOR_LABEL = 'קומה';
 const APARTMENT_LABEL = 'דירה';
 const HOUSE_NUM_LABEL = 'מספר בית';
 const UNKNOWN = 'לא ידוע';
@@ -50,8 +47,6 @@ const AddressForm: React.FC<Props> = ({
         }
     }, [cityWatcher]);
 
-    const houseNumberFieldNameSplitted = houseNumberField?.name.split('.');
-    const floorFieldNameSplitted = floorField?.name.split('.');
     const apartmentFieldNameSplitted = apartmentField?.name.split('.');
     const smallFieldsClass = unsized ? [classes.fullHeight , classes.heightendTextField].join(" ") : classes.fullHeight;
 

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningCheck.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningCheck.tsx
@@ -31,6 +31,7 @@ const ContactQuestioningCheck: React.FC<Props> = (props: Props): JSX.Element => 
                     <Avatar className={classes.avatar}>3</Avatar>
                     <Typography><b>תשאול לצורך הפנייה לבדיקה</b></Typography>
                 </Grid>
+
                 <Grid item>
                     <Grid container>
                         <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.DOES_FEEL_GOOD} className={classes.fieldName}/>
@@ -58,6 +59,7 @@ const ContactQuestioningCheck: React.FC<Props> = (props: Props): JSX.Element => 
                         error={formErrors && formErrors[InteractedContactFields.DOES_FEEL_GOOD]}
                     />
                 </Grid>
+
                 <Grid item>
                     <Grid container>
                         <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.DOES_HAVE_BACKGROUND_DISEASES} className={classes.fieldName}/>
@@ -85,6 +87,7 @@ const ContactQuestioningCheck: React.FC<Props> = (props: Props): JSX.Element => 
                         error={formErrors && formErrors[InteractedContactFields.DOES_HAVE_BACKGROUND_DISEASES]}
                     />
                 </Grid>
+
                 <Grid item>
                     <Grid container>
                         <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.DOES_LIVE_WITH_CONFIRMED} className={classes.fieldName}/>
@@ -111,6 +114,7 @@ const ContactQuestioningCheck: React.FC<Props> = (props: Props): JSX.Element => 
                         error={formErrors && formErrors[InteractedContactFields.DOES_LIVE_WITH_CONFIRMED]}
                     />
                 </Grid>
+
                 <Grid item>
                     <Grid container>
                         <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.REPEATING_OCCURANCE_WITH_CONFIRMED} className={classes.fieldName}/>
@@ -137,6 +141,7 @@ const ContactQuestioningCheck: React.FC<Props> = (props: Props): JSX.Element => 
                         error={formErrors && formErrors[InteractedContactFields.REPEATING_OCCURANCE_WITH_CONFIRMED]}
                     />
                 </Grid>
+
                 <Grid item>
                     <Grid container>
                         <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.DOES_WORK_WITH_CROWD} className={classes.fieldName}/>
@@ -164,10 +169,10 @@ const ContactQuestioningCheck: React.FC<Props> = (props: Props): JSX.Element => 
                         error={formErrors && formErrors[InteractedContactFields.DOES_WORK_WITH_CROWD]}
                     />
                 </Grid>
-                <Grid item>
-                    <Grid container>
-                        <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.OCCUPATION} className={classes.fieldName}/>
-                        <Grid item xs={5}>
+
+                <Grid item container>
+                    <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.OCCUPATION} className={classes.fieldName}/>
+                    <Grid item xs={5}>
                         <Controller
                             control={control}
                             name={`form[${index}.${InteractedContactFields.OCCUPATION}]`}
@@ -196,9 +201,9 @@ const ContactQuestioningCheck: React.FC<Props> = (props: Props): JSX.Element => 
                                 )
                             }}
                             />
-                        </Grid>
                     </Grid>
                 </Grid>
+                
             </Grid>
         </Grid>
     )

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningClinical.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningClinical.tsx
@@ -63,10 +63,12 @@ const ContactQuestioningClinical: React.FC<Props> = (props: Props): JSX.Element 
         },
         houseNumberField: {
             name: `form[${index}].${InteractedContactFields.ISOLATION_ADDRESS}.${InteractedContactFields.CONTACTED_PERSON_HOUSE_NUMBER}`,
+            className: classes.addressTextField,
             defaultValue: interactedContact.isolationAddress?.houseNum,
         },
         apartmentField: {
             name: `form[${index}].${InteractedContactFields.ISOLATION_ADDRESS}.${InteractedContactFields.CONTACTED_PERSON_APARTMENT_NUMBER}`,
+            className: classes.addressTextField,
             defaultValue: interactedContact.isolationAddress?.apartment
         }
     };
@@ -120,53 +122,53 @@ const ContactQuestioningClinical: React.FC<Props> = (props: Props): JSX.Element 
                     <Avatar className={classes.avatar}>2</Avatar>
                     <Typography><b>פרטי מגע וכניסה לבידוד</b></Typography>
                 </Grid>
-                <Grid item>
-                    <Grid container>
-                        <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.FAMILY_RELATIONSHIP} className={classes.fieldName}/>
-                        <Grid item xs={5}>
-                            <Controller
-                                control={control}
-                                name={`form[${index}].${InteractedContactFields.FAMILY_RELATIONSHIP}`}
-                                defaultValue={interactedContact.familyRelationship}                                            
-                                render={(props) => {
-                                    return (
-                                        <FormControl variant='outlined' fullWidth>
-                                            <Select
-                                                {...props}
-                                                disabled={isFieldDisabled || isFamilyContact}
-                                                test-id='familyRelationshipSelect'
-                                                placeholder='קרבה משפחתית'
-                                                onChange={(event) => {
-                                                    props.onChange(event.target.value)
-                                                }}
-                                            >
-                                                {
-                                                    familyRelationships?.length > 0 &&
-                                                    [emptyFamilyRelationship].concat(familyRelationships).map((familyRelationship) => (
-                                                        <MenuItem className={classes.menuItem}
-                                                            key={familyRelationship.id}
-                                                            value={familyRelationship.id}>
-                                                            {familyRelationship.displayName}
-                                                        </MenuItem>
-                                                    ))
-                                                }
-                                            </Select>
-                                        </FormControl>
-                                    )
-                                }}
-                            />
-                        </Grid>
+
+                <Grid item container>
+                    <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.FAMILY_RELATIONSHIP} className={classes.fieldName}/>
+                    <Grid item xs={5}>
+                        <Controller
+                            control={control}
+                            name={`form[${index}].${InteractedContactFields.FAMILY_RELATIONSHIP}`}
+                            defaultValue={interactedContact.familyRelationship}                                            
+                            render={(props) => {
+                                return (
+                                    <FormControl variant='outlined' fullWidth>
+                                        <Select
+                                            {...props}
+                                            disabled={isFieldDisabled || isFamilyContact}
+                                            test-id='familyRelationshipSelect'
+                                            placeholder='קרבה משפחתית'
+                                            onChange={(event) => {
+                                                props.onChange(event.target.value)
+                                            }}
+                                        >
+                                            {
+                                                familyRelationships?.length > 0 &&
+                                                [emptyFamilyRelationship].concat(familyRelationships).map((familyRelationship) => (
+                                                    <MenuItem className={classes.menuItem}
+                                                        key={familyRelationship.id}
+                                                        value={familyRelationship.id}>
+                                                        {familyRelationship.displayName}
+                                                    </MenuItem>
+                                                ))
+                                            }
+                                        </Select>
+                                    </FormControl>
+                                )
+                            }}
+                        />
                     </Grid>
                 </Grid>
+
                 <Grid container item>
                     <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.RELATIONSHIP} className={classes.fieldName}/>
-                    <Grid item xs={7}>
+                    <Grid item xs={5}>
                         <Controller
                             control={control}
                             name={`form[${index}].${InteractedContactFields.RELATIONSHIP}`}
                             defaultValue={interactedContact.relationship}
-                            render={(props) => {
-                                return (
+                            render={(props) => { return (
+                                <FormControl variant='outlined' fullWidth>
                                     <HebrewTextField
                                         {...props}
                                         error={formErrors && formErrors[InteractedContactFields.ADDITIONAL_PHONE_NUMBER]?.message}
@@ -176,26 +178,27 @@ const ContactQuestioningClinical: React.FC<Props> = (props: Props): JSX.Element 
                                             props.onChange(newValue)
                                         }}
                                         placeholder='קשר'
-                                    />)
-                            }}
+                                    />
+                                </FormControl>
+                            )}}
                         />
                     </Grid>
                 </Grid>
+
                 <Grid container item>
-                    <Grid container item>
-                        <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.ISOLATION_PLACE}/>
-                        <Grid container item xs={7}>
-                            <AddressForm
-                                unsized={true}
-                                disabled={isFieldDisabled}
-                                control={control}
-                                watch={watch}
-                                errors={isolationAddressErrors}
-                                {...addressFormFields}
-                            />
-                        </Grid>
+                    <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.ISOLATION_PLACE}/>
+                    <Grid container item xs={5}>
+                        <AddressForm
+                            unsized={true}
+                            disabled={isFieldDisabled}
+                            control={control}
+                            watch={watch}
+                            errors={isolationAddressErrors}
+                            {...addressFormFields}
+                        />
                     </Grid>
                 </Grid>
+                
                 <Grid item>
                     <Grid container>
                         <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.DOES_NEED_HELP_IN_ISOLATION} className={classes.fieldName}/>
@@ -223,6 +226,7 @@ const ContactQuestioningClinical: React.FC<Props> = (props: Props): JSX.Element 
                         error={formErrors && formErrors[InteractedContactFields.DOES_NEED_HELP_IN_ISOLATION]}
                     />
                 </Grid>
+
                 <Grid item>
                     <Grid container>
                         <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.DOES_NEED_ISOLATION} className={classes.fieldName}/>
@@ -253,19 +257,23 @@ const ContactQuestioningClinical: React.FC<Props> = (props: Props): JSX.Element 
                         error={formErrors && formErrors[InteractedContactFields.DOES_NEED_ISOLATION]}
                     />
                 </Grid>
+
                 <Grid container item>
                     <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.ISOLATION_END_DATE} className={classes.fieldName}/>
                     <Grid item xs={5}>
-                        <AlphanumericTextField
-                            disabled
-                            testId='isolationEndDate'
-                            name='isolationEndDate'
-                            value={formattedIsolationEndDate}
-                            onChange={() => {
-                            }}
-                        />
+                        <FormControl variant='outlined' fullWidth>
+                            <AlphanumericTextField
+                                disabled
+                                testId='isolationEndDate'
+                                name='isolationEndDate'
+                                value={formattedIsolationEndDate}
+                                onChange={() => {
+                                }}
+                            />
+                        </FormControl>
                     </Grid>
                 </Grid>
+
             </Grid>
         </Grid>
     )

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningFieldsNames.ts
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningFieldsNames.ts
@@ -16,6 +16,7 @@ enum ContactQuestioningFieldsNames {
     REPEATING_OCCURANCE_WITH_CONFIRMED = 'מפגש חוזר עם המאומת?',
     DOES_WORK_WITH_CROWD = 'עבודה עם קהל במסגרת העבודה?',
     OCCUPATION = 'תעסוקה:',
+    EXTRA_INFO = 'הערות נוספות:',
 };
 
 export default ContactQuestioningFieldsNames;

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
@@ -82,64 +82,68 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
                         <b>פרטים אישיים נוספים</b>
                     </Typography>
                 </Grid>
-                <Grid item>
-                    <Grid container>
-                        <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.IDENTIFICATION_TYPE} className={classes.fieldName}/>
-                        <Grid item xs={5}>
-                            <Controller
-                                control={control}
-                                name={`form[${index}].${InteractedContactFields.IDENTIFICATION_TYPE}`}
-                                defaultValue={formValues.identificationType?.id}
-                                render={(props) => (
-                                    <FormControl 
-                                        error={currentFormErrors ? !!(currentFormErrors[InteractedContactFields.IDENTIFICATION_TYPE]) : false}  
-                                        variant='outlined'
-                                        fullWidth
-                                    >
-                                        <Select
-                                            {...props}
-                                            disabled={shouldIdDisable}
-                                            onChange={(event) => {
-                                                props.onChange(event.target.value)
+
+                <Grid container item>
+                    <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.IDENTIFICATION_TYPE} className={classes.fieldName}/>
+                    <Grid item xs={5}>
+                        <Controller
+                            control={control}
+                            name={`form[${index}].${InteractedContactFields.IDENTIFICATION_TYPE}`}
+                            defaultValue={formValues.identificationType?.id}
+                            render={(props) => (
+                                <FormControl 
+                                    error={currentFormErrors ? !!(currentFormErrors[InteractedContactFields.IDENTIFICATION_TYPE]) : false}  
+                                    variant='outlined'
+                                    fullWidth
+                                >
+                                    <Select
+                                        {...props}
+                                        disabled={shouldIdDisable}
+                                        onChange={(event) => {
+                                            props.onChange(event.target.value)
+                                        }}
+                                        MenuProps={{
+                                            anchorOrigin: {
+                                                vertical: 'bottom',
+                                                horizontal: 'left'
+                                            },
+                                            transformOrigin: {
+                                                vertical: 'top',
+                                                horizontal: 'left'
+                                            },
+                                            getContentAnchorEl: null
                                             }}
-                                            MenuProps={{
-                                                anchorOrigin: {
-                                                    vertical: 'bottom',
-                                                    horizontal: 'left'
-                                                },
-                                                transformOrigin: {
-                                                    vertical: 'top',
-                                                    horizontal: 'left'
-                                                },
-                                                getContentAnchorEl: null
-                                                }}
-                                        >
-                                            {Object.values(identificationTypes).map((identificationType: IdentificationType) => (
-                                                <MenuItem
-                                                    className={classes.smallSizeText}
-                                                    key={identificationType.id}
-                                                    value={identificationType.id}>
-                                                    {identificationType.type}
-                                                </MenuItem>
-                                            ))}
-                                        </Select>
-                                    </FormControl>
-                                )}
-                            />
-                            {currentFormErrors && currentFormErrors[InteractedContactFields.IDENTIFICATION_TYPE] && <FormHelperText>{requiredText}</FormHelperText>}
-                        </Grid>
+                                    >
+                                        {Object.values(identificationTypes).map((identificationType: IdentificationType) => (
+                                            <MenuItem
+                                                className={classes.smallSizeText}
+                                                key={identificationType.id}
+                                                value={identificationType.id}>
+                                                {identificationType.type}
+                                            </MenuItem>
+                                        ))}
+                                    </Select>
+                                </FormControl>
+                            )}
+                        />
+                        {currentFormErrors && currentFormErrors[InteractedContactFields.IDENTIFICATION_TYPE] && <FormHelperText>{requiredText}</FormHelperText>}
                     </Grid>
                 </Grid>
+
                 <Grid container item>
                     <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.IDENTIFICATION_NUMBER} className={classes.fieldName}/>
+                    <Grid item xs={5}>
                         <Controller
                             control={control}
                             name={`form[${index}].${InteractedContactFields.IDENTIFICATION_NUMBER}`}
                             defaultValue={
                                 interactedContact.identificationNumber
                             }
-                            render={(props) => {
-                                return (
+                            render={(props) => { return (
+                                <FormControl 
+                                    variant='outlined'
+                                    fullWidth
+                                >
                                     <IdentificationTextField
                                         {...props}
                                         error={(currentFormErrors && currentFormErrors[InteractedContactFields.IDENTIFICATION_NUMBER]?.message ) || ''}
@@ -151,67 +155,91 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
                                         placeholder='מספר תעודה'
                                         isId={isId}
                                     />
+                                </FormControl>
+                            )}}
+                        />
+                    </Grid>
+                </Grid>
+
+                <Grid container item alignItems='center'>
+                    <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.BIRTH_DATE} className={classes.fieldName}/>
+                    <Grid item xs={5}>
+                        <Controller
+                            control={control}
+                            name={`form[${index}].${InteractedContactFields.BIRTH_DATE}`}
+                            defaultValue={interactedContact.birthDate}
+                            render={(props) => {
+                                const dateError = currentFormErrors && currentFormErrors[InteractedContactFields.BIRTH_DATE]?.message;
+                                return (
+                                    <FormControl 
+                                        variant='outlined'
+                                        fullWidth
+                                    >
+                                        <DatePick
+                                            {...props}
+                                            disabled={isFieldDisabled}
+                                            testId='contactBirthDate'
+                                            maxDate={new Date()}
+                                            maxDateMessage='תאריך לידה לא יכול להיות יותר מאוחר מהיום'
+                                            useBigCalender={false}
+                                            labelText={dateError ? invalidDateText : undefined}
+                                            error={Boolean(dateError)}
+                                            onChange={(newDate: Date) => {
+                                                props.onChange(newDate);
+                                                setAge(calcAge(newDate));
+                                            }}
+                                        />
+                                    </FormControl>
                                 );
                             }}
                         />
+                    </Grid>
                 </Grid>
-                <Grid container item alignItems='center'>
-                    <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.BIRTH_DATE} className={classes.fieldName}/>
-                    <Controller
-                        control={control}
-                        name={`form[${index}].${InteractedContactFields.BIRTH_DATE}`}
-                        defaultValue={interactedContact.birthDate}
-                        render={(props) => {
-                            const dateError = currentFormErrors && currentFormErrors[InteractedContactFields.BIRTH_DATE]?.message;
-                            return (
-                                <DatePick
-                                    {...props}
-                                    disabled={isFieldDisabled}
-                                    testId='contactBirthDate'
-                                    maxDate={new Date()}
-                                    maxDateMessage='תאריך לידה לא יכול להיות יותר מאוחר מהיום'
-                                    useBigCalender={false}
-                                    labelText={dateError ? invalidDateText : undefined}
-                                    error={Boolean(dateError)}
-                                    onChange={(newDate: Date) => {
-                                        props.onChange(newDate);
-                                        setAge(calcAge(newDate));
-                                    }}
-                                />
-                            );
-                        }}
-                    />
-                </Grid>
+
                 <Grid container item>
                     <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.AGE} className={classes.fieldName}/>
-                    <AlphanumericTextField
-                        disabled={true}
-                        name='age'
-                        testId='contactAge'
-                        value={age}
-                        onChange={() => {}}
-                        placeholder='בחר תאריך לידה'
-                    />
+                    <Grid item xs={5}>
+                        <FormControl 
+                            variant='outlined'
+                            fullWidth
+                        >
+                            <AlphanumericTextField
+                                disabled={true}
+                                name='age'
+                                testId='contactAge'
+                                value={age}
+                                onChange={() => {}}
+                                placeholder='בחר תאריך לידה'
+                            />
+                        </FormControl>
+                    </Grid>
                 </Grid>
+
                 <Grid container item>
                     <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.PHONE} className={classes.fieldName}/>
-                    <Controller
-                        control={control}
-                        name={`form[${index}].${InteractedContactFields.PHONE_NUMBER}`}
-                        defaultValue={interactedContact.phoneNumber}
-                        render={(props) => {
-                            return (
-                                <NumericTextField
-                                    {...props}
-                                    error={currentFormErrors && currentFormErrors[InteractedContactFields.PHONE_NUMBER]?.message}
-                                    disabled={isFieldDisabled}
-                                    testId='phoneNumber'
-                                    placeholder='הכנס טלפון:'
-                                />
-                            );
-                        }}
-                    />
+                    <Grid item xs={5}>
+                        <Controller
+                            control={control}
+                            name={`form[${index}].${InteractedContactFields.PHONE_NUMBER}`}
+                            defaultValue={interactedContact.phoneNumber}
+                            render={(props) => { return (
+                                <FormControl 
+                                    variant='outlined'
+                                    fullWidth
+                                >
+                                    <NumericTextField
+                                        {...props}
+                                        error={currentFormErrors && currentFormErrors[InteractedContactFields.PHONE_NUMBER]?.message}
+                                        disabled={isFieldDisabled}
+                                        testId='phoneNumber'
+                                        placeholder='הכנס טלפון:'
+                                    />
+                                </FormControl>
+                            )}}
+                        />
+                    </Grid>
                 </Grid>
+
                 <Grid container item>
                     <Grid item xs={12}>
                         <Typography >
@@ -237,14 +265,19 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
                         })
                     }
                 </Grid>
+
                 <Grid container item>
-                    <Grid item xs={12}>
+                    <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.EXTRA_INFO} className={classes.fieldName}/>
+                    <Grid item xs={5}>
                         <Controller
                             control={control}
                             name={`form[${index}].${InteractedContactFields.EXTRA_INFO}`}
                             defaultValue={interactedContact.extraInfo}
-                            render={(props) => {
-                                return (
+                            render={(props) => { return (
+                                <FormControl 
+                                    variant='outlined'
+                                    fullWidth
+                                >
                                     <AlphanumericTextField
                                         {...props}
                                         disabled={isFieldDisabled}
@@ -253,8 +286,9 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
                                             props.onChange(newValue)
                                         }}
                                         placeholder='הערות נוספות'
-                                />)
-                            }}
+                                    />
+                                </FormControl>
+                            )}}
                         />
                     </Grid>
                 </Grid>

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
@@ -140,10 +140,7 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
                                 interactedContact.identificationNumber
                             }
                             render={(props) => { return (
-                                <FormControl 
-                                    variant='outlined'
-                                    fullWidth
-                                >
+                                <FormControl variant='outlined' fullWidth>
                                     <IdentificationTextField
                                         {...props}
                                         error={(currentFormErrors && currentFormErrors[InteractedContactFields.IDENTIFICATION_NUMBER]?.message ) || ''}
@@ -171,10 +168,7 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
                             render={(props) => {
                                 const dateError = currentFormErrors && currentFormErrors[InteractedContactFields.BIRTH_DATE]?.message;
                                 return (
-                                    <FormControl 
-                                        variant='outlined'
-                                        fullWidth
-                                    >
+                                    <FormControl variant='outlined' fullWidth>
                                         <DatePick
                                             {...props}
                                             disabled={isFieldDisabled}
@@ -199,10 +193,7 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
                 <Grid container item>
                     <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.AGE} className={classes.fieldName}/>
                     <Grid item xs={5}>
-                        <FormControl 
-                            variant='outlined'
-                            fullWidth
-                        >
+                        <FormControl variant='outlined' fullWidth>
                             <AlphanumericTextField
                                 disabled={true}
                                 name='age'
@@ -223,10 +214,7 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
                             name={`form[${index}].${InteractedContactFields.PHONE_NUMBER}`}
                             defaultValue={interactedContact.phoneNumber}
                             render={(props) => { return (
-                                <FormControl 
-                                    variant='outlined'
-                                    fullWidth
-                                >
+                                <FormControl variant='outlined' fullWidth>
                                     <NumericTextField
                                         {...props}
                                         error={currentFormErrors && currentFormErrors[InteractedContactFields.PHONE_NUMBER]?.message}
@@ -274,10 +262,7 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
                             name={`form[${index}].${InteractedContactFields.EXTRA_INFO}`}
                             defaultValue={interactedContact.extraInfo}
                             render={(props) => { return (
-                                <FormControl 
-                                    variant='outlined'
-                                    fullWidth
-                                >
+                                <FormControl variant='outlined' fullWidth>
                                     <AlphanumericTextField
                                         {...props}
                                         disabled={isFieldDisabled}

--- a/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
+++ b/client/src/components/App/Content/InvestigationForm/TabManagement/ContactQuestioning/ContactQuestioningPersonal.tsx
@@ -82,18 +82,19 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
                         <b>פרטים אישיים נוספים</b>
                     </Typography>
                 </Grid>
-                <Grid item container alignItems='center' spacing={1}>
-                    <FieldName fieldName={ContactQuestioningFieldsNames.IDENTIFICATION_TYPE} className={classes.fieldName}/>
-                    <Grid item xs={3}> 
+                <Grid item>
+                    <Grid container>
+                        <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.IDENTIFICATION_TYPE} className={classes.fieldName}/>
+                        <Grid item xs={5}>
                             <Controller
                                 control={control}
                                 name={`form[${index}].${InteractedContactFields.IDENTIFICATION_TYPE}`}
                                 defaultValue={formValues.identificationType?.id}
                                 render={(props) => (
                                     <FormControl 
-                                        fullWidth 
                                         error={currentFormErrors ? !!(currentFormErrors[InteractedContactFields.IDENTIFICATION_TYPE]) : false}  
                                         variant='outlined'
+                                        fullWidth
                                     >
                                         <Select
                                             {...props}
@@ -126,9 +127,11 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
                                 )}
                             />
                             {currentFormErrors && currentFormErrors[InteractedContactFields.IDENTIFICATION_TYPE] && <FormHelperText>{requiredText}</FormHelperText>}
+                        </Grid>
                     </Grid>
-                    <FieldName fieldName={ContactQuestioningFieldsNames.IDENTIFICATION_NUMBER} className={classes.fieldName}/>
-                    <Grid item xs={3}>
+                </Grid>
+                <Grid container item>
+                    <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.IDENTIFICATION_NUMBER} className={classes.fieldName}/>
                         <Controller
                             control={control}
                             name={`form[${index}].${InteractedContactFields.IDENTIFICATION_NUMBER}`}
@@ -151,7 +154,6 @@ const ContactQuestioningPersonal: React.FC<Props> = (props: Props): JSX.Element 
                                 );
                             }}
                         />
-                    </Grid>
                 </Grid>
                 <Grid container item alignItems='center'>
                     <FieldName xs={5} fieldName={ContactQuestioningFieldsNames.BIRTH_DATE} className={classes.fieldName}/>


### PR DESCRIPTION
Additional changes in Contact Questioning Tab due to ticket: [1847](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1847/)

UI Changes:
- Now all fields have same width. 
- Separate identification type and number to different lines.
- Aligned extra info field to be the same line as the rest of the form.
- Address Form fields now have same size.