### PR TITLE
1859/fix/display-matching-sub-statuses

### DIFF
--- a/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigatedPersonInfo/InvestigationStatusInfo/InvestigationStatusInfo.tsx
+++ b/client/src/components/App/Content/InvestigationForm/InvestigationInfo/InvestigatedPersonInfo/InvestigationStatusInfo/InvestigationStatusInfo.tsx
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 import React, {ChangeEvent, useEffect, useMemo} from 'react';
 import {Collapse, FormControl, Grid, InputLabel, MenuItem, Select, TextField, Typography} from '@material-ui/core';
 
+import SubStatus from 'models/SubStatus';
 import StoreStateType from 'redux/storeStateType';
 import UserTypeCodes from 'models/enums/UserTypeCodes';
 import useStatusUtils from 'Utils/StatusUtils/useStatusUtils';
@@ -27,7 +28,7 @@ const InvestigationStatusInfo = (props: any) => {
 
     const investigationStatus = useSelector<StoreStateType, InvestigationStatus>(state => state.investigation.investigationStatus);
     const statuses = useSelector<StoreStateType, InvestigationMainStatus[]>(state => state.statuses);
-    const subStatuses = useSelector<StoreStateType, string[]>(state => state.subStatuses);
+    const subStatuses = useSelector<StoreStateType, SubStatus[]>(state => state.subStatuses);
     const userType = useSelector<StoreStateType, number>(state => state.user.data.userType);
 
     useEffect(() => {
@@ -37,7 +38,7 @@ const InvestigationStatusInfo = (props: any) => {
     }, [investigationStatus.subStatus]);
 
     const updatedSubStatuses = useMemo(() =>
-        investigationStatus.mainStatus === InvestigationMainStatusCodes.IN_PROCESS ? [inProcess , ...subStatuses] : subStatuses,
+        investigationStatus.mainStatus === InvestigationMainStatusCodes.IN_PROCESS ? [{displayName: inProcess, id: 0, parentStatus: 100000002} , ...subStatuses] : subStatuses,
         [subStatuses, investigationStatus]);
 
     const permittedStatuses = statuses.filter(status => status.id !== InvestigationMainStatusCodes.DONE);
@@ -123,8 +124,8 @@ const InvestigationStatusInfo = (props: any) => {
                                             test-id='currentSubStatus'
                                             label={subStatusLabel}
                                             value={investigationStatus.subStatus as string | undefined}
-                                            onChange={(event) => {
-                                                const newSubStatus = event.target.value as string
+                                            onChange={(event: any) => {
+                                                const newSubStatus = event.target.value?.displayName as string
                                                 setInvestigationStatus({
                                                     mainStatus: investigationStatus.mainStatus,
                                                     subStatus: newSubStatus ? String(newSubStatus) : null,
@@ -133,11 +134,11 @@ const InvestigationStatusInfo = (props: any) => {
                                             }}
                                         >
                                             {
-                                                updatedSubStatuses.map((subStatus: string) => (
+                                                updatedSubStatuses.map((subStatus: SubStatus) => (
                                                     <MenuItem
-                                                        key={subStatus}
-                                                        value={subStatus}>
-                                                        {subStatus}
+                                                        key={subStatus.id}
+                                                        value={subStatus.displayName}>
+                                                        {subStatus.displayName}
                                                     </MenuItem>
                                                 ))
                                             }

--- a/client/src/components/App/Content/InvestigationForm/useInvestigationForm.ts
+++ b/client/src/components/App/Content/InvestigationForm/useInvestigationForm.ts
@@ -157,7 +157,7 @@ const useInvestigationForm = (): useInvestigationFormOutcome => {
             subStatusesByStatusLogger.info(`recieved DB response ${JSON.stringify(result)}`, Severity.LOW);
             const resultNodes = result?.data?.data?.allInvestigationSubStatuses?.nodes;
             if (resultNodes) {
-                setSubStatuses(resultNodes.map((element: any) => element.displayName));
+                setSubStatuses(resultNodes);
             }
         }).catch((err: any) => {
             subStatusesByStatusLogger.error( `error DB response ${JSON.stringify(err)}`,  Severity.LOW);

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -11,13 +11,13 @@ import { KeyboardArrowDown, KeyboardArrowLeft, Refresh } from '@material-ui/icon
 
 import Desk from 'models/Desk';
 import User from 'models/User';
+import SubStatus from 'models/SubStatus';
 import SortOrder from 'models/enums/SortOrder';
 import StoreStateType from 'redux/storeStateType';
 import useDesksUtils from 'Utils/Desk/useDesksUtils';
 import UserTypeCodes from 'models/enums/UserTypeCodes';
 import InvestigatorOption from 'models/InvestigatorOption';
 import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
-import InvestigationSubStatus from 'models/InvestigationSubStatus';
 import InvestigationTableRowType from 'models/InvestigationTableRow';
 import InvestigationMainStatus from 'models/InvestigationMainStatus';
 import RefreshSnackbar from 'commons/RefreshSnackbar/RefreshSnackbar';
@@ -51,7 +51,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
     const [order, setOrder] = useState<Order>(SortOrder.asc);
     const [orderBy, setOrderBy] = useState<string>(defaultOrderBy);
     const [allStatuses, setAllStatuses] = useState<InvestigationMainStatus[]>([]);
-    const [allSubStatuses, setAllSubStatuses] = useState<InvestigationSubStatus[]>([]);
+    const [allSubStatuses, setAllSubStatuses] = useState<SubStatus[]>([]);
     const [allComplexReasons, setAllComplexReasons] = useState<(number|null)[]>([]);
     const [currentPage, setCurrentPage] = useState<number>(defaultPage);
     const [checkGroupedInvestigationOpen, setCheckGroupedInvestigationOpen] = useState<number[]>([])

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -231,9 +231,9 @@ const InvestigationTable: React.FC = (): JSX.Element => {
         };
 
     useEffect(() => {
-        window.addEventListener("keydown", handleEscKey);
+        window.addEventListener('keydown', handleEscKey);
         return () => {
-            window.removeEventListener("keydown", handleEscKey);
+            window.removeEventListener('keydown', handleEscKey);
         };
     }, []);
 

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTable.tsx
@@ -255,7 +255,7 @@ const InvestigationTable: React.FC = (): JSX.Element => {
                             statuses={allStatuses}
                             subStatuses={allSubStatuses}
                             filteredStatuses={statusFilter}
-                            onFilterChange={(event, value) => changeStatusFilter(value)}
+                            onFilterChange={changeStatusFilter}
                             filteredSubStatuses={subStatusFilter}
                             onSubStatusChange={(event, value) => changeSubStatusFilter(value)}
                             changeInactiveUserFilter={changeInactiveUserFilter}

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/InvestigationTableInterfaces.ts
@@ -3,10 +3,10 @@ import { MutableRefObject } from 'react';
 import User from 'models/User';
 import Desk from 'models/Desk';
 import County from 'models/County';
+import SubStatus from 'models/SubStatus';
 import { TimeRange } from 'models/TimeRange';
 import InvestigatorOption from 'models/InvestigatorOption';
 import InvestigationTableRow from 'models/InvestigationTableRow';
-import InvestigationSubStatus from 'models/InvestigationSubStatus';
 import InvestigationMainStatus from 'models/InvestigationMainStatus';
 import InvestigationMainStatusCodes from 'models/enums/InvestigationMainStatusCodes';
 import AllocatedInvestigator from 'models/InvestigationTable/AllocateInvestigatorDialog/AllocatedInvestigator';
@@ -30,7 +30,7 @@ export interface HistoryState {
     inactiveUserFilter?: boolean;
     isAdminLandingRedirect?: boolean;
     filterTitle?: string;
-}
+};
 
 export interface useInvestigationTableParameters {
     currentPage: number;
@@ -38,11 +38,11 @@ export interface useInvestigationTableParameters {
     setSelectedRow: React.Dispatch<React.SetStateAction<SelectedRow>>;
     setAllStatuses: React.Dispatch<React.SetStateAction<InvestigationMainStatus[]>>;
     setAllComplexReasons: React.Dispatch<React.SetStateAction<(number|null)[]>>;
-    setAllSubStatuses: React.Dispatch<React.SetStateAction<InvestigationSubStatus[]>>;
+    setAllSubStatuses: React.Dispatch<React.SetStateAction<SubStatus[]>>;
     setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
     setAllGroupedInvestigations: React.Dispatch<React.SetStateAction<Map<string, InvestigationTableRow[]>>>;
     investigationColor: MutableRefObject<Map<string, string>>;
-}
+};
 
 export interface useInvestigationTableOutcome {
     tableRows: InvestigationTableRow[];
@@ -67,7 +67,7 @@ export interface useInvestigationTableOutcome {
     statusFilter: StatusFilter;
     subStatusFilter: SubStatusFilter;
     changeStatusFilter: (statuses: InvestigationMainStatus[]) => void;
-    changeSubStatusFilter: (subStatuses: InvestigationSubStatus[]) => void;
+    changeSubStatusFilter: (subStatuses: SubStatus[]) => void;
     deskFilter: DeskFilter;
     changeDeskFilter: (desks: Desk[]) => void;
     changeSearchFilter: (searchQuery: string) => void;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/TableFilter/TableFilter.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/TableFilter/TableFilter.tsx
@@ -1,20 +1,21 @@
-import React from 'react'
+import React, { useMemo, useState } from 'react'
 import { Autocomplete } from '@material-ui/lab';
 import { Card, Checkbox, Collapse, FormControl, Grid, Box, TextField, Typography } from '@material-ui/core';
 
-import { stringAlphanum } from 'commons/AlphanumericTextField/AlphanumericTextField';
-import SearchBar from 'commons/SearchBar/SearchBar';
+import Desk from 'models/Desk';
+import SubStatus from 'models/SubStatus';
 import { TimeRange } from 'models/TimeRange';
-import timeRanges, { customTimeRange, timeRangeMinDate } from 'models/enums/timeRanges';
+import SearchBar from 'commons/SearchBar/SearchBar';
 import DateRangePick from 'commons/DatePick/DateRangePick';
 import SelectDropdown from 'commons/Select/SelectDropdown';
-import InvestigationSubStatus from 'models/InvestigationSubStatus';
 import InvestigationMainStatus from 'models/InvestigationMainStatus';
-import Desk from 'models/Desk';
+import { stringAlphanum } from 'commons/AlphanumericTextField/AlphanumericTextField';
+import InvestigationMainStatusCodes from 'models/enums/InvestigationMainStatusCodes';
+import timeRanges, { customTimeRange, timeRangeMinDate } from 'models/enums/timeRanges';
 
-import DeskFilter from '../DeskFilter/DeskFilter';
 import useStyles from './TableFilterStyles';
 import useTableFilter from './useTableFilter';
+import DeskFilter from '../DeskFilter/DeskFilter';
 import { StatusFilter as StatusFilterType, SubStatusFilter as SubStatusFilterType } from '../InvestigationTableInterfaces';
 
 const searchBarLabel = 'מספר אפידמיולוגי, ת"ז, שם או טלפון';
@@ -38,7 +39,14 @@ const TableFilter = (props: Props) => {
         onTimeRangeFilterChange
     });
 
+    const [statusesId, setStatusesIds] = useState([]);
     const isCustomTimeRange = timeRangeFilter.id === customTimeRange.id
+
+
+    // const updatedSubStatuses = useMemo(() =>
+    //     status === InvestigationMainStatusCodes.IN_PROCESS ? [inProcess , ...subStatuses] : subStatuses,
+    //     [subStatuses, status]);
+
 
     return (
         <Card className={classes.card}>
@@ -137,7 +145,7 @@ const TableFilter = (props: Props) => {
                 )}
                 limitTags={1}
             />
-            <Grid className={classes.endCard} xs={3} direction="column">
+            <Grid className={classes.endCard} xs={3} direction='column'>
                 <div className={classes.row}>
                     <Checkbox
                         onChange={(event) => changeUnassginedUserFilter(event.target.checked)}
@@ -173,7 +181,7 @@ const TableFilter = (props: Props) => {
 
 interface Props {
     statuses: InvestigationMainStatus[];
-    subStatuses: InvestigationSubStatus[];
+    subStatuses: SubStatus[];
     filteredStatuses: StatusFilterType;
     filteredSubStatuses: SubStatusFilterType;
     unassignedUserFilter: boolean;
@@ -181,7 +189,7 @@ interface Props {
     changeUnassginedUserFilter: (isFilterOn: boolean) => void;
     changeInactiveUserFilter: (isFilterOn: boolean) => void;
     onFilterChange: (event: React.ChangeEvent<{}>, selectedStatuses: InvestigationMainStatus[]) => void;
-    onSubStatusChange: (event: React.ChangeEvent<{}>, selectedSubStatuses: InvestigationSubStatus[]) => void;
+    onSubStatusChange: (event: React.ChangeEvent<{}>, selectedSubStatuses: SubStatus[]) => void;
     timeRangeFilter: TimeRange;
     onTimeRangeFilterChange: (timeRangeFilter: TimeRange) => void;
     updateDateFilter: string;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/TableFilter/TableFilter.tsx
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/TableFilter/TableFilter.tsx
@@ -39,14 +39,9 @@ const TableFilter = (props: Props) => {
         onTimeRangeFilterChange
     });
 
-    const [statusesId, setStatusesIds] = useState([]);
-    const isCustomTimeRange = timeRangeFilter.id === customTimeRange.id
+    const [subStatusFiltered, setSubStatusFiltered] = useState<SubStatus[]>(subStatuses);
 
-
-    // const updatedSubStatuses = useMemo(() =>
-    //     status === InvestigationMainStatusCodes.IN_PROCESS ? [inProcess , ...subStatuses] : subStatuses,
-    //     [subStatuses, status]);
-
+    const isCustomTimeRange = timeRangeFilter.id === customTimeRange.id;
 
     return (
         <Card className={classes.card}>
@@ -80,7 +75,7 @@ const TableFilter = (props: Props) => {
                 <Typography className={classes.timeRangeError}>{errorMes}</Typography>
             }
             <Autocomplete
-                disabled={updateDateFilter !== "" || nonContactFilter}
+                disabled={updateDateFilter !== '' || nonContactFilter}
                 ChipProps={{className:classes.chip}}
                 className={classes.autocomplete}
                 classes={{inputFocused: classes.autocompleteInputText}}
@@ -90,7 +85,12 @@ const TableFilter = (props: Props) => {
                 options={statuses}
                 value={statuses.filter(status => filteredStatuses.includes(status.id))}
                 getOptionLabel={(option) => option.displayName}
-                onChange={onFilterChange}
+                onChange={(event, value) => {
+                    onFilterChange(value);
+                    value.length > 0 
+                        ? setSubStatusFiltered(subStatuses.filter(subStatus => value.map(status => status.id).includes(subStatus.parentStatus)))
+                        : setSubStatusFiltered(subStatuses)
+                }}
                 renderInput={(params) =>
                     <TextField
                         label={'סטטוס'}
@@ -113,15 +113,15 @@ const TableFilter = (props: Props) => {
                 limitTags={1}
             />
             <Autocomplete
-                disabled={updateDateFilter !== ""}
+                disabled={updateDateFilter !== ''}
                 ChipProps={{className:classes.chip}}
                 className={classes.autocomplete}
                 classes={{inputFocused: classes.autocompleteInputText}}
                 size='small'
                 disableCloseOnSelect
                 multiple
-                options={subStatuses}
-                value={subStatuses.filter(subStatus => filteredSubStatuses.includes(subStatus.displayName))}
+                options={subStatusFiltered.length > 0 ? subStatusFiltered : subStatuses}
+                value={subStatusFiltered.filter(subStatus => filteredSubStatuses.includes(subStatus.displayName))}
                 getOptionLabel={(option) => option.displayName}
                 onChange={onSubStatusChange}
                 renderInput={(params) =>
@@ -188,7 +188,7 @@ interface Props {
     inactiveUserFilter: boolean;
     changeUnassginedUserFilter: (isFilterOn: boolean) => void;
     changeInactiveUserFilter: (isFilterOn: boolean) => void;
-    onFilterChange: (event: React.ChangeEvent<{}>, selectedStatuses: InvestigationMainStatus[]) => void;
+    onFilterChange: (selectedStatuses: InvestigationMainStatus[]) => void;
     onSubStatusChange: (event: React.ChangeEvent<{}>, selectedSubStatuses: SubStatus[]) => void;
     timeRangeFilter: TimeRange;
     onTimeRangeFilterChange: (timeRangeFilter: TimeRange) => void;

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -144,7 +144,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             timeRangeFilter: historyTimeRange = defaultTimeRange,
             inactiveUserFilter : historyInactiveUserFilter = false, 
             unassignedUserFilter : historyUnassignedUserFilter = false,
-            updateDateFilter : historyUpdateDateFilter = "",
+            updateDateFilter : historyUpdateDateFilter = '',
             nonContactFilter : historyNonContactFilter = false,
             isAdminLandingRedirect : historyisAdminLandingRedirect = false,
             filterTitle} = useMemo(() => {
@@ -672,7 +672,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             [TableHeadersNames.city]: row.city,
             [TableHeadersNames.subOccupation]: row.subOccupation,
             [TableHeadersNames.investigatorName]: row.investigator.authorityName ? 
-                                                    row.investigator.userName + " - " + row.investigator.authorityName : 
+                                                    row.investigator.userName + ' - ' + row.investigator.authorityName : 
                                                     row.investigator.userName,
             [investigatorIdPropertyName]: row.investigator.id,
             [TableHeadersNames.investigationStatus]: row.mainStatus,

--- a/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
+++ b/client/src/components/App/Content/LandingPage/InvestigationTable/useInvestigationTable.ts
@@ -21,7 +21,6 @@ import InvestigatorOption from 'models/InvestigatorOption';
 import { defaultTimeRange } from 'models/enums/timeRanges';
 import useCustomSwal from 'commons/CustomSwal/useCustomSwal';
 import InvestigationTableRow from 'models/InvestigationTableRow';
-import InvestigationSubStatus from 'models/InvestigationSubStatus';
 import InvestigationMainStatus from 'models/InvestigationMainStatus';
 import { setIsLoading } from 'redux/IsLoading/isLoadingActionCreators';
 import getColorByGroupId from 'Utils/GroupedInvestigations/getColorByGroupId';
@@ -42,6 +41,7 @@ import {
     TableHeadersNames, IndexedInvestigationData, investigatorIdPropertyName, TableKeys, HiddenTableKeys
 } from './InvestigationTablesHeaders';
 import { DeskFilter, HistoryState, StatusFilter, SubStatusFilter, useInvestigationTableOutcome, useInvestigationTableParameters } from './InvestigationTableInterfaces';
+import SubStatus from 'models/SubStatus';
 
 const investigationURL = '/investigation';
 
@@ -243,8 +243,8 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
         setCurrentPage(defaultPage);
     };
 
-    const changeSubStatusFilter = (subStatuses: InvestigationSubStatus[]) => {
-        const subStatusesIds = subStatuses.map(subStatuse => subStatuse.displayName);
+    const changeSubStatusFilter = (subStatuses: SubStatus[]) => {
+        const subStatusesIds = subStatuses.map(subStatus => subStatus.displayName);
         updateFilterHistory('subStatusFilter', subStatusesIds);
         setSubStatusFilter(subStatusesIds);
         handleFilterChange(filterCreators.SUB_STATUS(subStatusesIds));
@@ -347,7 +347,7 @@ const useInvestigationTable = (parameters: useInvestigationTableParameters): use
             then((result) => {
                 if (result?.data && result.headers['content-type'].includes('application/json')) {
                     subStatusesLogger.info('The investigations statuses were fetched successfully', Severity.LOW);
-                    const allSubStatuses: InvestigationMainStatus[] = result.data;
+                    const allSubStatuses: SubStatus[] = result.data;
                     setAllSubStatuses(allSubStatuses);
                 } else {
                     subStatusesLogger.error('Got 200 status code but results structure isnt as expected', Severity.HIGH);

--- a/client/src/models/InvestigationMainStatus.ts
+++ b/client/src/models/InvestigationMainStatus.ts
@@ -1,6 +1,6 @@
-interface InvestigationMainStatus  {
+interface InvestigationMainStatus {
     id: number;
     displayName: string;
-}
+};
 
 export default InvestigationMainStatus;

--- a/client/src/models/InvestigationStatus.ts
+++ b/client/src/models/InvestigationStatus.ts
@@ -2,4 +2,4 @@ export interface InvestigationStatus {
     mainStatus: number;
     subStatus: string | null;
     statusReason: string | null;
-}
+};

--- a/client/src/models/InvestigationSubStatus.ts
+++ b/client/src/models/InvestigationSubStatus.ts
@@ -1,6 +1,0 @@
-interface InvestigationSubStatus  {
-    id: number;
-    displayName: string;
-}
-
-export default InvestigationSubStatus;

--- a/client/src/models/SubStatus.ts
+++ b/client/src/models/SubStatus.ts
@@ -1,5 +1,6 @@
 interface SubStatus {
-    parentId: number;
+    id: number;
+    parentStatus: number;
     displayName: string;
 };
 

--- a/client/src/models/SubStatus.ts
+++ b/client/src/models/SubStatus.ts
@@ -1,0 +1,6 @@
+interface SubStatus {
+    parentId: number;
+    displayName: string;
+};
+
+export default SubStatus;

--- a/client/src/redux/Status/statusesActionCreators.ts
+++ b/client/src/redux/Status/statusesActionCreators.ts
@@ -8,4 +8,4 @@ export const setStatuses = (statuses: InvestigationMainStatus[]): void => {
         type: actionTypes.SET_STATUSES,
         payload: { statuses }
     })
-}
+};

--- a/client/src/redux/Status/statusesReducer.ts
+++ b/client/src/redux/Status/statusesReducer.ts
@@ -2,14 +2,15 @@ import InvestigationMainStatus from 'models/InvestigationMainStatus';
 
 import * as Actions from './statusesActionTypes';
 
-const initialState: InvestigationMainStatus[] = []
+const initialState: InvestigationMainStatus[] = [];
 
 const statusesReducer = (state = initialState, action: Actions.StatusesAction): InvestigationMainStatus[] => {
     switch (action.type) {
-        case Actions.SET_STATUSES: return action.payload.statuses
-
-        default: return state;
-    }
-}
+        case Actions.SET_STATUSES: 
+            return action.payload.statuses;
+        default: 
+            return state;
+    };
+};
 
 export default statusesReducer;

--- a/client/src/redux/SubStatuses/subStatusesActionCreators.ts
+++ b/client/src/redux/SubStatuses/subStatusesActionCreators.ts
@@ -1,9 +1,11 @@
-import {store} from '../store';
+import SubStatus from 'models/SubStatus';
+
+import { store } from '../store';
 import * as actionTypes from './subStatusesActionTypes';
 
-export const setSubStatuses = (subStatuses: string[]): void => {
+export const setSubStatuses = (subStatuses: SubStatus[]): void => {
     store.dispatch({
         type: actionTypes.SET_SUB_STATUSES,
-        payload: {subStatuses}
+        payload: { subStatuses }
     })
-}
+};

--- a/client/src/redux/SubStatuses/subStatusesActionTypes.ts
+++ b/client/src/redux/SubStatuses/subStatusesActionTypes.ts
@@ -1,8 +1,10 @@
+import SubStatus from 'models/SubStatus';
+
 export const SET_SUB_STATUSES = 'SET_SUB_STATUSES';
 
 interface SetSubStatuses {
     type: typeof SET_SUB_STATUSES,
-    payload: { subStatuses: string[] }
-}
+    payload: { subStatuses: SubStatus[] }
+};
 
 export type SubStatusesAction = SetSubStatuses;

--- a/client/src/redux/SubStatuses/subStatusesReducer.ts
+++ b/client/src/redux/SubStatuses/subStatusesReducer.ts
@@ -1,13 +1,16 @@
+import SubStatus from 'models/SubStatus';
+
 import * as Actions from './subStatusesActionTypes';
 
-const initialState: string[] = []
+const initialState: SubStatus[] = [];
 
-const subStatusesReducer = (state = initialState, action: Actions.SubStatusesAction): string[] => {
+const subStatusesReducer = (state = initialState, action: Actions.SubStatusesAction): SubStatus[] => {
     switch (action.type) {
-        case Actions.SET_SUB_STATUSES: return action.payload.subStatuses
-
-        default: return state;
-    }
-}
+        case Actions.SET_SUB_STATUSES: 
+            return action.payload.subStatuses;
+        default: 
+            return state;
+    };
+};
 
 export default subStatusesReducer;

--- a/client/src/redux/storeStateType.ts
+++ b/client/src/redux/storeStateType.ts
@@ -2,6 +2,7 @@ import Desk from 'models/Desk';
 import City from 'models/City';
 import Country from 'models/Country';
 import District from 'models/District';
+import SubStatus from 'models/SubStatus';
 import Authority from 'models/Authority';
 import ContactType from 'models/ContactType';
 import CountyReducer from 'models/CountyReducer';
@@ -27,7 +28,7 @@ export default interface StoreStateType {
     countries: Map<string, Country>;
     contactTypes: Map<number, ContactType>;
     occupations: string[];
-    subStatuses: string[];
+    subStatuses: SubStatus[];
     statuses: InvestigationMainStatus[];
     formsValidations: { [key: number]: (boolean | null)[] };
     address: FlattenedDBAddress;

--- a/server/src/DBService/InvestigationInfo/Query.ts
+++ b/server/src/DBService/InvestigationInfo/Query.ts
@@ -65,6 +65,7 @@ query GetAllSubStatuses($parentStatus: Int!) {
     nodes {
       displayName
       parentStatus
+      id
     }
   }
 }

--- a/server/src/DBService/InvestigationInfo/Query.ts
+++ b/server/src/DBService/InvestigationInfo/Query.ts
@@ -64,6 +64,7 @@ query GetAllSubStatuses($parentStatus: Int!) {
   allInvestigationSubStatuses(orderBy: DISPLAY_NAME_ASC, filter: {parentStatus: {equalTo: $parentStatus}}) {
     nodes {
       displayName
+      parentStatus
     }
   }
 }

--- a/server/src/DBService/LandingPage/Query.ts
+++ b/server/src/DBService/LandingPage/Query.ts
@@ -180,6 +180,7 @@ query allInvestigationSubStatuses {
     nodes {
       id
       displayName
+      parentStatus
     }
   }
 }


### PR DESCRIPTION
This fix bug: [1859](https://dev.azure.com/spectrumFactory/CoronaI/_workitems/edit/1859)

Now we saving Sub Statuses with the information about their parent status and we can filter the options on sub Status according to that.